### PR TITLE
Allow stale X-Sense devices to be removed

### DIFF
--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
-    Platform.ALARM_CONTROL_PANEL,  # ── NIEUW: burglar alarm safeMode ──
+    Platform.ALARM_CONTROL_PANEL,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.SENSOR,
@@ -42,3 +43,33 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow users to remove XSense devices no longer returned by the cloud API."""
+    coordinator: XSenseDataUpdateCoordinator | None = hass.data.get(DOMAIN, {}).get(
+        entry.entry_id
+    )
+    if coordinator is None:
+        return False
+
+    data = coordinator.data
+    if not data:
+        return False
+
+    current_identifiers = set()
+    for station in data.get("stations", {}).values():
+        current_identifiers.add(station.entity_id)
+        current_identifiers.add(station.sn)
+
+    for device in data.get("devices", {}).values():
+        current_identifiers.add(device.entity_id)
+        current_identifiers.add(device.sn)
+
+    return not any(
+        identifier
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN and identifier[1] in current_identifiers
+    )


### PR DESCRIPTION
## Summary
- Add `async_remove_config_entry_device` so Home Assistant can remove devices that no longer appear in the X-Sense cloud data
- Fail closed if coordinator data is unavailable, and keep current station/device identifiers protected

## Verification
- `python -m compileall -q custom_components/xsense`
- `git diff --check`