### PR TITLE
Expose supported mute action buttons

### DIFF
--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -41,13 +41,13 @@ SENSORS: tuple[XSenseButtonEntityDescription, ...] = (
         exists_fn=lambda entity, xsense: xsense.has_action(entity, "test"),
         press_fn=partial(run_action, action="test"),
     ),
-    # XSenseButtonEntityDescription(
-    #     key="mute",
-    #     translation_key="mute",
-    #     entity_category=EntityCategory.CONFIG,
-    #     exists_fn=lambda entity, xsense: xsense.has_action(entity, "mute"),
-    #     press_fn=partial(run_action, action="mute"),
-    # ),
+    XSenseButtonEntityDescription(
+        key="mute",
+        translation_key="mute",
+        entity_category=EntityCategory.CONFIG,
+        exists_fn=lambda entity, xsense: xsense.has_action(entity, "mute"),
+        press_fn=partial(run_action, action="mute"),
+    ),
 )
 
 

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -26,6 +26,14 @@
                 "name": "Mute Status"
             }
         },
+        "button": {
+            "mute": {
+                "name": "Mute"
+            },
+            "test": {
+                "name": "Test"
+            }
+        },
         "sensor": {
             "alarm_vol": {
                 "name": "Alarm Volume"


### PR DESCRIPTION
## Summary
- enable the existing mute button entity description
- add English button translation entries for Test and Mute

## Why
`python-xsense` already exposes mute actions for supported device types, and the integration already gates buttons with `xsense.has_action(entity, "mute")`. This exposes mute only for devices the library marks as mute-capable.

## Validation
- inspected the `python-xsense` action implementation and entity action map
- `python -m compileall -q custom_components/xsense`
- `python -m json.tool custom_components/xsense/translations/en.json`
- `git diff --check`