### PR TITLE
Fix MQTT subscription compatibility with Home Assistant 2026.6

### DIFF
--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -483,7 +483,10 @@ class XSenseMQTT:
         is_simple_match = not ("+" in topic or "#" in topic)
         matcher = None if is_simple_match else _matcher_for_topic(topic)
 
-        subscription = Subscription(topic, is_simple_match, matcher, job, qos, encoding)
+        try:
+            subscription = Subscription(topic, is_simple_match, matcher, job, qos, encoding, 1)
+        except TypeError:
+            subscription = Subscription(topic, is_simple_match, matcher, job, qos, encoding)
 
         self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()


### PR DESCRIPTION
## Summary
- pass a subscription identifier when constructing MQTT subscriptions on newer Home Assistant versions
- keep compatibility with older Home Assistant versions by falling back to the previous constructor signature

## Context
Home Assistant 2026.6 adds a required `subscription_id` argument to `homeassistant.components.mqtt.client.Subscription`. Without this, XSense fails during coordinator refresh with:

```
TypeError: Subscription.__init__() missing 1 required positional argument: 'subscription_id'
```

Fixes #123.

## Testing
- `python3 -m py_compile custom_components/xsense/mqtt.py`
- `git diff --check`