### PR TITLE
docs: Show README language flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
-<div align="right">
-  <details>
-    <summary>🌐 Language</summary>
-
-| | | |
-|---|---|---|
-| [🇬🇧 English](readme/README_en.md) | [🇩🇪 Deutsch](readme/README_de.md) | [🇫🇷 Français](readme/README_fr.md) |
-| [🇪🇸 Español](readme/README_es.md) | [🇮🇹 Italiano](readme/README_it.md) | [🇵🇱 Polski](readme/README_pl.md) |
-| [🇳🇱 Nederlands](readme/README_nl.md) | [🇵🇹 Português](readme/README_pt.md) | [🇧🇷 Português (Brasil)](readme/README_pt-BR.md) |
-| [🇨🇿 Čeština](readme/README_cs.md) | [🇸🇰 Slovenčina](readme/README_sk.md) | [🇭🇺 Magyar](readme/README_hu.md) |
-| [🇷🇴 Română](readme/README_ro.md) | [🇸🇮 Slovenščina](readme/README_sl.md) | [🇭🇷 Hrvatski](readme/README_hr.md) |
-| [🇩🇰 Dansk](readme/README_da.md) | [🇸🇪 Svenska](readme/README_sv.md) | [🇳🇴 Norsk](readme/README_no.md) |
-| [🇫🇮 Suomi](readme/README_fi.md) | [🇪🇪 Eesti](readme/README_et.md) | [🇱🇻 Latviešu](readme/README_lv.md) |
-| [🇱🇹 Lietuvių](readme/README_lt.md) | [🇹🇷 Türkçe](readme/README_tr.md) | [🇬🇷 Ελληνικά](readme/README_el.md) |
-| [🇷🇺 Русский](readme/README_ru.md) | [🇺🇦 Українська](readme/README_uk.md) | [🇮🇱 עברית](readme/README_he.md) |
-| [🇸🇦 العربية](readme/README_ar.md) | [🇮🇳 हिन्दी](readme/README_hi.md) | [🇨🇳 中文 (简体)](readme/README_zh-CN.md) |
-| [🇹🇼 中文 (繁體)](readme/README_zh-TW.md) | [🇯🇵 日本語](readme/README_ja.md) | [🇰🇷 한국어](readme/README_ko.md) |
-| [🇹🇭 ไทย](readme/README_th.md) | [🇻🇳 Tiếng Việt](readme/README_vi.md) | [🇮🇩 Bahasa Indonesia](readme/README_id.md) |
-| [🇮🇷 فارسی](readme/README_fa.md) | [🇮🇳 অসমীয়া](readme/README_as.md) | |
-  </details>
-</div>
-
 # ha-xsense-component_test 
  ![GitHub Release](https://img.shields.io/github/release/Jarnsen/ha-xsense-component_test.svg?style=plastic) ![GitHub issues](https://img.shields.io/github/issues/Jarnsen/ha-xsense-component_test.svg?style=plastic) ![GitHub Stars](https://img.shields.io/github/stars/Jarnsen/ha-xsense-component_test.svg?style=plastic) ![GitHub Last Commit](https://img.shields.io/github/last-commit/Jarnsen/ha-xsense-component_test.svg?style=plastic) ![Documentation](https://img.shields.io/badge/docs-excellent-brightgreen.svg?style=plastic) ![HACS Status](https://img.shields.io/badge/HACS-Default-blue.svg?style=plastic) ![Home Assistant](https://img.shields.io/badge/Home%20Assistant-%3E%3D%202025.3.0-brightgreen.svg?style=plastic) [![Discord](https://img.shields.io/discord/1118894710027731025.svg?style=plastic&logo=discord&label=Discord)](https://discord.com/invite/5phHHgGb3V) [![YouTube Channel](https://img.shields.io/youtube/channel/subscribers/UCXao3LZhkhYyGybSl3yCxwQ.svg?style=plastic&logo=youtube&label=Subscribers)](https://www.youtube.com/channel/UCXao3LZhkhYyGybSl3yCxwQ) [![YouTube Video](https://img.shields.io/badge/Watch%20on-YouTube-red.svg?style=plastic&logo=youtube)](https://www.youtube.com/watch?v=3CCKK-qX-YA)
 ---
@@ -51,44 +29,21 @@ Dieses Repository enthält die Home Assistant-Integration für X-Sense-Geräte. 
 
 ### Available Languages / Verfügbare Sprachen:
 
-- [🇬🇧 English (en)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_en.md)
-- [🇩🇪 German (Deutsch) (de)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_de.md)
-- [🇫🇷 French (Français) (fr)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_fr.md)
-- [🇪🇸 Spanish (Español) (es)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_es.md)
-- [🇮🇹 Italian (Italiano) (it)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_it.md)
-- [🇵🇱 Polish (Polski) (pl)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_pl.md)
-- [🇳🇱 Dutch (Nederlands) (nl)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_nl.md)
-- [🇵🇹 Portuguese (Português) (pt)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_pt.md)
-- [🇧🇷 Brazilian Portuguese (Português Brasil) (pt-BR)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_pt-BR.md)
-- [🇨🇿 Czech (Čeština) (cs)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_cs.md)
-- [🇸🇰 Slovak (Slovenčina) (sk)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_sk.md)
-- [🇭🇺 Hungarian (Magyar) (hu)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_hu.md)
-- [🇷🇴 Romanian (Română) (ro)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ro.md)
-- [🇸🇮 Slovenian (Slovenščina) (sl)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_sl.md)
-- [🇭🇷 Croatian (Hrvatski) (hr)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_hr.md)
-- [🇩🇰 Danish (Dansk) (da)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_da.md)
-- [🇸🇪 Swedish (Svenska) (sv)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_sv.md)
-- [🇳🇴 Norwegian (Norsk) (no)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_no.md)
-- [🇫🇮 Finnish (Suomi) (fi)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_fi.md)
-- [🇪🇪 Estonian (Eesti) (et)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_et.md)
-- [🇱🇻 Latvian (Latviešu) (lv)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_lv.md)
-- [🇱🇹 Lithuanian (Lietuvių) (lt)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_lt.md)
-- [🇹🇷 Turkish (Türkçe) (tr)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_tr.md)
-- [🇬🇷 Greek (Ελληνικά) (el)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_el.md)
-- [🇷🇺 Russian (Русский) (ru)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ru.md)
-- [🇺🇦 Ukrainian (Українська) (uk)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_uk.md)
-- [🇮🇱 Hebrew (עברית) (he)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_he.md)
-- [🇸🇦 Arabic (العربية) (ar)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ar.md)
-- [🇮🇳 Hindi (हिन्दी) (hi)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_hi.md)
-- [🇨🇳 Simplified Chinese (中文 简体) (zh-CN)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_zh-CN.md)
-- [🇹🇼 Traditional Chinese (中文 繁體) (zh-TW)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_zh-TW.md)
-- [🇯🇵 Japanese (日本語) (ja)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ja.md)
-- [🇰🇷 Korean (한국어) (ko)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_ko.md)
-- [🇹🇭 Thai (ไทย) (th)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_th.md)
-- [🇻🇳 Vietnamese (Tiếng Việt) (vi)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_vi.md)
-- [🇮🇩 Indonesian (Bahasa Indonesia) (id)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_id.md)
-- [🇮🇷 Persian (فارسی) (fa)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_fa.md)
-- [🇮🇳 Assamese (অসমীয়া) (as)](https://github.com/Jarnsen/ha-xsense-component_test/blob/main/readme/README_as.md)
+| | | |
+|---|---|---|
+| <img src="https://flagcdn.com/16x12/gb.png" width="16" height="12" alt=""> [English](readme/README_en.md) | <img src="https://flagcdn.com/16x12/de.png" width="16" height="12" alt=""> [Deutsch](readme/README_de.md) | <img src="https://flagcdn.com/16x12/fr.png" width="16" height="12" alt=""> [Français](readme/README_fr.md) |
+| <img src="https://flagcdn.com/16x12/es.png" width="16" height="12" alt=""> [Español](readme/README_es.md) | <img src="https://flagcdn.com/16x12/it.png" width="16" height="12" alt=""> [Italiano](readme/README_it.md) | <img src="https://flagcdn.com/16x12/pl.png" width="16" height="12" alt=""> [Polski](readme/README_pl.md) |
+| <img src="https://flagcdn.com/16x12/nl.png" width="16" height="12" alt=""> [Nederlands](readme/README_nl.md) | <img src="https://flagcdn.com/16x12/pt.png" width="16" height="12" alt=""> [Português](readme/README_pt.md) | <img src="https://flagcdn.com/16x12/br.png" width="16" height="12" alt=""> [Português (Brasil)](readme/README_pt-BR.md) |
+| <img src="https://flagcdn.com/16x12/cz.png" width="16" height="12" alt=""> [Čeština](readme/README_cs.md) | <img src="https://flagcdn.com/16x12/sk.png" width="16" height="12" alt=""> [Slovenčina](readme/README_sk.md) | <img src="https://flagcdn.com/16x12/hu.png" width="16" height="12" alt=""> [Magyar](readme/README_hu.md) |
+| <img src="https://flagcdn.com/16x12/ro.png" width="16" height="12" alt=""> [Română](readme/README_ro.md) | <img src="https://flagcdn.com/16x12/si.png" width="16" height="12" alt=""> [Slovenščina](readme/README_sl.md) | <img src="https://flagcdn.com/16x12/hr.png" width="16" height="12" alt=""> [Hrvatski](readme/README_hr.md) |
+| <img src="https://flagcdn.com/16x12/dk.png" width="16" height="12" alt=""> [Dansk](readme/README_da.md) | <img src="https://flagcdn.com/16x12/se.png" width="16" height="12" alt=""> [Svenska](readme/README_sv.md) | <img src="https://flagcdn.com/16x12/no.png" width="16" height="12" alt=""> [Norsk](readme/README_no.md) |
+| <img src="https://flagcdn.com/16x12/fi.png" width="16" height="12" alt=""> [Suomi](readme/README_fi.md) | <img src="https://flagcdn.com/16x12/ee.png" width="16" height="12" alt=""> [Eesti](readme/README_et.md) | <img src="https://flagcdn.com/16x12/lv.png" width="16" height="12" alt=""> [Latviešu](readme/README_lv.md) |
+| <img src="https://flagcdn.com/16x12/lt.png" width="16" height="12" alt=""> [Lietuvių](readme/README_lt.md) | <img src="https://flagcdn.com/16x12/tr.png" width="16" height="12" alt=""> [Türkçe](readme/README_tr.md) | <img src="https://flagcdn.com/16x12/gr.png" width="16" height="12" alt=""> [Ελληνικά](readme/README_el.md) |
+| <img src="https://flagcdn.com/16x12/ru.png" width="16" height="12" alt=""> [Русский](readme/README_ru.md) | <img src="https://flagcdn.com/16x12/ua.png" width="16" height="12" alt=""> [Українська](readme/README_uk.md) | <img src="https://flagcdn.com/16x12/il.png" width="16" height="12" alt=""> [עברית](readme/README_he.md) |
+| <img src="https://flagcdn.com/16x12/sa.png" width="16" height="12" alt=""> [العربية](readme/README_ar.md) | <img src="https://flagcdn.com/16x12/in.png" width="16" height="12" alt=""> [हिन्दी](readme/README_hi.md) | <img src="https://flagcdn.com/16x12/cn.png" width="16" height="12" alt=""> [中文 (简体)](readme/README_zh-CN.md) |
+| <img src="https://flagcdn.com/16x12/tw.png" width="16" height="12" alt=""> [中文 (繁體)](readme/README_zh-TW.md) | <img src="https://flagcdn.com/16x12/jp.png" width="16" height="12" alt=""> [日本語](readme/README_ja.md) | <img src="https://flagcdn.com/16x12/kr.png" width="16" height="12" alt=""> [한국어](readme/README_ko.md) |
+| <img src="https://flagcdn.com/16x12/th.png" width="16" height="12" alt=""> [ไทย](readme/README_th.md) | <img src="https://flagcdn.com/16x12/vn.png" width="16" height="12" alt=""> [Tiếng Việt](readme/README_vi.md) | <img src="https://flagcdn.com/16x12/id.png" width="16" height="12" alt=""> [Bahasa Indonesia](readme/README_id.md) |
+| <img src="https://flagcdn.com/16x12/ir.png" width="16" height="12" alt=""> [فارسی](readme/README_fa.md) | <img src="https://flagcdn.com/16x12/in.png" width="16" height="12" alt=""> [অসমীয়া](readme/README_as.md) | |
 
 If a language is missing, please let us know, and we will do our best to add it.
 


### PR DESCRIPTION
## Summary
- remove the duplicate collapsed language picker
- show a single visible language table in the README
- use image flags so they render consistently instead of relying on emoji flags

## Checks
- verified README-only diff
- ran `git diff --check -- README.md`
