### PR TITLE
Prepare 1.2.3 release

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -12,5 +12,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest version to `1.2.3` for the next hotfix release

## Validation
- `python3 -m json.tool custom_components/xsense/manifest.json`
- `git diff --check`
