### PR TITLE
Support all README languages from PR 109

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 <div align="right">
   <details>
-    <summary>Language</summary>
-
-    [English](readme/README_en.md) | [Deutsch](readme/README_de.md) | [Nederlands](readme/README_nl.md) | [Español](readme/README_es.md) | [Français](readme/README_fr.md) | [Italiano](readme/README_it.md) | [Português](readme/README_pt.md) | [Русский](readme/README_ru.md) | [中文](readme/README_cn.md) | [日本語](readme/README_ja.md) | [العربية](readme/README_ar.md) | [Ελληνικά](readme/README_el.md) | [हिन्दी](readme/README_hi.md) | [Polski](readme/README_pl.md) | [Türkçe](readme/README_tr.md)
+    <summary>🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="readme/README_en.md">English</a>
+        | <a href="readme/README_de.md">Deutsch</a>
+        | <a href="readme/README_nl.md">Nederlands</a>
+        | <a href="readme/README_es.md">Español</a>
+        | <a href="readme/README_fr.md">Français</a>
+        | <a href="readme/README_it.md">Italiano</a>
+        | <a href="readme/README_pt.md">Português</a>
+        | <a href="readme/README_ru.md">Русский</a>
+        | <a href="readme/README_cn.md">中文</a>
+        | <a href="readme/README_zh-TW.md">繁體中文</a>
+        | <a href="readme/README_ja.md">日本語</a>
+        | <a href="readme/README_ko.md">한국어</a>
+        | <a href="readme/README_ar.md">العربية</a>
+        | <a href="readme/README_fa.md">فارسی</a>
+        | <a href="readme/README_el.md">Ελληνικά</a>
+        | <a href="readme/README_hi.md">हिन्दी</a>
+        | <a href="readme/README_th.md">ไทย</a>
+        | <a href="readme/README_pl.md">Polski</a>
+        | <a href="readme/README_tr.md">Türkçe</a>
+        | <a href="readme/README_vi.md">Tiếng Việt</a>
+        | <a href="readme/README_id.md">Bahasa Indonesia</a>
+        | <a href="readme/README_as.md">অসমীয়া</a>
+      </div>
+    </div>
   </details>
 </div>
 
@@ -45,12 +69,19 @@ Dieses Repository enthält die Home Assistant-Integration für X-Sense-Geräte. 
 - [Portuguese (português) (pt)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_pt.md)
 - [Russian (русский) (ru)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ru.md)
 - [Simplified Chinese (中文) (cn)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_cn.md)
+- [Traditional Chinese (繁體中文) (zh-TW)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_zh-TW.md)
 - [Japanese (日本語) (ja)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ja.md)
+- [Korean (한국어) (ko)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ko.md)
 - [Arabic (العربية) (ar)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ar.md)
+- [Persian (فارسی) (fa)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_fa.md)
 - [Greek (Ελληνικά) (el)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_el.md)
 - [Hindi (हिन्दी) (hi)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_hi.md)
+- [Thai (ไทย) (th)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_th.md)
 - [Polish (polski) (pl)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_pl.md)
 - [Turkish (türkçe) (tr)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_tr.md)
+- [Vietnamese (Tiếng Việt) (vi)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_vi.md)
+- [Indonesian (Bahasa Indonesia) (id)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_id.md)
+- [Assamese (অসমীয়া) (as)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_as.md)
 
 If a language is missing, please let us know, and we will do our best to add it.
 

--- a/readme/README_as.md
+++ b/readme/README_as.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## সামগ্ৰিক বিৱৰণ
+এই Home Assistant integration-এ X-Sense device সমূহক smart home system-ত ব্যৱহাৰ কৰিবলৈ সহায় কৰে। ই [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense)-ৰ মূল code-ৰ ওপৰত আধাৰিত আৰু তেওঁৰ অনুমতি আৰু সহযোগিতাৰে প্ৰকাশ কৰা হৈছে।
+
+Home Assistant-ৰ official integration উপলব্ধ নোহোৱা পৰ্যন্ত, এই HACS integration-টো নতুন feature যোগ কৰা আৰু সমস্যা সমাধানৰ বাবে update হৈ থাকিব।
+
+## বৈশিষ্ট্য
+- বিভিন্ন X-Sense device Home Assistant-ত integrate কৰে।
+- X-Sense sensor data-ৰ ওপৰত automation সমৰ্থন কৰে।
+- X-Sense account-ত উপলব্ধ থাকিলে base station, smoke detector, carbon monoxide detector, heat alarm, water leak detector, thermo-hygrometer, door sensor, motion sensor, light, keypad, mailbox sensor আৰু listener device সমৰ্থন কৰে।
+- X-Sense MQTT shadow-ৰ জৰিয়তে real-time update, আৰু backup হিচাপে periodic cloud polling।
+- HACS-ৰ জৰিয়তে সহজ installation।
+
+## প্ৰয়োজনীয়তা
+- চলি থকা Home Assistant server।
+- supported device থকা X-Sense account।
+- Home Assistant-ত HACS install কৰা থাকিব লাগিব।
+
+## প্ৰস্তুতি
+- **Home Assistant-ৰ বাবে দ্বিতীয় X-Sense account সৃষ্টি কৰক**: একে account app আৰু Home Assistant-ত একেলগে স্থিৰভাৱে login হৈ নাথাকিব পাৰে, সেয়ে পৃথক account ব্যৱহাৰ কৰাটো ভাল।
+- **মূল account-ৰ পৰা Home Assistant account-লৈ supported device share কৰক**: device administration মূল account-ত ৰাখক আৰু Home Assistant-লৈ কেৱল প্ৰয়োজনীয় device share কৰক।
+
+## Installation আৰু configuration
+1. Home Assistant-ত HACS খুলক।
+2. `https://github.com/Jarnsen/ha-xsense-component_test` custom repository হিচাপে যোগ কৰক।
+3. integration download আৰু install কৰক।
+4. Home Assistant Integrations পৃষ্ঠাত X-Sense username আৰু password দি setup সম্পূৰ্ণ কৰক।
+
+## Supported devices
+কোন entity সৃষ্টি হ'ব সেয়া X-Sense cloud বা MQTT shadow-এ report কৰা field-ৰ ওপৰত নিৰ্ভৰ কৰে। সাধাৰণ device-ৰ ভিতৰত SBS50 base station, XS/SC/XP/XC smoke আৰু CO device, XH heat alarm, SWS water detector, STH thermo-hygrometer, SDS door sensor, SMS motion sensor, light, keypad, mailbox, driveway alarm আৰু supported field report কৰা অন্য device থাকে।
+
+## Entity আৰু action
+- alarm, mute, end-of-life, AC break, water alarm, temperature alarm, charging, motion, door, armed, reminder, light আৰু diagnostic binary sensor।
+- battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO, volume, readable timestamp, serial number, MAC address আৰু অন্য diagnostic sensor।
+- device-এ support কৰিলে LED light, alarm, reminders, PIR, sunshine, await আৰু keypad sound control-ৰ switch।
+- supported model-ৰ বাবে test, mute আৰু fire drill button।
+
+## Automation উদাহৰণ
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "Water leak detected!"
+```
+
+## আপোনাৰ সহায় প্ৰয়োজন
+আপোনাৰ ওচৰত যদি এতিয়াও test নোহোৱা X-Sense device আছে, GitHub, Discord বা Home Assistant forum-ত feedback দিয়ক।

--- a/readme/README_fa.md
+++ b/readme/README_fa.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## نمای کلی
+این یکپارچه‌سازی Home Assistant امکان استفاده از دستگاه‌های X-Sense را در خانه هوشمند فراهم می‌کند. این پروژه بر پایه کد اصلی [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense) ساخته شده و با اجازه و همکاری او منتشر شده است.
+
+تا زمانی که یکپارچه‌سازی رسمی Home Assistant آماده شود، این نسخه HACS برای افزودن قابلیت‌ها و رفع مشکلات به‌روزرسانی می‌شود.
+
+## قابلیت‌ها
+- افزودن انواع دستگاه‌های X-Sense به Home Assistant.
+- پشتیبانی از اتوماسیون بر پایه داده‌های حسگرهای X-Sense.
+- پشتیبانی از ایستگاه پایه، هشدار دود، هشدار مونوکسید کربن، هشدار گرما، نشت آب، دما و رطوبت، حسگر در، حسگر حرکت، چراغ، صفحه‌کلید، صندوق پستی و دستگاه listener در صورت گزارش شدن توسط حساب X-Sense.
+- به‌روزرسانی بلادرنگ از طریق X-Sense MQTT shadow و polling دوره‌ای ابر به عنوان پشتیبان.
+- نصب آسان از طریق HACS.
+
+## پیش‌نیازها
+- سرور Home Assistant فعال.
+- حساب X-Sense با دستگاه‌های پشتیبانی‌شده.
+- نصب بودن HACS در Home Assistant.
+
+## آماده‌سازی
+- **یک حساب دوم X-Sense برای Home Assistant بسازید**: استفاده از حساب جداگانه توصیه می‌شود، زیرا ورود همزمان با یک حساب در برنامه و Home Assistant ممکن است پایدار نباشد.
+- **دستگاه‌های پشتیبانی‌شده را از حساب اصلی با حساب Home Assistant به اشتراک بگذارید**: مدیریت دستگاه‌ها در حساب اصلی باقی می‌ماند و Home Assistant فقط به دستگاه‌های اشتراک‌گذاری‌شده دسترسی دارد.
+
+## نصب و پیکربندی
+1. HACS را در Home Assistant باز کنید.
+2. آدرس `https://github.com/Jarnsen/ha-xsense-component_test` را به عنوان custom repository اضافه کنید.
+3. یکپارچه‌سازی را دانلود و نصب کنید.
+4. در صفحه Integrations با نام کاربری و رمز عبور X-Sense پیکربندی را انجام دهید.
+
+## دستگاه‌های پشتیبانی‌شده
+Entityهای ایجادشده به فیلدهایی بستگی دارد که X-Sense cloud یا MQTT shadow گزارش می‌کند. دستگاه‌های رایج شامل SBS50 base station، دستگاه‌های دود و CO سری XS/SC/XP/XC، هشدار گرما XH، نشت آب SWS، دما و رطوبت STH، حسگر در SDS، حسگر حرکت SMS، چراغ، صفحه‌کلید، صندوق پستی، هشدار مسیر ورودی و سایر دستگاه‌هایی است که فیلدهای پشتیبانی‌شده را گزارش می‌کنند.
+
+## Entityها و عملکردها
+- Binary sensor برای alarm، mute، پایان عمر، AC break، هشدار آب، هشدار دما، شارژ، حرکت، در، armed، reminder، light و diagnostics.
+- Sensor برای باتری، RF، Wi-Fi، firmware، دما، رطوبت، CO، volume، زمان‌های خوانا، شماره سریال، MAC و diagnostics دیگر.
+- Switch برای تنظیمات قابل نوشتن مانند LED light، alarm، reminders، PIR، sunshine، await و keypad sound در صورت پشتیبانی دستگاه.
+- دکمه‌های test، mute و fire drill برای مدل‌های پشتیبانی‌شده.
+
+## نمونه Automation
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "نشت آب تشخیص داده شد!"
+```
+
+## به کمک شما نیاز داریم
+اگر دستگاه X-Sense تست‌نشده‌ای دارید، لطفاً بازخورد خود را در GitHub، Discord یا انجمن Home Assistant ارسال کنید.

--- a/readme/README_id.md
+++ b/readme/README_id.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## Ringkasan
+Integrasi Home Assistant ini memungkinkan perangkat X-Sense digunakan di sistem rumah pintar. Integrasi ini dibuat berdasarkan kode asli dari [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense) dan diterbitkan dengan izin serta kerja samanya.
+
+Sampai integrasi resmi Home Assistant tersedia, integrasi HACS ini akan terus diperbarui untuk menambah fitur dan memperbaiki masalah.
+
+## Fitur
+- Mengintegrasikan berbagai perangkat X-Sense ke Home Assistant.
+- Mendukung otomatisasi berdasarkan data sensor X-Sense.
+- Mendukung base station, detektor asap, detektor karbon monoksida, alarm panas, detektor kebocoran air, termohigrometer, sensor pintu, sensor gerak, lampu, keypad, sensor kotak surat, dan perangkat listener saat tersedia di akun X-Sense.
+- Pembaruan real-time melalui X-Sense MQTT shadow, dengan polling cloud berkala sebagai cadangan.
+- Instalasi mudah melalui HACS.
+
+## Persyaratan
+- Server Home Assistant yang berfungsi.
+- Akun X-Sense dengan perangkat yang didukung.
+- HACS harus terpasang di Home Assistant.
+
+## Persiapan
+- **Buat akun X-Sense kedua untuk Home Assistant**: Akun terpisah disarankan karena satu akun mungkin tidak stabil jika digunakan bersamaan di aplikasi dan Home Assistant.
+- **Bagikan perangkat yang didukung dari akun utama ke akun Home Assistant**: Pengelolaan tetap dilakukan di akun utama, sementara Home Assistant memakai perangkat yang dibagikan.
+
+## Instalasi dan konfigurasi
+1. Buka HACS di Home Assistant.
+2. Tambahkan `https://github.com/Jarnsen/ha-xsense-component_test` sebagai custom repository.
+3. Unduh dan pasang integrasi.
+4. Konfigurasikan dengan nama pengguna dan kata sandi X-Sense di halaman Integrations Home Assistant.
+
+## Perangkat yang didukung
+Entity yang dibuat bergantung pada field yang dilaporkan oleh X-Sense cloud atau MQTT shadow. Perangkat umum mencakup SBS50 base station, perangkat asap dan CO seri XS/SC/XP/XC, alarm panas XH, detektor air SWS, termohigrometer STH, sensor pintu SDS, sensor gerak SMS, lampu, keypad, kotak surat, driveway alarm, dan perangkat lain yang melaporkan field yang didukung.
+
+## Entity dan aksi
+- Binary sensor untuk alarm, mute, end-of-life, AC break, water alarm, temperature alarm, charging, motion, door, armed, reminder, light, dan diagnostics.
+- Sensor untuk battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO, volume, timestamp yang mudah dibaca, serial number, MAC address, dan diagnostics lain.
+- Switch untuk pengaturan yang dapat ditulis seperti LED light, alarm, reminders, PIR, sunshine, await, dan keypad sound jika didukung perangkat.
+- Tombol test, mute, dan fire drill untuk model yang didukung.
+
+## Contoh Automation
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "Kebocoran air terdeteksi!"
+```
+
+## Kami membutuhkan bantuan
+Jika Anda memiliki perangkat X-Sense yang belum diuji, silakan kirim masukan melalui GitHub, Discord, atau forum Home Assistant.

--- a/readme/README_ko.md
+++ b/readme/README_ko.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## 개요
+이 Home Assistant 통합은 X-Sense 장치를 스마트 홈 시스템에서 사용할 수 있게 해 줍니다. [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense)의 원래 코드를 기반으로 하며, 그의 허가와 협력 아래 배포됩니다.
+
+공식 Home Assistant 통합이 제공되기 전까지 이 HACS 통합은 새 기능 추가와 문제 수정을 위해 계속 업데이트됩니다.
+
+## 기능
+- 여러 X-Sense 장치를 Home Assistant에 통합합니다.
+- X-Sense 센서 데이터를 기반으로 자동화를 만들 수 있습니다.
+- X-Sense 계정에서 보고되는 경우 베이스 스테이션, 연기 감지기, 일산화탄소 감지기, 열 감지기, 누수 감지기, 온습도계, 문 센서, 모션 센서, 조명, 키패드, 우편함 센서, 리스너 장치를 지원합니다.
+- X-Sense MQTT shadow를 통한 실시간 업데이트와 주기적 클라우드 폴링 백업을 사용합니다.
+- HACS로 쉽게 설치할 수 있습니다.
+
+## 요구 사항
+- 정상 작동하는 Home Assistant 서버.
+- 지원되는 장치가 있는 X-Sense 계정.
+- Home Assistant에 HACS가 설치되어 있어야 합니다.
+
+## 준비
+- **Home Assistant용 두 번째 X-Sense 계정 만들기**: 같은 계정으로 앱과 Home Assistant에 동시에 안정적으로 로그인하기 어렵기 때문에 별도 계정을 권장합니다.
+- **기본 계정에서 Home Assistant 계정으로 지원 장치 공유**: 관리는 기본 계정에서 계속하고, 필요한 장치만 Home Assistant 계정에 공유합니다.
+
+## 설치 및 설정
+1. Home Assistant에서 HACS를 엽니다.
+2. 사용자 지정 저장소로 `https://github.com/Jarnsen/ha-xsense-component_test`를 추가합니다.
+3. 통합을 다운로드하고 설치합니다.
+4. Home Assistant 통합 화면에서 X-Sense 사용자 이름과 비밀번호를 입력합니다.
+
+## 지원 장치
+생성되는 엔티티는 X-Sense 클라우드 또는 MQTT shadow가 보고하는 필드에 따라 달라집니다. SBS50 베이스 스테이션, XS/SC/XP/XC 계열 연기 및 일산화탄소 장치, XH 열 감지기, SWS 누수 감지기, STH 온습도계, SDS 문 센서, SMS 모션 센서, 조명, 키패드, 우편함, 진입로 알람 및 기타 지원 필드를 보고하는 장치를 포함합니다.
+
+## 사용 가능한 엔티티와 동작
+- 알람, 음소거, 수명 종료, AC 오류, 누수, 온도 알람, 충전, 모션, 문, 경계, 알림, 조명 및 진단 이진 센서.
+- 배터리, RF 신호, Wi-Fi 신호, 펌웨어, 온도, 습도, CO 값, 볼륨, 읽기 쉬운 타임스탬프, 일련번호, MAC 주소 및 기타 진단 센서.
+- 장치가 지원하는 경우 LED 조명, 알람, 알림, PIR, 햇빛, 대기 및 키패드 소리 설정 스위치.
+- 지원 모델의 테스트, 음소거 및 화재 훈련 버튼.
+
+## 자동화 예시
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "누수가 감지되었습니다!"
+```
+
+## 도움이 필요합니다
+테스트되지 않은 X-Sense 장치가 있다면 GitHub, Discord 또는 Home Assistant 포럼에 피드백을 남겨 주세요.

--- a/readme/README_th.md
+++ b/readme/README_th.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## ภาพรวม
+อินทิเกรชันนี้ช่วยให้ใช้อุปกรณ์ X-Sense กับ Home Assistant ได้ในระบบสมาร์ตโฮม พัฒนาจากโค้ดเดิมของ [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense) และเผยแพร่โดยได้รับอนุญาตและความร่วมมือจากเขา
+
+ก่อนที่อินทิเกรชันอย่างเป็นทางการของ Home Assistant จะพร้อมใช้งาน อินทิเกรชัน HACS นี้จะได้รับการอัปเดตเพื่อเพิ่มความสามารถและแก้ไขปัญหาอย่างต่อเนื่อง
+
+## คุณสมบัติ
+- รวมอุปกรณ์ X-Sense หลายประเภทเข้ากับ Home Assistant
+- รองรับการทำงานอัตโนมัติจากข้อมูลเซนเซอร์ X-Sense
+- รองรับสถานีฐาน เครื่องตรวจจับควัน เครื่องตรวจจับคาร์บอนมอนอกไซด์ เครื่องตรวจจับความร้อน เซนเซอร์น้ำรั่ว เครื่องวัดอุณหภูมิและความชื้น เซนเซอร์ประตู เซนเซอร์ตรวจจับการเคลื่อนไหว ไฟ คีย์แพด เซนเซอร์กล่องจดหมาย และอุปกรณ์ listener เมื่อมีข้อมูลในบัญชี X-Sense
+- อัปเดตแบบเรียลไทม์ผ่าน X-Sense MQTT shadow พร้อมการดึงข้อมูลจากคลาวด์เป็นระยะเป็นแผนสำรอง
+- ติดตั้งผ่าน HACS ได้ง่าย
+
+## ข้อกำหนด
+- เซิร์ฟเวอร์ Home Assistant ที่ใช้งานได้
+- บัญชี X-Sense ที่มีอุปกรณ์ที่รองรับ
+- ติดตั้ง HACS ใน Home Assistant แล้ว
+
+## การเตรียมตัว
+- **สร้างบัญชี X-Sense ที่สองสำหรับ Home Assistant**: แนะนำให้ใช้บัญชีแยก เพราะบัญชีเดียวกันอาจไม่สามารถล็อกอินในแอปและ Home Assistant ได้พร้อมกันอย่างเสถียร
+- **แชร์อุปกรณ์ที่รองรับจากบัญชีหลักไปยังบัญชี Home Assistant**: ใช้บัญชีหลักสำหรับจัดการอุปกรณ์ และแชร์เฉพาะอุปกรณ์ที่ต้องการใช้งานกับ Home Assistant
+
+## การติดตั้งและตั้งค่า
+1. เปิด HACS ใน Home Assistant
+2. เพิ่ม `https://github.com/Jarnsen/ha-xsense-component_test` เป็น custom repository
+3. ดาวน์โหลดและติดตั้งอินทิเกรชัน
+4. ตั้งค่าด้วยชื่อผู้ใช้และรหัสผ่าน X-Sense ในหน้า Integrations ของ Home Assistant
+
+## อุปกรณ์ที่รองรับ
+เอนทิตีที่สร้างขึ้นขึ้นอยู่กับฟิลด์ที่ X-Sense cloud หรือ MQTT shadow รายงาน อุปกรณ์ที่พบได้บ่อยได้แก่ SBS50 base station, อุปกรณ์ควันและคาร์บอนมอนอกไซด์ตระกูล XS/SC/XP/XC, XH heat alarm, SWS water leak detector, STH thermo-hygrometer, SDS door sensor, SMS motion sensor, ไฟ, คีย์แพด, กล่องจดหมาย, driveway alarm และอุปกรณ์อื่นที่รายงานฟิลด์ที่รองรับ
+
+## เอนทิตีและคำสั่ง
+- Binary sensor สำหรับ alarm, mute, end-of-life, AC break, water alarm, temperature alarm, charging, motion, door, armed, reminder, light และ diagnostics
+- Sensor สำหรับ battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO, volume, timestamp ที่อ่านง่าย, serial number, MAC address และ diagnostics อื่น ๆ
+- Switch สำหรับการตั้งค่าที่อุปกรณ์รองรับ เช่น LED light, alarm, reminders, PIR, sunshine, await และ keypad sound
+- ปุ่ม test, mute และ fire drill สำหรับรุ่นที่รองรับ
+
+## ตัวอย่าง Automation
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "ตรวจพบน้ำรั่ว!"
+```
+
+## ต้องการความช่วยเหลือ
+หากคุณมีอุปกรณ์ X-Sense ที่ยังไม่ได้ทดสอบ โปรดแจ้งผลการใช้งานผ่าน GitHub, Discord หรือฟอรัม Home Assistant

--- a/readme/README_vi.md
+++ b/readme/README_vi.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## Tổng quan
+Tích hợp Home Assistant này cho phép sử dụng thiết bị X-Sense trong hệ thống nhà thông minh. Dự án dựa trên mã gốc của [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense) và được phát hành với sự cho phép cùng hợp tác của ông.
+
+Cho đến khi có tích hợp Home Assistant chính thức, tích hợp HACS này sẽ tiếp tục được cập nhật để thêm tính năng và sửa lỗi.
+
+## Tính năng
+- Tích hợp nhiều thiết bị X-Sense vào Home Assistant.
+- Hỗ trợ tự động hóa dựa trên dữ liệu cảm biến X-Sense.
+- Hỗ trợ trạm gốc, đầu báo khói, đầu báo CO, báo nhiệt, cảm biến rò rỉ nước, nhiệt ẩm kế, cảm biến cửa, cảm biến chuyển động, đèn, bàn phím, cảm biến hộp thư và thiết bị listener khi được tài khoản X-Sense báo cáo.
+- Cập nhật thời gian thực qua X-Sense MQTT shadow, với polling đám mây định kỳ làm dự phòng.
+- Cài đặt dễ dàng qua HACS.
+
+## Yêu cầu
+- Máy chủ Home Assistant đang hoạt động.
+- Tài khoản X-Sense có thiết bị được hỗ trợ.
+- HACS đã được cài đặt trong Home Assistant.
+
+## Chuẩn bị
+- **Tạo tài khoản X-Sense thứ hai cho Home Assistant**: Nên dùng tài khoản riêng vì một tài khoản có thể không đăng nhập ổn định cùng lúc trong ứng dụng và Home Assistant.
+- **Chia sẻ thiết bị được hỗ trợ từ tài khoản chính sang tài khoản Home Assistant**: Tiếp tục quản lý bằng tài khoản chính và chỉ chia sẻ các thiết bị cần tích hợp.
+
+## Cài đặt và cấu hình
+1. Mở HACS trong Home Assistant.
+2. Thêm `https://github.com/Jarnsen/ha-xsense-component_test` làm custom repository.
+3. Tải xuống và cài đặt tích hợp.
+4. Cấu hình bằng tên người dùng và mật khẩu X-Sense trong trang Integrations của Home Assistant.
+
+## Thiết bị được hỗ trợ
+Các entity được tạo phụ thuộc vào trường dữ liệu mà X-Sense cloud hoặc MQTT shadow báo cáo. Các thiết bị phổ biến gồm SBS50 base station, thiết bị khói và CO dòng XS/SC/XP/XC, báo nhiệt XH, cảm biến nước SWS, nhiệt ẩm kế STH, cảm biến cửa SDS, cảm biến chuyển động SMS, đèn, bàn phím, hộp thư, driveway alarm và các thiết bị khác báo cáo trường được hỗ trợ.
+
+## Entity và thao tác
+- Binary sensor cho alarm, mute, end-of-life, AC break, water alarm, temperature alarm, charging, motion, door, armed, reminder, light và diagnostics.
+- Sensor cho battery, RF signal, Wi-Fi signal, firmware, temperature, humidity, CO, volume, timestamp dễ đọc, serial number, MAC address và diagnostics khác.
+- Switch cho các cài đặt có thể ghi như LED light, alarm, reminders, PIR, sunshine, await và keypad sound khi thiết bị hỗ trợ.
+- Nút test, mute và fire drill cho các mẫu được hỗ trợ.
+
+## Ví dụ Automation
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "Phát hiện rò rỉ nước!"
+```
+
+## Cần sự hỗ trợ của bạn
+Nếu bạn có thiết bị X-Sense chưa được kiểm thử, hãy gửi phản hồi qua GitHub, Discord hoặc diễn đàn Home Assistant.

--- a/readme/README_zh-TW.md
+++ b/readme/README_zh-TW.md
@@ -1,0 +1,58 @@
+# ha-xsense-component_test
+
+<p align="center">
+<img src="https://github.com/user-attachments/assets/8e05446e-bc14-4a21-9f6d-8e9f9defd630" alt="Image">
+</p>
+
+## 概覽
+這個 Home Assistant 整合可讓 X-Sense 裝置加入智慧家庭系統。它以 [Theo Snel](https://github.com/theosnel/homeassistant-core/tree/xsense/homeassistant/components/xsense) 的原始程式碼為基礎，並在他的同意與合作下發布。
+
+在官方 Home Assistant 整合可用之前，這個 HACS 整合會持續更新，以加入新功能並修正問題。
+
+## 功能
+- 將多種 X-Sense 裝置整合到 Home Assistant。
+- 支援以 X-Sense 感測資料建立自動化。
+- 支援基地台、煙霧警報器、一氧化碳警報器、熱警報器、漏水偵測器、溫溼度計、門窗感測器、動作感測器、燈具、鍵盤、信箱感測器與監聽器等裝置，前提是 X-Sense 帳戶有回報這些裝置。
+- 透過 X-Sense MQTT shadow 取得即時更新，並以週期性雲端輪詢作為備援。
+- 可透過 HACS 安裝。
+
+## 需求
+- 可正常運作的 Home Assistant 伺服器。
+- 具有受支援裝置的 X-Sense 帳戶。
+- 已安裝 HACS。
+
+## 準備
+- **建立第二個 X-Sense 帳戶供 Home Assistant 使用**：同一帳戶通常無法同時穩定登入 X-Sense App 與 Home Assistant，因此建議使用獨立帳戶。
+- **從主要帳戶分享受支援裝置給 Home Assistant 帳戶**：用主要帳戶管理裝置，並將要整合的裝置分享給 Home Assistant 帳戶。
+
+## 安裝與設定
+1. 在 Home Assistant 中開啟 HACS。
+2. 將 `https://github.com/Jarnsen/ha-xsense-component_test` 加入 HACS 自訂存放庫。
+3. 下載並安裝整合。
+4. 在 Home Assistant 的整合頁面中使用 X-Sense 帳號密碼完成設定。
+
+## 支援的裝置
+支援的實體取決於 X-Sense 雲端或 MQTT shadow 回報的欄位。常見裝置包含 SBS50 基地台、XS/SC/XP/XC 系列煙霧與一氧化碳裝置、XH 熱警報器、SWS 漏水偵測器、STH 溫溼度計、SDS 門窗感測器、SMS 動作感測器，以及燈具、鍵盤、信箱、車道警報與其他回報支援欄位的裝置。
+
+## 可用實體與動作
+- 警報、靜音、壽命結束、AC 中斷、漏水、溫度警報、充電、動作、門窗、佈防、提醒、燈光與診斷二元感測器。
+- 電量、RF 訊號、Wi-Fi 訊號、韌體、溫度、濕度、CO 數值、音量、可讀時間戳記、序號、MAC 位址與其他診斷感測器。
+- 裝置回報支援時，會提供 LED 燈、警報、提醒、PIR、日照、等待與鍵盤聲音等開關。
+- 支援型號會提供測試、靜音與消防演練按鈕。
+
+## 自動化範例
+```yaml
+automation:
+  - alias: "X-Sense Water Leak Alarm"
+    trigger:
+      platform: state
+      entity_id: binary_sensor.xsense_waterleak
+      to: "on"
+    action:
+      service: notify.notify
+      data:
+        message: "偵測到漏水！"
+```
+
+## 需要協助
+如果你有尚未測試的 X-Sense 裝置，請在 GitHub、Discord 或 Home Assistant 論壇提供回饋。


### PR DESCRIPTION
## Summary
- Restore the styled README language selector so it matches the intent of PR #109.
- Keep all links local to this repository instead of external generated translation pages.
- Add the missing language README files from the original selector: Traditional Chinese, Korean, Thai, Persian, Vietnamese, Indonesian, and Assamese.
- Update the main README language list so every listed language points to an existing file.

## Validation
- Verified all README selector links resolve to local files.
- 
