### PR TITLE
Adjust entity categories and device class

### DIFF
--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -37,7 +37,6 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         key="is_life_end",
         translation_key="is_life_end",
         device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:timelapse",
         exists_fn=lambda entity: "isLifeEnd" in entity.data,
         value_fn=lambda entity: entity.data["isLifeEnd"] == 1,
@@ -45,8 +44,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
     XSenseBinarySensorEntityDescription(
         key="alarm_status",
         translation_key="alarm_status",
-        # device_class=BinarySensorDeviceClass.PROBLEM,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.SMOKE,
         icon="mdi:alarm-light-outline",
         exists_fn=lambda entity: "alarmStatus" in entity.data,
         value_fn=lambda entity: entity.data["alarmStatus"],
@@ -54,9 +52,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
     XSenseBinarySensorEntityDescription(
         key="mute_status",
         translation_key="mute_status",
-        # device_class=BinarySensorDeviceClass.PROBLEM,
         icon="mdi:alarm-light-off",
-        entity_category=EntityCategory.DIAGNOSTIC,
         exists_fn=lambda entity: "muteStatus" in entity.data,
         value_fn=lambda entity: entity.data["muteStatus"],
     ),

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -94,7 +94,6 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="alarm_vol",
         translation_key="alarm_vol",
-        entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:volume-high",
         state_class=SensorStateClass.MEASUREMENT,
@@ -104,7 +103,6 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="voice_vol",
         translation_key="voice_vol",
-        entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:volume-high",
@@ -147,6 +145,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         key="rf_level",
         translation_key="rf_level",
         device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:signal",
         name="Signal strength",
         options=STATE_SIGNAL,


### PR DESCRIPTION
Adjust entity categories and device class for better reporting and icon colors. Yellow "On" now renders as red "Detected", "Off" renders as "Clear". Adjusts other sensors as Diagnostic or not for default cards.

Logbook
April 2, 2025
Fire Hall1 Alarm Status cleared (no smoke detected)
1:30:47 PM - 4 hours ago
Fire Hall1 Alarm Status detected smoke
1:26:09 PM - 4 hours ago