### PR TITLE
Require python-xsense 0.0.17 for STH0B support

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["python-xsense>=0.0.16,<0.1", "paho-mqtt>=2.1.0,<3"],
+  "requirements": ["python-xsense>=0.0.17,<0.1", "paho-mqtt>=2.1.0,<3"],
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],

--- a/readme/README_en.md
+++ b/readme/README_en.md
@@ -90,7 +90,7 @@ This integration supports a variety of X-Sense devices. Here is a list of the cu
 - **Smoke detector (XS01-M, WX; XS03-WX; XS0B-MR)**: Early detection of smoke.
 - **Carbon monoxide and smoke combination detector (SC07-WX; XP0A-MR (partially supported))**: Combined devices for detecting carbon monoxide and smoke.
 - **Water leak detector (SWS51)**: Detects the presence of water in unwanted areas.
-- **Hygrometer-thermometer (STH51)**: Monitors temperature and humidity.
+- **Hygrometer-thermometer (STH51, STH0B)**: Monitors temperature and humidity.
 
 These devices can be used to create automations and alerts after being integrated into Home Assistant.
 


### PR DESCRIPTION
## Summary
- Raise the `python-xsense` minimum to 0.0.17 so the integration gets the STH0B mappings
- Document STH0B alongside STH51 in the English README device list

## Verification
- `python -m json.tool custom_components/xsense/manifest.json`
- `git diff --check`