### PR TITLE
Fix X-Sense setup shadow 404 and smoke controls

### DIFF
--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -16,6 +16,39 @@ from .station import Station
 CAMERA_TYPES = {"SSC0A", "SSC0B"}
 CAMERA_LIVE_URL_MAX_AGE_SECONDS = 240
 
+# The Android app reads these standalone Wi-Fi device categories from the
+# house-level mainpage/2nd_mainpage shadows, not from station-level mainpage
+# shadows. Querying a station-level mainpage for them returns 404 on accounts
+# such as #160 and should not fail setup.
+_HOUSE_STATE_DEVICE_TYPES = {
+    "SC06-WX",
+    "SC07-WX",
+    "STH0C",
+    "SWS0B",
+    "XC04-WX",
+    "XC0C-iA",
+    "XC0C-iR",
+    "XC0M-iR",
+    "XP0A-iR",
+    "XP0H-iR",
+    "XP0J-iA",
+    "XS01-WX",
+    "XS03-WX",
+    "XS0B-iR",
+    "XS0E-iR",
+    "XS0R-iA",
+}
+
+
+def _station_state_shadow_names(station: Station) -> tuple[str, ...]:
+    if station.type in _HOUSE_STATE_DEVICE_TYPES:
+        return ()
+    if station.type == "SBS10":
+        return ("mainpage",)
+    if station.type == "SBS50":
+        return ("2nd_mainpage",)
+    return ("2nd_mainpage",)
+
 
 class AsyncXSense(XSenseBase):
     def __init__(self, session=None):
@@ -518,16 +551,16 @@ class AsyncXSense(XSenseBase):
             )
 
     async def get_state(self, station: Station):
-        res = None
-        if station.type not in ("SBS10",):
-            res = await self.get_thing(station, "2nd_mainpage")
+        for page in _station_state_shadow_names(station):
+            res = await self.get_thing(station, page)
 
-        if res is None or self._lastres.status == 404:
-            res = await self.get_thing(station, "mainpage")
+            if self._lastres.status == 404:
+                return
 
-        if "reported" in res.get("state", {}):
-            self.parse_get_state(station, res["state"]["reported"])
-        else:
+            if "reported" in res.get("state", {}):
+                self.parse_get_state(station, res["state"]["reported"])
+                return
+
             text = await self._lastres.text()
             raise APIFailure(
                 f"Unable to retrieve station data: {self._lastres.status}/{text}"
@@ -536,17 +569,16 @@ class AsyncXSense(XSenseBase):
     async def set_state(
         self, entity: Entity, shadow: str, topic: str, definition: Dict
     ):
-        station = entity.station
-        t = datetime.now(timezone.utc)
-        timestamp = t.strftime("%Y%m%d%H%M%S")
+        station = getattr(entity, "station", entity)
 
         desired = {
             "deviceSN": entity.sn,
             "shadow": shadow,
             "stationSN": station.sn,
-            "time": timestamp,
             "userId": self.userid,
         }
+        if timestamp := _action_timestamp(definition):
+            desired["time"] = timestamp
         desired.update(definition.get("extra", {}))
         action_data = definition.get("data", {})
         if callable(action_data):
@@ -580,6 +612,15 @@ class AsyncXSense(XSenseBase):
         if callable(shadow):
             shadow = shadow(entity)
         return await self.set_state(entity, shadow, topic, action_def)
+
+
+def _action_timestamp(definition: Dict) -> str | None:
+    time_format = definition.get("time_format", "datetime")
+    if time_format is None:
+        return None
+    if time_format == "epoch_ms":
+        return str(int(datetime.now(timezone.utc).timestamp() * 1000))
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
 
 
 def _camera_data(data: Dict) -> Dict:

--- a/custom_components/xsense/api/entity_map.py
+++ b/custom_components/xsense/api/entity_map.py
@@ -48,6 +48,7 @@ def TestAction(shadow="appSelfTest", extra: Optional[Dict] = None):
         "action": "test",
         "topic": lambda x: f"2nd_selftest_{x.sn}",
         "shadow": shadow,
+        "time_format": "epoch_ms",
     }
     if extra:
         data["extra"] = extra
@@ -68,6 +69,11 @@ def _fire_drill_alarm_type(entity) -> str:
     return "1"
 
 
+def _fire_drill_device_sn(entity) -> str:
+    station = getattr(entity, "station", entity)
+    return station.sn
+
+
 def FireDrillAction():
     return {
         "action": "firedrill",
@@ -77,6 +83,7 @@ def FireDrillAction():
             "alarmTone": "1",
             "alarmType": _fire_drill_alarm_type(entity),
             "alarmVol": "75",
+            "deviceSN": _fire_drill_device_sn(entity),
             "drill": "1",
             "drillTime": "30",
             "location": "17",
@@ -90,6 +97,7 @@ def SATestAction(shadow="appSelfTest"):
         "action": "test",
         "topic": lambda x: f"appselftest_{x.sn}",
         "shadow": shadow,
+        "time_format": None,
     }
 
 

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from functools import partial
 
 from .api.async_xsense import CAMERA_TYPES
 from .api.device import Device
 from .api.entity import Entity
-from .api.entity_map import entities
-from .api.exceptions import XSenseError
 
 from homeassistant import config_entries
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -28,50 +25,7 @@ from .entity import XSenseEntity
 
 async def run_action(entity: Entity, xsense: AsyncXSense, action: str) -> None:
     """Run an XSense action for either a child device or a station entity."""
-    entity_def = entities.get(entity.type)
-    if not entity_def:
-        raise XSenseError(
-            f"Entity type {entity.type} is unknown, action {action} not possible"
-        )
-
-    action_def = next(
-        (
-            item
-            for item in entity_def.get("actions", [])
-            if item.get("action") == action
-        ),
-        None,
-    )
-    if not action_def:
-        raise XSenseError(
-            f"Action {action} is not supported for entity type {entity.type}"
-        )
-
-    topic = action_def.get("topic")
-    if callable(topic):
-        topic = topic(entity)
-    if not topic:
-        raise XSenseError(f"Action {action} for entity type {entity.type} has no topic")
-
-    shadow = action_def["shadow"]
-    if callable(shadow):
-        shadow = shadow(entity)
-
-    station = getattr(entity, "station", entity)
-    desired = {
-        "deviceSN": entity.sn,
-        "shadow": shadow,
-        "stationSN": station.sn,
-        "time": datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S"),
-        "userId": xsense.userid,
-    }
-    desired.update(action_def.get("extra", {}))
-    action_data = action_def.get("data", {})
-    if callable(action_data):
-        action_data = action_data(entity)
-    desired.update(action_data)
-
-    await xsense.do_thing(station, topic, {"state": {"desired": desired}})
+    await xsense.action(entity, action)
 
 
 async def wake_camera(entity: Entity, xsense: AsyncXSense) -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-asyncio

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1,0 +1,192 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+API_PATH = (
+    Path(__file__).resolve().parents[2] / "custom_components" / "xsense" / "api"
+)
+
+
+def load_api_module(module_name: str):
+    """Import the embedded API package without importing the HA integration package."""
+    sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+
+    xsense_pkg = types.ModuleType("custom_components.xsense")
+    xsense_pkg.__path__ = [str(API_PATH.parent)]
+    sys.modules["custom_components.xsense"] = xsense_pkg
+
+    api_pkg = types.ModuleType("custom_components.xsense.api")
+    api_pkg.__path__ = [str(API_PATH)]
+    sys.modules["custom_components.xsense.api"] = api_pkg
+
+    return importlib.import_module(f"custom_components.xsense.api.{module_name}")
+
+
+async_xsense = load_api_module("async_xsense")
+exceptions = load_api_module("exceptions")
+
+
+class FakeResponse:
+    def __init__(self, status: int, body: str = "body") -> None:
+        self.status = status
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+
+class FakeStation:
+    def __init__(self, station_type: str = "SBS50") -> None:
+        self.type = station_type
+        self.sn = "station-sn"
+        self.parsed = []
+
+
+@pytest.mark.asyncio
+async def test_get_state_skips_house_level_wifi_device_shadows():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation("STH0C")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        raise AssertionError("house-level devices should not query station shadows")
+
+    client.get_thing = get_thing
+
+    await client.get_state(station)
+
+    assert calls == []
+    assert station.parsed == []
+
+
+@pytest.mark.asyncio
+async def test_get_state_uses_sbs50_second_mainpage_shadow():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation("SBS50")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        client._lastres = FakeResponse(200)
+        return {"state": {"reported": {"alarmStatus": True}}}
+
+    client.get_thing = get_thing
+    client.parse_get_state = lambda station_arg, reported: station_arg.parsed.append(
+        reported
+    )
+
+    await client.get_state(station)
+
+    assert calls == ["2nd_mainpage"]
+    assert station.parsed == [{"alarmStatus": True}]
+
+
+@pytest.mark.asyncio
+async def test_get_state_ignores_missing_sbs50_second_mainpage_shadow():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation("SBS50")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        client._lastres = FakeResponse(404, "missing")
+        return {"message": "missing"}
+
+    client.get_thing = get_thing
+
+    await client.get_state(station)
+
+    assert calls == ["2nd_mainpage"]
+    assert station.parsed == []
+
+
+@pytest.mark.asyncio
+async def test_get_state_raises_for_malformed_non_404_response():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation()
+
+    async def get_thing(station_arg, page):
+        client._lastres = FakeResponse(500, "server error")
+        return {"state": {}}
+
+    client.get_thing = get_thing
+
+    with pytest.raises(exceptions.APIFailure, match="500/server error"):
+        await client.get_state(station)
+
+
+class FakeXSenseStation:
+    def __init__(self) -> None:
+        self.type = "SBS50"
+        self.sn = "station-sn"
+        self.shadow_name = "SBS50station-sn"
+
+
+class FakeXSenseDevice:
+    def __init__(self, device_type: str = "XS0B-MR") -> None:
+        self.type = device_type
+        self.sn = "device-sn"
+        self.station = FakeXSenseStation()
+        self.data = {}
+
+
+@pytest.mark.asyncio
+async def test_second_gen_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS0B-MR")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "app2ndSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_fire_drill_keeps_datetime_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS0B-MR")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "firedrill")
+
+    assert len(calls) == 1
+    _, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert page == "2nd_firedrill"
+    assert desired["shadow"] == "appFireDrill"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "station-sn"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 14
+    assert desired["drill"] == "1"
+    assert desired["drillTime"] == "30"


### PR DESCRIPTION
## Summary
- match Android app shadow selection for standalone Wi-Fi devices so setup does not fail on missing station-level `mainpage` shadows
- route Home Assistant button presses through the shared API action builder
- match Android app payloads for smoke self-test and fire drill commands
- add focused API regression tests for the setup 404 path and control payloads

## Root Cause
Version 1.2.1 could query station-level `mainpage`/`2nd_mainpage` shadows for standalone Wi-Fi devices where the Android app uses house-level shadows instead. Some accounts then received a 404 (`No shadow exists with name: mainpage`) during setup.

The smoke control buttons also had drift from the Android app payloads: self-test commands need epoch-millisecond timestamps, and fire drill commands use the base station serial as the desired `deviceSN`.

## Validation
- `/root/.venvs/ha-xsense-test/bin/python -m pytest -q`
- `python3 -m py_compile $(find custom_components/xsense tests -name "*.py")`
- `git diff --check`
