### PR TITLE
Fix Release Drafter template variables

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,37 +1,32 @@
 # .github/release-drafter.yml
 
 template: |
-  ## 🎉 What's Changed
+  ## What's Changed
 
   $CHANGES
 
-  ---
-  🧪 **Tests:** $TESTS
-  🔒 **Security:** $SECURITY
-  📦 **Dependencies:** $DEPENDENCIES
-
 categories:
-  - title: 🚀 Features
+  - title: Features
     labels:
       - feature
       - enhancement
-  - title: 🐛 Bug Fixes
+  - title: Bug Fixes
     labels:
       - bug
       - bugfix
-  - title: 🧰 Maintenance
+  - title: Maintenance
     labels:
       - maintenance
       - refactor
-  - title: 🛠️ Infrastructure
+  - title: Infrastructure
     labels:
       - infrastructure
       - ci
-  - title: 🔒 Security
+  - title: Security
     labels:
       - security
       - vulnerability
-  - title: 📦 Dependencies
+  - title: Dependencies
     labels:
       - dependencies
       - dependency-update
@@ -39,11 +34,10 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 no-changes-template: 'No changes'
 
-version-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
-name-template: 'Release v$NEXT_PATCH_VERSION'
-
-generate-notes: true
+tag-prefix: 'v.'
+version-template: '$MAJOR.$MINOR.$PATCH'
+tag-template: 'v.$RESOLVED_VERSION'
+name-template: 'Release v.$RESOLVED_VERSION'
 
 exclude-labels:
   - 'wontfix'


### PR DESCRIPTION
## Summary
- remove unsupported Release Drafter placeholders from the draft body
- use the repository tag format with `v.` and `$RESOLVED_VERSION`
- keep the generated draft notes to the actual merged PR list

## Validation
- `git diff --check`
- sanity check confirmed `$TESTS`, `$SECURITY`, `$DEPENDENCIES`, and `$NEXT_PATCH_VERSION` are no longer present
