### PR TITLE
Add credential reconfigure and stale entity handling

### DIFF
--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -27,14 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
-
-
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -77,7 +77,7 @@ class XSenseAlarmControlPanel(
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._station = station
+        self._station_id = station.entity_id
         self._attr_unique_id = f"{station.sn}_alarm"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, station.entity_id)},
@@ -89,6 +89,11 @@ class XSenseAlarmControlPanel(
         self._safemode: str | None = None
 
     @property
+    def _station(self):
+        """Return the current station object from coordinator data."""
+        return self.coordinator.data["stations"][self._station_id]
+
+    @property
     def alarm_state(self) -> AlarmControlPanelState | None:
         """Return the current alarm state."""
         return SAFEMODE_TO_STATE.get(self._safemode)
@@ -96,14 +101,15 @@ class XSenseAlarmControlPanel(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated coordinator data."""
-        safemode = getattr(self._station, "safe_mode", None)
+        station = self._station
+        safemode = getattr(station, "safe_mode", None)
         if safemode is None:
-            safemode = self._station.data.get("safeMode")
+            safemode = station.data.get("safeMode")
 
         if safemode != self._safemode:
             LOGGER.debug(
                 "Station %s safeMode changed from %s to %s",
-                self._station.sn,
+                station.sn,
                 self._safemode,
                 safemode,
             )
@@ -130,9 +136,10 @@ class XSenseAlarmControlPanel(
 
     async def _set_safe_mode(self, safe_mode: str) -> None:
         """Request a safeMode change through the X-Sense MQTT shadow."""
+        station = self._station
         LOGGER.debug(
             "Station %s requesting safeMode %s via MQTT appMode",
-            self._station.sn, safe_mode,
+            station.sn, safe_mode,
         )
 
         coordinator: XSenseDataUpdateCoordinator = self.coordinator
@@ -143,7 +150,7 @@ class XSenseAlarmControlPanel(
                 "desired": {
                     "shadow": "appMode",
                     "safeMode": safe_mode,
-                    "stationSN": self._station.sn,
+                    "stationSN": station.sn,
                     "source": "1",
                     "forceArm": "0",
                     "userId": api.userid,
@@ -153,16 +160,16 @@ class XSenseAlarmControlPanel(
         }
 
         topic = (
-            f"$aws/things/{self._station.shadow_name}"
+            f"$aws/things/{station.shadow_name}"
             f"/shadow/name/2nd_appmode/update"
         )
 
-        mqtt = coordinator.mqtt_server(self._station.house.mqtt_server)
+        mqtt = coordinator.mqtt_server(station.house.mqtt_server)
 
         if mqtt is None or not mqtt.connected:
             LOGGER.error(
                 "Station %s cannot set safeMode because MQTT is not connected",
-                self._station.sn,
+                station.sn,
             )
             return
 
@@ -170,14 +177,14 @@ class XSenseAlarmControlPanel(
             await mqtt.async_publish(topic, json.dumps(payload), qos=0, retain=False)
             LOGGER.debug(
                 "Station %s published appMode command %s on %s",
-                self._station.sn, safe_mode, topic,
+                station.sn, safe_mode, topic,
             )
 
-            _apply_safe_mode(self._station, safe_mode)
+            _apply_safe_mode(station, safe_mode)
             self.async_write_ha_state()
 
         except Exception as ex:  # noqa: BLE001
             LOGGER.exception(
                 "Could not set safeMode %s for station %s: %s",
-                safe_mode, self._station.sn, ex,
+                safe_mode, station.sn, ex,
             )

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -91,7 +92,12 @@ class XSenseAlarmControlPanel(
     @property
     def _station(self):
         """Return the current station object from coordinator data."""
-        return self.coordinator.data["stations"][self._station_id]
+        return self.coordinator.data["stations"].get(self._station_id)
+
+    @property
+    def available(self) -> bool:
+        """Return if the alarm control panel is available."""
+        return self._station is not None and super().available
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:
@@ -102,6 +108,11 @@ class XSenseAlarmControlPanel(
     def _handle_coordinator_update(self) -> None:
         """Handle updated coordinator data."""
         station = self._station
+        if station is None:
+            self._safemode = None
+            self.async_write_ha_state()
+            return
+
         safemode = getattr(station, "safe_mode", None)
         if safemode is None:
             safemode = station.data.get("safeMode")
@@ -137,6 +148,9 @@ class XSenseAlarmControlPanel(
     async def _set_safe_mode(self, safe_mode: str) -> None:
         """Request a safeMode change through the X-Sense MQTT shadow."""
         station = self._station
+        if station is None:
+            raise HomeAssistantError("X-Sense station is no longer available")
+
         LOGGER.debug(
             "Station %s requesting safeMode %s via MQTT appMode",
             station.sn, safe_mode,

--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -170,10 +170,9 @@ class XSenseBinarySensorEntity(XSenseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
-        if self._station_id:
-            device = self.coordinator.data["devices"][self._dev_id]
-        else:
-            device = self.coordinator.data["stations"][self._dev_id]
+        device = self._current_entity()
+        if device is None:
+            return None
 
         return self.entity_description.value_fn(device)
 
@@ -183,10 +182,9 @@ class XSenseBinarySensorEntity(XSenseEntity, BinarySensorEntity):
         if self.entity_description.key != "alarm_status":
             return self.entity_description.device_class
 
-        if self._station_id:
-            entity = self.coordinator.data["devices"][self._dev_id]
-        else:
-            entity = self.coordinator.data["stations"][self._dev_id]
+        entity = self._current_entity()
+        if entity is None:
+            return None
 
         return alarm_device_class(entity)
 
@@ -198,6 +196,9 @@ class XSenseMQTTConnectedEntity(XSenseBinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return the state of the sensor."""
 
-        device = self.coordinator.data["stations"][self._dev_id]
+        device = self._current_entity()
+        if device is None:
+            return None
+
         mqtt_server = self.coordinator.mqtt_server(device.house.mqtt_server)
         return bool(mqtt_server and mqtt_server.connected)

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -16,6 +16,7 @@ from homeassistant import config_entries
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -148,10 +149,8 @@ class XSenseButtonEntity(XSenseEntity, ButtonEntity):
         """Press the button."""
 
         xsense = self.coordinator.xsense
-
-        if self._station_id:
-            device = self.coordinator.data["devices"][self._dev_id]
-        else:
-            device = self.coordinator.data["stations"][self._dev_id]
+        device = self._current_entity()
+        if device is None:
+            raise HomeAssistantError("X-Sense entity is no longer available")
 
         await self.entity_description.press_fn(device, xsense)

--- a/custom_components/xsense/config_flow.py
+++ b/custom_components/xsense/config_flow.py
@@ -27,6 +27,16 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+def credentials_schema(default_email: str | None = None) -> vol.Schema:
+    """Return the credentials schema, optionally prefilled with the current email."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_EMAIL, default=default_email): str,
+            vol.Required(CONF_PASSWORD): str,
+        }
+    )
+
+
 async def _async_init_and_login(session: xsense.AsyncXSense, email, password) -> None:
     """Initialize the X-Sense client and log in."""
     await session.init()
@@ -60,7 +70,6 @@ class XSenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for X-Sense Home Security."""
 
     VERSION = 1
-    entry: config_entries.ConfigEntry
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -95,7 +104,6 @@ class XSenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, user_input=None):
         """Perform reauth upon an API authentication error."""
-        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -103,6 +111,7 @@ class XSenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle re-authentication with XSense."""
         errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
 
         if user_input is not None:
             email = user_input[CONF_EMAIL]
@@ -117,27 +126,49 @@ class XSenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                existing_entry = await self.async_set_unique_id(email)
-                if existing_entry and self.entry:
-                    self.hass.config_entries.async_update_entry(
-                        existing_entry,
-                        data={
-                            **self.entry.data,
-                            CONF_EMAIL: email,
-                            CONF_PASSWORD: password,
-                        },
-                    )
-                    await self.hass.config_entries.async_reload(existing_entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
+                await self.async_set_unique_id(email)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_EMAIL: email, CONF_PASSWORD: password},
+                )
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_EMAIL, default=self.entry.data[CONF_EMAIL]): str,
-                    vol.Required(CONF_PASSWORD): str,
-                }
-            ),
+            data_schema=credentials_schema(entry.data[CONF_EMAIL]),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle user-initiated credential updates."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            email = user_input[CONF_EMAIL]
+            password = user_input[CONF_PASSWORD]
+            try:
+                _ = await validate_input(self.hass, email, password)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(email)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_EMAIL: email, CONF_PASSWORD: password},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=credentials_schema(entry.data[CONF_EMAIL]),
             errors=errors,
         )
 

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -60,6 +60,12 @@ class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
             parent = (DOMAIN, station_id)
             self._attr_device_info.update({ATTR_VIA_DEVICE: parent})
 
+    def _current_entity(self) -> Entity | None:
+        """Return the current coordinator entity for this Home Assistant entity."""
+        if self._station_id:
+            return self.coordinator.data["devices"].get(self._dev_id)
+        return self.coordinator.data["stations"].get(self._dev_id)
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._handle_coordinator_update()
@@ -68,9 +74,8 @@ class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if self._station_id:
-            entity = self.coordinator.data["devices"][self._dev_id]
-        else:
-            entity = self.coordinator.data["stations"][self._dev_id]
+        entity = self._current_entity()
+        if entity is None:
+            return False
 
         return entity.online not in OFFLINE_STATES and super().available

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -200,9 +200,8 @@ class XSenseSensorEntity(XSenseEntity, SensorEntity):
     @property
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
-        if self._station_id:
-            device = self.coordinator.data["devices"][self._dev_id]
-        else:
-            device = self.coordinator.data["stations"][self._dev_id]
+        device = self._current_entity()
+        if device is None:
+            return None
 
         return self.entity_description.value_fn(device)

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -1,6 +1,18 @@
 {
   "config": {
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "reconfigure": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
       "user": {
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
@@ -14,7 +26,9 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Reconfiguration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -9,6 +11,18 @@
             "unknown": "Unexpected error"
         },
         "step": {
+            "reauth_confirm": {
+                "data": {
+                    "email": "Email",
+                    "password": "Password"
+                }
+            },
+            "reconfigure": {
+                "data": {
+                    "email": "Email",
+                    "password": "Password"
+                }
+            },
             "user": {
                 "data": {
                     "email": "Email",


### PR DESCRIPTION
## Summary
- add a Home Assistant reconfigure flow so X-Sense account credentials can be updated without removing the integration
- modernize reauth to use Home Assistant's update-and-reload helper
- make stale X-Sense entities go unavailable cleanly when the cloud no longer returns their station or device
- keep the alarm control panel pointed at the latest coordinator station object after reconnects

## Context
This addresses the remaining maintenance issues found during the issue audit, especially the request to change credentials without reinstalling and the stale-device/remove-device reports. It also hardens the SBS50 alarm panel path added in the recent alarm work.

## Validation
- Parsed all integration Python files with AST using Windows Python
- Parsed all integration JSON files
- Ran `git diff --check`