### PR TITLE
Add checks for non-empty MAC addresses

### DIFF
--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -39,9 +39,9 @@ class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
         )
 
         connections = set()
-        if "mac" in entity.data:
+        if "mac" in entity.data and entity.data["mac"]:
             connections.add((CONNECTION_NETWORK_MAC, entity.data["mac"]))
-        if "macBT" in entity.data:
+        if "macBT" in entity.data and entity.data["macBT"]:
             connections.add((CONNECTION_BLUETOOTH, entity.data["macBT"]))
 
         self._attr_device_info = DeviceInfo(


### PR DESCRIPTION
This makes the integration check for empty Mac addresses. Otherwise, empty connections are added when the address is not yet know to the system (initial setup).

<img width="353" height="438" alt="Bildschirmfoto 2025-10-28 um 09 07 07" src="https://github.com/user-attachments/assets/48daf837-62f4-41f3-9d6e-1674c770198c" />
