### PR TITLE
Handle X-Sense login timeouts

### DIFF
--- a/custom_components/xsense/config_flow.py
+++ b/custom_components/xsense/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for X-Sense Home Security integration."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -14,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGIN_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +27,12 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def _async_init_and_login(session: xsense.AsyncXSense, email, password) -> None:
+    """Initialize the X-Sense client and log in."""
+    await session.init()
+    await session.login(email, password)
+
+
 async def validate_input(hass: HomeAssistant, email, password) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -33,12 +40,15 @@ async def validate_input(hass: HomeAssistant, email, password) -> dict[str, Any]
     """
 
     session = xsense.AsyncXSense()
-    await session.init()
 
     try:
-        await session.login(email, password)
+        await asyncio.wait_for(
+            _async_init_and_login(session, email, password), timeout=LOGIN_TIMEOUT
+        )
     except xsense.exceptions.AuthFailed as ex:
         raise InvalidAuth(f"Login failed: {str(ex)}") from ex
+    except (TimeoutError, xsense.exceptions.APIFailure) as ex:
+        raise CannotConnect from ex
     if not session.access_token:
         raise InvalidAuth
 

--- a/custom_components/xsense/const.py
+++ b/custom_components/xsense/const.py
@@ -8,6 +8,7 @@ COORDINATOR = "coordinator"
 
 DEFAULT_SCAN_INTERVAL = 300
 POLL_INTERVAL_MIN = 5
+LOGIN_TIMEOUT = 45
 
 LOGGER = logging.getLogger(__package__)
 

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
 from datetime import datetime, timedelta
 import json
@@ -17,10 +18,24 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.logging import catch_log_exception
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, POLL_INTERVAL_MIN
+from .const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    LOGIN_TIMEOUT,
+    POLL_INTERVAL_MIN,
+)
 from .mqtt import DEFAULT_ENCODING, DEFAULT_QOS, XSenseMQTT
 
 _IGNORED_TOPIC_SUFFIXES = ("/update/accepted", "/update/documents", "/update/rejected")
+
+
+async def _async_init_and_login(
+    xsense: AsyncXSense, email: str, password: str
+) -> None:
+    """Initialize the X-Sense client and log in."""
+    await xsense.init()
+    await xsense.login(email, password)
 
 
 class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -60,14 +75,20 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         email = self.entry.data[CONF_EMAIL]
         password = self.entry.data[CONF_PASSWORD]
 
-        self.xsense = AsyncXSense()
-        await self.xsense.init()
+        xsense = AsyncXSense()
 
         try:
-            await self.xsense.login(email, password)
+            await asyncio.wait_for(
+                _async_init_and_login(xsense, email, password), timeout=LOGIN_TIMEOUT
+            )
         except AuthFailed as ex:
             raise ConfigEntryAuthFailed(f"Login failed: {ex!s}") from ex
+        except APIFailure as ex:
+            raise UpdateFailed(f"XSense API Issue: {ex}") from ex
+        except TimeoutError as ex:
+            raise UpdateFailed("Timed out connecting to X-Sense") from ex
 
+        self.xsense = xsense
         self._initialized = False
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -199,7 +220,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             if safe_mode is not None:
                 _apply_safe_mode(station, safe_mode)
-                LOGGER.debug("HTTP poll: station %s safeMode = %s", station.sn, safe_mode)
+                LOGGER.debug(
+                    "HTTP poll: station %s safeMode = %s", station.sn, safe_mode
+                )
             else:
                 LOGGER.warning(
                     "Station %s has no safeMode in 2nd_safemode shadow: %s",


### PR DESCRIPTION
## Summary
- add a bounded timeout around X-Sense client init/login during config flow and setup
- keep explicit `AuthFailed` responses as invalid auth
- report API failures and login timeouts as connection/setup retry errors instead of misleading authentication failures
- avoid storing a half-initialized X-Sense client when login does not complete

## Context
Issue #111 shows Home Assistant cancelling setup with `Global task timeout: Bootstrap stage 2 timeout` while `xsense.login(...)` was still running. That is not evidence of a bad password, so the integration should fail cleanly as a connection problem and retry later.

## Validation
- Parsed all integration Python files with AST using Windows Python
- Checked changed-file line lengths
- Ran `git diff --check`
