### PR TITLE
Improve release workflows and unload cleanup

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,12 +13,15 @@ on:
       - opened
       - closed
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_drafter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,11 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*.*.*'  # Reagiert auf Tags wie v1.0.0
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -13,19 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Repository auschecken
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
 
-      # GitHub Release erstellen
       - name: Create GitHub Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v3.0.0
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-          body: |
-            ## 🎉 What's Changed
-
-            ${{ steps.generate_release_notes.outputs.notes }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,13 +2,19 @@ name: Mark and Close Stale Issues
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Täglich um Mitternacht
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Dieses Issue wurde als inaktiv markiert, da es seit 30 Tagen keine Aktivität gab.'

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -39,8 +39,14 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        coordinator: XSenseDataUpdateCoordinator | None = hass.data[DOMAIN].pop(
+            entry.entry_id, None
+        )
+        if coordinator is not None:
+            await coordinator.async_shutdown()
 
     return unload_ok
 

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -84,6 +84,7 @@ class XSenseAlarmControlPanel(
             "name": station.name,
             "manufacturer": MANUFACTURER,
             "model": station.type,
+            "serial_number": station.sn,
         }
         self._safemode: str | None = None
 

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -45,6 +45,17 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Get mqtt server instance for specific host."""
         return self.mqtt_servers.get(host)
 
+    async def async_shutdown(self) -> None:
+        """Disconnect all MQTT clients owned by this coordinator."""
+        mqtt_servers = list(self.mqtt_servers.values())
+        self.mqtt_servers.clear()
+
+        for mqtt in mqtt_servers:
+            try:
+                await mqtt.async_disconnect(disconnect_paho_client=True)
+            except Exception as ex:  # noqa: BLE001
+                LOGGER.warning("Could not disconnect XSense MQTT client: %s", ex)
+
     async def _connect(self) -> None:
         email = self.entry.data[CONF_EMAIL]
         password = self.entry.data[CONF_PASSWORD]

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -50,7 +50,7 @@ class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
             identifiers={(DOMAIN, entity.entity_id)},
             connections=connections,
             manufacturer=MANUFACTURER,
-            serial_number=entity.data.get("stationSN"),
+            serial_number=entity.sn,
             model=entity.type,
             name=entity.name,
         )


### PR DESCRIPTION
## Summary
- update release, release-drafter, and stale workflows to current maintained actions with explicit permissions
- replace the deprecated create-release action with generated GitHub release notes
- disconnect X-Sense MQTT clients during config-entry unload/reload
- correct serial metadata for child devices and the SBS50 alarm panel

## Validation
- Parsed all integration Python files with AST using Windows Python
- Ran `git diff --check`
- Verified current action release tags with `gh api`
