### PR TITLE
Mark battery sensors diagnostic

### DIFF
--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -133,6 +133,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
         value_fn=battery_percentage,
         exists_fn=lambda device: "batInfo" in device.data,


### PR DESCRIPTION
## Summary
- mark X-Sense battery sensors as diagnostic entities
- leave alarm status as a normal safety binary sensor

## Context
Discussion #55 pointed out that battery level is maintenance/diagnostic data, while alarm status is the primary safety state. Current main already keeps alarm status out of the diagnostic category, so this only corrects the battery entity category.

## Validation
- Parsed all integration Python files with AST using Windows Python
- Ran `git diff --check`