### PR TITLE
Add X-Sense setting switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ This repository contains the Home Assistant integration for X-Sense devices. Thi
 
 Dieses Repository enthält die Home Assistant-Integration für X-Sense-Geräte. Dieses Repository ist in mehreren Sprachen verfügbar, damit Nutzer weltweit die Integration einfach verstehen und nutzen können.
 
+### Recent Improvements / Aktuelle Verbesserungen
+
+- The integration now includes its X-Sense API client directly, removing the external `python-xsense` dependency.
+- MQTT shadow updates and polling have been improved to reduce unnecessary cloud requests while keeping device state current.
+- More X-Sense-reported entities are exposed, including additional smoke, CO, water, temperature, humidity, light, keypad, mailbox, motion, door, reminder, warning, and diagnostic fields when devices report them.
+- Device actions such as test, mute, and fire drill are available for supported models, and supported device settings such as LED light, reminders, alarm, PIR, and related toggles are exposed as switches.
+- X-Sense timestamp fields are shown as readable Home Assistant date/time sensors instead of raw compact values.
+
 ### Available Languages / Verfügbare Sprachen:
 
 - [English (en)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_en.md)

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -15,6 +15,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -77,6 +77,7 @@ BUTTONS: tuple[XSenseButtonEntityDescription, ...] = (
     XSenseButtonEntityDescription(
         key="test",
         translation_key="test",
+        name="Test",
         entity_category=EntityCategory.CONFIG,
         exists_fn=lambda entity, xsense: xsense.has_action(entity, "test"),
         press_fn=partial(run_action, action="test"),
@@ -84,6 +85,7 @@ BUTTONS: tuple[XSenseButtonEntityDescription, ...] = (
     XSenseButtonEntityDescription(
         key="mute",
         translation_key="mute",
+        name="Mute",
         entity_category=EntityCategory.CONFIG,
         exists_fn=lambda entity, xsense: xsense.has_action(entity, "mute"),
         press_fn=partial(run_action, action="mute"),
@@ -91,6 +93,7 @@ BUTTONS: tuple[XSenseButtonEntityDescription, ...] = (
     XSenseButtonEntityDescription(
         key="fire_drill",
         translation_key="fire_drill",
+        name="Fire Drill",
         entity_category=EntityCategory.CONFIG,
         exists_fn=lambda entity, xsense: xsense.has_action(entity, "firedrill"),
         press_fn=partial(run_action, action="firedrill"),

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from .api.device import Device
 from .api.entity import Entity
@@ -35,7 +36,7 @@ class XSenseSensorEntityDescription(SensorEntityDescription):
     """Describes XSense sensor entity."""
 
     exists_fn: Callable[[Entity], bool] = lambda _: True
-    value_fn: Callable[[Entity], StateType]
+    value_fn: Callable[[Entity], StateType | datetime]
 
 
 def battery_percentage(device: Entity) -> int | None:
@@ -60,6 +61,36 @@ def rf_level(device: Entity) -> str | None:
 def data_value(key: str) -> Callable[[Entity], StateType]:
     """Return a value function for a X-Sense data key."""
     return lambda entity: entity.data[key]
+
+
+def timestamp_value(value) -> datetime | None:
+    """Return an aware datetime for X-Sense timestamp payload values."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+
+    text = str(value)
+    if text.isdigit():
+        if len(text) == 14:
+            return datetime.strptime(text, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+        if len(text) == 13:
+            return datetime.fromtimestamp(int(text) / 1000, tz=timezone.utc)
+        if len(text) == 10:
+            return datetime.fromtimestamp(int(text), tz=timezone.utc)
+
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def data_timestamp(key: str) -> Callable[[Entity], datetime | None]:
+    """Return a value function for a X-Sense timestamp data key."""
+    return lambda entity: timestamp_value(entity.data[key])
 
 
 def has_data(key: str) -> Callable[[Entity], bool]:
@@ -584,41 +615,41 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="time",
         name="Report Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:clock-outline",
-        value_fn=data_value("time"),
+        value_fn=data_timestamp("time"),
         exists_fn=has_data("time"),
     ),
     XSenseSensorEntityDescription(
         key="online_time",
         name="Online Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:clock-check-outline",
-        value_fn=data_value("onlineTime"),
+        value_fn=data_timestamp("onlineTime"),
         exists_fn=has_data("onlineTime"),
     ),
     XSenseSensorEntityDescription(
         key="utc_time",
         name="UTC Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:clock-outline",
-        value_fn=data_value("utcTime"),
+        value_fn=data_timestamp("utcTime"),
         exists_fn=has_data("utcTime"),
     ),
     XSenseSensorEntityDescription(
         key="app_time",
         name="App Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:clock-outline",
-        value_fn=data_value("appTime"),
+        value_fn=data_timestamp("appTime"),
         exists_fn=has_data("appTime"),
     ),
     XSenseSensorEntityDescription(
         key="test_time",
         name="Test Time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:clock-check-outline",
-        value_fn=data_value("testTime"),
+        value_fn=data_timestamp("testTime"),
         exists_fn=has_data("testTime"),
     ),
     XSenseSensorEntityDescription(
@@ -799,7 +830,7 @@ class XSenseSensorEntity(XSenseEntity, SensorEntity):
         super().__init__(coordinator, entity, station_id)
 
     @property
-    def native_value(self) -> str | int | float | None:
+    def native_value(self) -> str | int | float | datetime | None:
         """Return the state of the sensor."""
         device = self._current_entity()
         if device is None:

--- a/custom_components/xsense/switch.py
+++ b/custom_components/xsense/switch.py
@@ -1,0 +1,248 @@
+"""Support for X-Sense switches."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from .api.device import Device
+from .api.entity import Entity
+
+from homeassistant import config_entries
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import XSenseDataUpdateCoordinator
+from .entity import XSenseEntity
+
+
+def boolean_state(value) -> bool:
+    """Return the normalized bool for common X-Sense boolean payload values."""
+    if isinstance(value, str):
+        return value == "1"
+    return bool(value)
+
+
+def on_off_value(value: bool) -> str:
+    """Return the X-Sense on/off payload value."""
+    return "1" if value else "0"
+
+
+def has_data(key: str) -> Callable[[Entity], bool]:
+    """Return an exists function for an X-Sense data key."""
+    return lambda entity: key in entity.data
+
+
+def data_bool(key: str) -> Callable[[Entity], bool]:
+    """Return a value function for an X-Sense boolean data key."""
+    return lambda entity: boolean_state(entity.data[key])
+
+
+def entity_topic(entity: Entity) -> str:
+    """Return the settings shadow topic used by the X-Sense app."""
+    station = getattr(entity, "station", None)
+    if station and station.type == "SBS50":
+        return f"2nd_cfg_{entity.sn}"
+    return f"info_{entity.sn}"
+
+
+@dataclass(kw_only=True, frozen=True)
+class XSenseSwitchEntityDescription(SwitchEntityDescription):
+    """Describes X-Sense switch entity."""
+
+    data_key: str
+    exists_fn: Callable[[Entity], bool]
+    value_fn: Callable[[Entity], bool]
+    read_key: str | None = None
+    write_value_fn: Callable[[bool], str] = on_off_value
+    entity_category: EntityCategory | None = EntityCategory.CONFIG
+
+
+SWITCHES: tuple[XSenseSwitchEntityDescription, ...] = (
+    XSenseSwitchEntityDescription(
+        key="led_light",
+        data_key="ledLight",
+        name="LED Light",
+        icon="mdi:led-on",
+        exists_fn=has_data("ledLight"),
+        value_fn=data_bool("ledLight"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="alarm_enabled",
+        data_key="alarmEnable",
+        read_key="alarmEnabled",
+        name="Alarm Enabled",
+        icon="mdi:bell-check",
+        exists_fn=lambda entity: (
+            "alarmEnable" in entity.data or "alarmEnabled" in entity.data
+        ),
+        value_fn=lambda entity: boolean_state(
+            entity.data.get("alarmEnable", entity.data.get("alarmEnabled"))
+        ),
+    ),
+    XSenseSwitchEntityDescription(
+        key="continued_alarm",
+        data_key="continueAlarm",
+        read_key="continuedAlarm",
+        name="Continued Alarm",
+        icon="mdi:bell-plus",
+        exists_fn=lambda entity: (
+            "continueAlarm" in entity.data or "continuedAlarm" in entity.data
+        ),
+        value_fn=lambda entity: boolean_state(
+            entity.data.get("continueAlarm", entity.data.get("continuedAlarm"))
+        ),
+    ),
+    XSenseSwitchEntityDescription(
+        key="chirp_tone_enabled",
+        data_key="chirpToneEnable",
+        name="Chirp Tone Enabled",
+        icon="mdi:volume-high",
+        exists_fn=has_data("chirpToneEnable"),
+        value_fn=data_bool("chirpToneEnable"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="reminder_enabled",
+        data_key="remindOn",
+        name="Reminder Enabled",
+        icon="mdi:bell-clock",
+        exists_fn=has_data("remindOn"),
+        value_fn=data_bool("remindOn"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="reminder_tone_enabled",
+        data_key="remindToneEnable",
+        name="Reminder Tone Enabled",
+        icon="mdi:volume-high",
+        exists_fn=has_data("remindToneEnable"),
+        value_fn=data_bool("remindToneEnable"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="await_enabled",
+        data_key="awaitEnable",
+        name="Await Enabled",
+        icon="mdi:timer-sand",
+        exists_fn=has_data("awaitEnable"),
+        value_fn=data_bool("awaitEnable"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="pir_enabled",
+        data_key="pirEnable",
+        name="PIR Enabled",
+        icon="mdi:motion-sensor",
+        exists_fn=has_data("pirEnable"),
+        value_fn=data_bool("pirEnable"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="sunshine_enabled",
+        data_key="sunshineEnable",
+        name="Sunshine Enabled",
+        icon="mdi:white-balance-sunny",
+        exists_fn=has_data("sunshineEnable"),
+        value_fn=data_bool("sunshineEnable"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="key_sound_enabled",
+        data_key="keySound",
+        name="Key Sound Enabled",
+        icon="mdi:volume-high",
+        exists_fn=has_data("keySound"),
+        value_fn=data_bool("keySound"),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the X-Sense switch entry."""
+    devices: list[Device] = []
+    coordinator: XSenseDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    for station in coordinator.data["stations"].values():
+        devices.extend(
+            XSenseSwitchEntity(coordinator, station, description)
+            for description in SWITCHES
+            if description.exists_fn(station)
+        )
+
+    for dev in coordinator.data["devices"].values():
+        devices.extend(
+            XSenseSwitchEntity(
+                coordinator, dev, description, station_id=dev.station.entity_id
+            )
+            for description in SWITCHES
+            if description.exists_fn(dev)
+        )
+
+    async_add_entities(devices)
+
+
+class XSenseSwitchEntity(XSenseEntity, SwitchEntity):
+    """Switches for X-Sense settings."""
+
+    entity_description: XSenseSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: XSenseDataUpdateCoordinator,
+        entity: Entity,
+        entity_description: XSenseSwitchEntityDescription,
+        station_id: str | None = None,
+    ) -> None:
+        """Set up the instance."""
+        self._station_id = station_id
+        self.entity_description = entity_description
+        self._attr_available = False
+
+        super().__init__(coordinator, entity, station_id)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the switch."""
+        entity = self._current_entity()
+        if entity is None:
+            return None
+
+        return self.entity_description.value_fn(entity)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on the X-Sense setting."""
+        await self._async_set_state(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the X-Sense setting."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, enabled: bool) -> None:
+        """Write the switch state through the X-Sense device settings shadow."""
+        xsense = self.coordinator.xsense
+        entity = self._current_entity()
+        if entity is None:
+            raise HomeAssistantError("X-Sense entity is no longer available")
+
+        station = getattr(entity, "station", entity)
+        desired = {
+            "deviceSN": entity.sn,
+            "shadow": "infoDev",
+            "stationSN": station.sn,
+            "time": datetime.now().strftime("%Y%m%d%H%M%S"),
+            "userId": xsense.userid,
+            self.entity_description.data_key: self.entity_description.write_value_fn(
+                enabled
+            ),
+        }
+        topic = entity_topic(entity)
+
+        await xsense.do_thing(station, topic, {"state": {"desired": desired}})
+        entity.data[self.entity_description.data_key] = enabled
+        if self.entity_description.read_key:
+            entity.data[self.entity_description.read_key] = enabled
+        self.coordinator.async_update_listeners()

--- a/readme/README_en.md
+++ b/readme/README_en.md
@@ -102,7 +102,8 @@ These devices can be used to create automations and alerts after being integrate
 The integration creates Home Assistant entities only for fields that are present in the X-Sense cloud or MQTT shadow payloads. Depending on the device, this can include:
 
 - Alarm, mute, end-of-life, AC-break, water-alarm, temperature-alarm, charging, motion, door, armed, warning, reminder, light, PIR, and keypad status binary sensors.
-- Battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO level, CO peak, alarm volume, voice volume, chirp volume, reminder volume, warning thresholds, mute timers, timezone, serial number, MAC address, and other diagnostic sensors.
+- Battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO level, CO peak, alarm volume, voice volume, chirp volume, reminder volume, warning thresholds, mute timers, readable timestamp fields, timezone, serial number, MAC address, and other diagnostic sensors.
+- Switches for supported writable settings reported by X-Sense, such as LED light, alarm enablement, continued alarm, chirp tone, reminders, PIR, sunshine, await, and keypad sound controls.
 - Test, mute, and fire-drill buttons for device models where the X-Sense app exposes the matching action.
 
 Some entities are diagnostic or configuration-related and are grouped that way in Home Assistant. If a device does not report a specific field, the matching entity is not created.


### PR DESCRIPTION
## Summary
- Add a switch platform for X-Sense settings that the mobile app writes through the device settings shadow.
- Expose writable settings such as LED light, alarm enablement, continued alarm, chirp tone, reminders, PIR, sunshine, await, and keypad sound when devices report the matching fields.
- Show compact X-Sense timestamp values as Home Assistant timestamp sensors.
- Add explicit button names and update the README documentation for the recent improvements.

## Validation
- python -m ruff check --no-cache custom_components/xsense/__init__.py custom_components/xsense/button.py custom_components/xsense/sensor.py custom_components/xsense/switch.py
- python -m ruff format --check --no-cache custom_components/xsense/__init__.py custom_components/xsense/button.py custom_components/xsense/sensor.py custom_components/xsense/switch.py
- AST parsed all integration Python files with bytecode disabled.
- git diff --check
