### PR TITLE
Prepare XSense integration for 1.0.23

### DIFF
--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -195,4 +195,4 @@ class XSenseMQTTConnectedEntity(XSenseBinarySensorEntity):
 
         device = self.coordinator.data["stations"][self._dev_id]
         mqtt_server = self.coordinator.mqtt_server(device.house.mqtt_server)
-        return mqtt_server.connected
+        return bool(mqtt_server and mqtt_server.connected)

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
 from functools import partial
 
 from xsense.device import Device
 from xsense.entity import Entity
+from xsense.entity_map import entities
+from xsense.exceptions import XSenseError
 
 from homeassistant import config_entries
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -20,9 +23,45 @@ from .coordinator import AsyncXSense, XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
 
 
-async def run_action(entity: Entity, xsense: AsyncXSense, action: str):
-    """Wrap xsense method in a async callable."""
-    return await xsense.action(entity, action)
+async def run_action(entity: Entity, xsense: AsyncXSense, action: str) -> None:
+    """Run an XSense action for either a child device or a station entity."""
+    entity_def = entities.get(entity.type)
+    if not entity_def:
+        raise XSenseError(
+            f"Entity type {entity.type} is unknown, action {action} not possible"
+        )
+
+    action_def = next(
+        (
+            item
+            for item in entity_def.get("actions", [])
+            if item.get("action") == action
+        ),
+        None,
+    )
+    if not action_def:
+        raise XSenseError(
+            f"Action {action} is not supported for entity type {entity.type}"
+        )
+
+    topic = action_def.get("topic")
+    if callable(topic):
+        topic = topic(entity)
+    if not topic:
+        raise XSenseError(f"Action {action} for entity type {entity.type} has no topic")
+
+    station = getattr(entity, "station", entity)
+    desired = {
+        "deviceSN": entity.sn,
+        "shadow": action_def["shadow"],
+        "stationSN": station.sn,
+        "time": datetime.now().strftime("%Y%m%d%H%M%S"),
+        "userId": xsense.userid,
+    }
+    desired.update(action_def.get("extra", {}))
+    desired.update(action_def.get("data", {}))
+
+    await xsense.do_thing(station, topic, {"state": {"desired": desired}})
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -30,10 +69,10 @@ class XSenseButtonEntityDescription(ButtonEntityDescription):
     """Describes XSense button entity."""
 
     exists_fn: Callable[[Entity, AsyncXSense], bool] = lambda entity, api: True
-    press_fn: Callable[[Entity, AsyncXSense], Awaitable[bool]]
+    press_fn: Callable[[Entity, AsyncXSense], Awaitable[None]]
 
 
-SENSORS: tuple[XSenseButtonEntityDescription, ...] = (
+BUTTONS: tuple[XSenseButtonEntityDescription, ...] = (
     XSenseButtonEntityDescription(
         key="test",
         translation_key="test",
@@ -48,6 +87,13 @@ SENSORS: tuple[XSenseButtonEntityDescription, ...] = (
         exists_fn=lambda entity, xsense: xsense.has_action(entity, "mute"),
         press_fn=partial(run_action, action="mute"),
     ),
+    XSenseButtonEntityDescription(
+        key="fire_drill",
+        translation_key="fire_drill",
+        entity_category=EntityCategory.CONFIG,
+        exists_fn=lambda entity, xsense: xsense.has_action(entity, "firedrill"),
+        press_fn=partial(run_action, action="firedrill"),
+    ),
 )
 
 
@@ -56,14 +102,14 @@ async def async_setup_entry(
     entry: config_entries.ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the xsense binary sensor entry."""
+    """Set up the xsense button entry."""
     devices: list[Device] = []
     coordinator: XSenseDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     for station in coordinator.data["stations"].values():
         devices.extend(
             XSenseButtonEntity(coordinator, station, description)
-            for description in SENSORS
+            for description in BUTTONS
             if description.exists_fn(station, coordinator.xsense)
         )
 
@@ -72,7 +118,7 @@ async def async_setup_entry(
             XSenseButtonEntity(
                 coordinator, dev, description, station_id=dev.station.entity_id
             )
-            for description in SENSORS
+            for description in BUTTONS
             if description.exists_fn(dev, coordinator.xsense)
         )
 

--- a/custom_components/xsense/diagnostics.py
+++ b/custom_components/xsense/diagnostics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -12,5 +12,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.0.20"
+  "version": "1.0.23"
 }

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -1,4 +1,3 @@
-
 """Support for xsense sensors."""
 
 from __future__ import annotations

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -33,9 +33,15 @@
       },
       "alarm_status": {
         "name": "Alarm"
+      },
+      "door": {
+        "name": "Door"
       }
     },
     "button": {
+      "fire_drill": {
+        "name": "Fire Drill"
+      },
       "test": {
         "name": "Test"
       },

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -28,6 +28,9 @@
             "connected": {
                 "name": "Connected"
             },
+            "door": {
+                "name": "Door"
+            },
             "is_life_end": {
                 "name": "Is life end"
             },
@@ -36,6 +39,9 @@
             }
         },
         "button": {
+            "fire_drill": {
+                "name": "Fire Drill"
+            },
             "mute": {
                 "name": "Mute"
             },


### PR DESCRIPTION
## Summary
- fix action buttons so they work for both child devices and station entities
- expose the mapped Fire Drill action behind the existing `xsense.has_action` capability check
- add missing Door and Fire Drill translations
- make the MQTT connected binary sensor safe when MQTT has not initialized yet
- add the missing diagnostics `ConfigEntry` import
- bump the integration manifest version to 1.0.23 for the next release after v.1.0.22

## Why
This prepares the integration code for the next release while leaving release/tag creation to the repository maintainer. The action wrapper no longer depends on the library helper path that assumes child-device shape, so station-level actions can publish correctly.

## Validation
- `python -m compileall -q custom_components/xsense`
- `python -m json.tool custom_components/xsense/manifest.json`
- `python -m json.tool custom_components/xsense/strings.json`
- `python -m json.tool custom_components/xsense/translations/en.json`
- `git diff --check`