### PR TITLE
Clarify alarm status entity label

### DIFF
--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -32,7 +32,7 @@
         "name": "Activate"
       },
       "alarm_status": {
-        "name": "Alarm"
+        "name": "Alarm Status"
       },
       "door": {
         "name": "Door"

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -23,7 +23,7 @@
                 "name": "Activate"
             },
             "alarm_status": {
-                "name": "Alarm"
+                "name": "Alarm Status"
             },
             "connected": {
                 "name": "Connected"


### PR DESCRIPTION
## Summary
- rename the generic alarm binary sensor label from `Alarm` to `Alarm Status`

## Why
The sensor now uses the correct Home Assistant device class per model, but the shared label can still look ambiguous on non-smoke devices. `Alarm Status` is clearer while leaving the actual smoke/CO/moisture/door/motion semantics to the device class.

## Validation
- `python -m json.tool custom_components/xsense/strings.json`
- `python -m json.tool custom_components/xsense/translations/en.json`
- `git diff --check`