### PR TITLE
Request realtime updates for STH0B devices

### DIFF
--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -342,7 +342,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Ask MQTT server for updates for all realtime devices."""
         for s in house.stations.values():
             updatable_devices = [
-                dev.sn for dev in s.devices.values() if dev.type in ["STH51", "STH0A"]
+                dev.sn
+                for dev in s.devices.values()
+                if dev.type in ["STH51", "STH0A", "STH0B"]
             ]
 
             if not updatable_devices:


### PR DESCRIPTION
## Summary
- include STH0B devices when requesting realtime temperature/humidity updates over MQTT

## Why
The integration now requires `python-xsense>=0.0.17`, which includes STH0B as a temperature device and maps its temperature/humidity payload fields. The coordinator still only requested realtime updates for STH51 and STH0A, so STH0B devices could miss the same realtime refresh path.

## Validation
- inspected the released `python-xsense 0.0.17` wheel mappings for STH0B support
- `python -m compileall -q custom_components/xsense`
- `git diff --check`