### PR TITLE
Prepare 1.2.1 release

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -12,5 +12,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest version to 1.2.1 for the next patch release

## Validation
- python -m py_compile for custom_components/xsense
- git diff --check
- manifest sanity check for version and paho-mqtt requirement
