### PR TITLE
Fix signed X-Sense shadow update body

### DIFF
--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -1,6 +1,6 @@
 import asyncio
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 from typing import Dict
 
 import aiohttp
@@ -225,11 +225,17 @@ class AsyncXSense(XSenseBase):
         if self._aws_token_expiring():
             await self.load_aws()
 
-        url, headers = self._thing_request(station, page, data)
+        body = _shadow_update_body(data)
+        url, headers = self._thing_request(station, page, body)
 
         session = await self._get_session()
-        async with session.post(url, json=data, headers=headers) as response:
+        async with session.post(url, data=body, headers=headers) as response:
             self._lastres = response
+            if response.status >= 400:
+                text = await response.text()
+                raise APIFailure(
+                    f"Unable to update thing shadow: {response.status}/{text}"
+                )
             return await response.json()
 
     async def login(self, username, password):
@@ -612,6 +618,10 @@ class AsyncXSense(XSenseBase):
         if callable(shadow):
             shadow = shadow(entity)
         return await self.set_state(entity, shadow, topic, action_def)
+
+
+def _shadow_update_body(data: Dict) -> str:
+    return json.dumps(data, separators=(",", ":"))
 
 
 def _action_timestamp(definition: Dict) -> str | None:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -190,3 +190,89 @@ async def test_fire_drill_keeps_datetime_payload_shape():
     assert len(desired["time"]) == 14
     assert desired["drill"] == "1"
     assert desired["drillTime"] == "30"
+
+
+class FakePostResponse:
+    def __init__(self, status: int = 200, body: str = "shadow error") -> None:
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return {"ok": True}
+
+    async def text(self):
+        return self._body
+
+
+class FakePostSession:
+    def __init__(self, status: int = 200):
+        self.calls = []
+        self.status = status
+
+    def post(self, url, data=None, json=None, headers=None):
+        self.calls.append({"url": url, "data": data, "json": json, "headers": headers})
+        return FakePostResponse(self.status)
+
+
+@pytest.mark.asyncio
+async def test_do_thing_signs_and_sends_same_serialized_body():
+    client = async_xsense.AsyncXSense()
+    client.aws_access_expiry = async_xsense.datetime.now(async_xsense.timezone.utc)
+    session = FakePostSession()
+    signed_payloads = []
+
+    client._aws_token_expiring = lambda: False
+
+    async def get_session():
+        return session
+
+    client._get_session = get_session
+
+    def thing_request(station, page, data):
+        signed_payloads.append(data)
+        return "https://example.invalid", {"signed": "yes"}
+
+    client._thing_request = thing_request
+
+    payload = {"state": {"desired": {"b": 2, "a": 1}}}
+    result = await client.do_thing(
+        FakeXSenseStation(), "2nd_selftest_device-sn", payload
+    )
+
+    assert result == {"ok": True}
+    assert len(signed_payloads) == 1
+    assert len(session.calls) == 1
+    assert session.calls[0]["json"] is None
+    assert session.calls[0]["data"] == signed_payloads[0]
+    assert session.calls[0]["data"] == async_xsense._shadow_update_body(payload)
+    assert session.calls[0]["data"] == '{"state":{"desired":{"b":2,"a":1}}}'
+
+
+@pytest.mark.asyncio
+async def test_do_thing_raises_on_shadow_update_failure():
+    client = async_xsense.AsyncXSense()
+    session = FakePostSession(status=403)
+
+    client._aws_token_expiring = lambda: False
+
+    async def get_session():
+        return session
+
+    client._get_session = get_session
+    client._thing_request = lambda station, page, data: (
+        "https://example.invalid",
+        {"signed": "yes"},
+    )
+
+    with pytest.raises(exceptions.APIFailure, match="403/shadow error"):
+        await client.do_thing(
+            FakeXSenseStation(),
+            "2nd_selftest_device-sn",
+            {"state": {"desired": {"a": 1}}},
+        )


### PR DESCRIPTION
## Summary
- sign X-Sense shadow updates using the exact JSON body that is sent to AWS IoT
- send shadow updates as the pre-serialized body instead of letting aiohttp reserialize them
- raise an API error when AWS rejects a shadow update instead of silently returning the response body
- add regression tests for signed/sent body parity and rejected shadow updates

## Root Cause
The Android app uses the AWS IoT SDK to update thing shadows, so the request body that is signed is the same body that is sent.

The integration was signing one JSON representation of the shadow update, then sending the Python object through `aiohttp` using `json=...`. That can produce a different serialized body from the one used for the SigV4 payload hash. For AWS signed requests, that mismatch can cause control requests such as Test and Fire Drill to be rejected or ignored while Home Assistant appears to have pressed the button.

## Validation
- `/root/.venvs/ha-xsense-test/bin/python -m pytest -q`
- `python3 -m py_compile $(find custom_components/xsense tests -name "*.py")`
- `git diff --check`
