### PR TITLE
Sync English entity translations

### DIFF
--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -19,11 +19,28 @@
     },
     "entity": {
         "binary_sensor": {
+            "activate": {
+                "name": "Activate"
+            },
+            "alarm_status": {
+                "name": "Alarm"
+            },
+            "connected": {
+                "name": "Connected"
+            },
             "is_life_end": {
                 "name": "Is life end"
             },
             "mute_status": {
                 "name": "Mute Status"
+            }
+        },
+        "button": {
+            "mute": {
+                "name": "Mute"
+            },
+            "test": {
+                "name": "Test"
             }
         },
         "sensor": {


### PR DESCRIPTION
## Summary
- add missing English names for connected, activate, and alarm binary sensors
- add English names for existing test and mute button translation keys

## Why
`strings.json` already defines these entity names, but `translations/en.json` was missing them. Keeping the English translation file aligned avoids untranslated or generic entity labels in Home Assistant.

## Validation
- `python -m json.tool custom_components/xsense/translations/en.json`
- `git diff --check`