### PR TITLE
Limit Release Drafter to trusted events

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,12 +6,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - opened
-      - closed
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Summary:
- Stop Release Drafter from running on pull_request events.
- Keep Release Drafter on trusted main pushes.
- Add workflow_dispatch so maintainers can still run it manually.

Why:
Forked PR runs cannot create releases with GITHUB_TOKEN, which caused noisy Release Drafter failures.

Validation:
- git diff --check
