### PR TITLE
chore(deps): relax python-xsense and paho-mqtt version pins

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -8,9 +8,9 @@
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["python-xsense==0.0.16", "paho-mqtt==2.1.0"],
+  "requirements": ["python-xsense>=0.0.16,<0.1", "paho-mqtt>=2.1.0,<3"],
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.0.18"
+  "version": "1.0.19"
 }


### PR DESCRIPTION
## Summary

Replace the strict equality pins on `python-xsense` and `paho-mqtt` with bounded compatible ranges to prevent the recurring class of "Setup failed: Requirements for xsense not found: [paho-mqtt==X.Y.Z]" regressions every time HA Core bumps a bundled dependency.

```diff
- "requirements": ["python-xsense==0.0.16", "paho-mqtt==2.1.0"],
+ "requirements": ["python-xsense>=0.0.16,<0.1", "paho-mqtt>=2.1.0,<3"],
```

## Motivation

In March 2025, HA Core 2025.3.0 brought `paho-mqtt` 2.x. Users on 1.0.14/1.0.15 who hadn't yet updated saw the integration fail to load with `Setup failed for custom integration 'xsense': Requirements for xsense not found: ['paho-mqtt==1.6.1']`. Tracked in many issues:

- #25 — Setup failed for xsense: paho-mqtt==1.6.1
- #29 — Xsense won't activate due to mqtt error (paho-1.6.1) after upgrading to HA 25.3
- #30 — Setup failed for xsense: Requirements not found
- #31 — Not working after HA Core Update to 2025.3.0
- #33 — paho-mqtt version issue with HA 2025.3.x
- #50 — Unable to login on core 2025.5.0

The fix at the time was to bump the strict pin (1.6.1 → 2.1.0). It works, but the pattern is fragile: any future HA Core release that pins `paho-mqtt==2.2.0` or higher will reintroduce the same failure for users who haven't updated HACS yet (or whose HACS is broken — e.g. expired GitHub token).

## What this changes

- `paho-mqtt`: `==2.1.0` → `>=2.1.0,<3` — accepts any 2.x patch/minor that HA Core ships
- `python-xsense`: `==0.0.16` → `>=0.0.16,<0.1` — accepts any 0.0.x without breaking on a future minor bump
- bump `version`: `1.0.18` → `1.0.19`

The upper bounds (`<3` and `<0.1`) keep behavior deterministic — if either lib ships a major version with breaking API, the integration will fail loud at install time (forcing an explicit upgrade) rather than crash silently at runtime.

## Why ranges are reasonable here

- `paho-mqtt` 2.x has had a stable public API since 2.0; 2.1.0 is just a patch on top. There's no reason to be more strict than `>=2.1.0,<3`.
- `python-xsense` is owned by the same author (`@theosnel`) — its 0.0.x versions are sequential bug fixes; pinning the floor (`>=0.0.16`) is enough to guarantee the API the integration uses.

## Test plan

- [ ] HA Core 2025.3.0+ with default `paho-mqtt 2.1.0` → integration loads (= current behavior)
- [ ] HA Core hypothetical with `paho-mqtt 2.2.0` → integration loads (= the case this MR unblocks)
- [ ] Smoke detector model SC07-WX reports state correctly (validated locally on 1.0.18 with patched manifest)
- [ ] No code change beyond the manifest — runtime behavior identical

## Out of scope

- Code changes (none needed; the integration already calls `python-xsense` which abstracts over `paho-mqtt`)
- Quality scale bumps
- HACS metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)