### PR TITLE
Improve availability and diagnostics data

### DIFF
--- a/custom_components/xsense/diagnostics.py
+++ b/custom_components/xsense/diagnostics.py
@@ -15,6 +15,14 @@ from .coordinator import XSenseDataUpdateCoordinator
 TO_REDACT = {CONF_EMAIL, CONF_PASSWORD, "title", "unique_id"}
 
 
+def entity_diagnostics(entity) -> dict[str, Any]:
+    """Return diagnostic data for an X-Sense entity."""
+    return {
+        "type": entity.type,
+        "data": entity.data,
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
@@ -26,8 +34,12 @@ async def async_get_config_entry_diagnostics(
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
         "data": {
             "stations": [
-                station.data
+                entity_diagnostics(station)
                 for station in coordinator.data["stations"].values()
+            ],
+            "devices": [
+                entity_diagnostics(device)
+                for device in coordinator.data["devices"].values()
             ],
         },
     }

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import XSenseDataUpdateCoordinator
 
+OFFLINE_STATES = {False, 0, "0", "false", "False", "offline", "Offline"}
+
 
 class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
     """Represent a XSense Entity."""
@@ -71,4 +73,4 @@ class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
         else:
             entity = self.coordinator.data["stations"][self._dev_id]
 
-        return entity.online not in ("0", False) and super().available
+        return entity.online not in OFFLINE_STATES and super().available


### PR DESCRIPTION
## Summary
- treat additional offline payload values as unavailable
- include child devices in config entry diagnostics
- include each diagnostic entity's model type alongside its data payload

## Validation
- AST parse validation with `C:\Users\Media\AppData\Local\Python\bin\python.exe`
- `git diff --check`

Follow-up for closed issue #66 and to make unsupported-device reports easier to diagnose.