### PR TITLE
Prepare 1.2.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dieses Repository enthält die Home Assistant-Integration für X-Sense-Geräte. 
 - MQTT shadow updates and polling have been improved to reduce unnecessary cloud requests while keeping device state current.
 - X-Sense camera support has been expanded using the Android app API behavior as a guide, including camera entities, thumbnails/live streams, readable status fields, and supported camera settings such as motion detection, recording, night vision, audio, cooldown, light, doorbell, wake, and codec controls.
 - More X-Sense-reported entities are exposed, including additional smoke, CO, water, temperature, humidity, light, keypad, mailbox, motion, door, reminder, warning, and diagnostic fields when devices report them.
-- Device actions such as test, mute, and fire drill are available for supported models, and supported device settings such as LED light, reminders, alarm, PIR, and related toggles are exposed as switches.
+- Device actions such as test, mute, and fire drill are available for supported models, and supported settings such as LED light, reminders, alarm, PIR, related toggles, and alarm, voice, chirp, and reminder volume levels are exposed as Home Assistant controls.
 - X-Sense timestamp fields are shown as readable Home Assistant date/time sensors instead of raw compact values.
 
 ### Available Languages / Verfügbare Sprachen:

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -8,7 +8,7 @@ import aiohttp
 from .aws_signer import AWSSigner
 from .base import XSenseBase
 from .entity import Entity
-from .entity_map import entities
+from .entity_map import EntityType, entities
 from .exceptions import SessionExpired, APIFailure, XSenseError
 from .house import House
 from .station import Station
@@ -48,6 +48,11 @@ def _station_state_shadow_names(station: Station) -> tuple[str, ...]:
     if station.type == "SBS50":
         return ("2nd_mainpage",)
     return ("2nd_mainpage",)
+
+
+def is_camera_entity(entity: Entity) -> bool:
+    """Return if an entity is an IPC camera discovered through the app path."""
+    return entity.type in CAMERA_TYPES or entity.entity_type == EntityType.CAMERA
 
 
 class AsyncXSense(XSenseBase):
@@ -309,17 +314,19 @@ class AsyncXSense(XSenseBase):
 
     async def update_camera_data(self):
         """Merge camera metadata and config from the Android app ADDX API."""
+        data = await self.addx_call("/device/listuserdevices")
+        devices = (data or {}).get("list") or []
+        self._ensure_addx_cameras(devices)
+
         cameras = [
             station
             for house in self.houses.values()
             for station in house.stations.values()
-            if station.type in CAMERA_TYPES
+            if is_camera_entity(station)
         ]
         if not cameras:
             return
 
-        data = await self.addx_call("/device/listuserdevices")
-        devices = (data or {}).get("list") or []
         by_sn = {device.get("serialNumber"): device for device in devices}
 
         for camera in cameras:
@@ -368,6 +375,45 @@ class AsyncXSense(XSenseBase):
                     doorbell = None
                 if doorbell:
                     camera.set_data(_camera_doorbell_data(doorbell))
+
+    def _ensure_addx_cameras(self, devices: list[Dict]) -> None:
+        """Add cameras that the app exposes only through the ADDX device list."""
+        if not self.houses:
+            return
+
+        fallback_house = next(iter(self.houses.values()))
+        for addx_device in devices:
+            sn = addx_device.get("serialNumber")
+            if not sn or self._get_station_by_sn(sn):
+                continue
+
+            house = self.houses.get(str(addx_device.get("houseId"))) or fallback_house
+            camera_type = _camera_type(addx_device)
+            if camera_type is None:
+                continue
+
+            station = Station(
+                house,
+                stationId=sn,
+                stationName=addx_device.get("deviceName")
+                or addx_device.get("displayModelNo")
+                or camera_type
+                or sn,
+                stationSn=sn,
+                onLine=addx_device.get("online", True),
+                category=camera_type,
+                devices=[],
+            )
+            station.entity_type = EntityType.CAMERA
+            house.stations[station.entity_id] = station
+            if house.station_order is not None:
+                house.station_order.append(station.entity_id)
+
+    def _get_station_by_sn(self, sn: str) -> Station | None:
+        for house in self.houses.values():
+            if station := house.get_station_by_sn(sn):
+                return station
+        return None
 
     async def update_camera_config(self, camera: Entity, **updates):
         """Write camera user config through the Android app endpoint."""
@@ -576,6 +622,11 @@ class AsyncXSense(XSenseBase):
         self, entity: Entity, shadow: str, topic: str, definition: Dict
     ):
         station = getattr(entity, "station", entity)
+        target = definition.get("target")
+        if callable(target):
+            target = target(entity)
+        if target is None:
+            target = station
 
         desired = {
             "deviceSN": entity.sn,
@@ -583,9 +634,12 @@ class AsyncXSense(XSenseBase):
             "stationSN": station.sn,
             "userId": self.userid,
         }
-        if timestamp := _action_timestamp(definition):
+        if timestamp := _action_timestamp(definition, entity):
             desired["time"] = timestamp
-        desired.update(definition.get("extra", {}))
+        extra = definition.get("extra", {})
+        if callable(extra):
+            extra = extra(entity)
+        desired.update(extra)
         action_data = definition.get("data", {})
         if callable(action_data):
             action_data = action_data(entity)
@@ -593,7 +647,57 @@ class AsyncXSense(XSenseBase):
 
         data = {"state": {"desired": desired}}
 
-        return await self.do_thing(station, topic, data)
+        return await self.do_thing(target, topic, data)
+
+    async def update_light_power(self, entity: Entity, enabled: bool):
+        """Write an SBS50 light power change through the app lampPower shadow."""
+        station = getattr(entity, "station", entity)
+        desired = {
+            "dev": entity.sn,
+            "isOn": "1" if enabled else "0",
+            "shadow": "lampPower",
+            "stationSN": station.sn,
+            "time": datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S"),
+            "userId": self.userid,
+            "userParam": "source=1",
+        }
+        return await self.do_thing(
+            station, "2nd_lamppower", {"state": {"desired": desired}}
+        )
+
+    async def update_shadow_volume(self, entity: Entity, data_key: str, value: int):
+        """Write a volume value through the same settings shadow as the app."""
+        station = getattr(entity, "station", entity)
+        desired = {
+            "shadow": "infoBase" if entity is station else "infoDev",
+            data_key: str(value),
+        }
+
+        if data_key in {"alarmVol", "voiceVol"}:
+            if _volume_includes_station_sn(entity, data_key):
+                desired["stationSN"] = station.sn
+
+            if entity is station:
+                if entity.type == "SBS10":
+                    if data_key != "voiceVol" and "voiceVol" in entity.data:
+                        desired["voiceVol"] = str(entity.data["voiceVol"])
+                    if data_key != "alarmVol" and "alarmVol" in entity.data:
+                        desired["alarmVol"] = str(entity.data["alarmVol"])
+            else:
+                desired["deviceSN"] = entity.sn
+
+            if data_key == "alarmVol":
+                if alarm_tone := entity.data.get("alarmTone"):
+                    desired["alarmTone"] = str(alarm_tone)
+        else:
+            desired["deviceSN"] = entity.sn
+            tone_key = _volume_tone_key(data_key)
+            if tone_key and (tone := entity.data.get(tone_key)):
+                desired[tone_key] = str(tone)
+
+        return await self.do_thing(
+            station, _shadow_config_topic(entity), {"state": {"desired": desired}}
+        )
 
     async def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)
@@ -620,17 +724,65 @@ class AsyncXSense(XSenseBase):
         return await self.set_state(entity, shadow, topic, action_def)
 
 
+def _shadow_config_topic(entity: Entity) -> str:
+    """Return the settings shadow topic used by the X-Sense app."""
+    station = getattr(entity, "station", None)
+    if entity.type == "SBS50":
+        return f"2nd_cfg_{entity.sn}"
+    if station and station.type == "SBS50":
+        return f"2nd_cfg_{entity.sn}"
+    return f"info_{entity.sn}"
+
+
+def _volume_includes_station_sn(entity: Entity, data_key: str) -> bool:
+    """Return if the APK volume payload includes stationSN for this entity."""
+    if data_key == "voiceVol":
+        return True
+    if getattr(entity, "entity_type", None) in {
+        EntityType.CO,
+        EntityType.LIGHT,
+        EntityType.TEMPERATURE,
+    }:
+        return False
+    return True
+
+
+def _volume_tone_key(data_key: str) -> str | None:
+    """Return the companion tone field the app preserves with volume changes."""
+    return {
+        "alarmVol": "alarmTone",
+        "chirpVol": "chirpTone",
+        "remindVol": "remindTone",
+    }.get(data_key)
+
+
 def _shadow_update_body(data: Dict) -> str:
     return json.dumps(data, separators=(",", ":"))
 
 
-def _action_timestamp(definition: Dict) -> str | None:
+def _action_timestamp(definition: Dict, entity: Entity) -> str | None:
     time_format = definition.get("time_format", "datetime")
+    if callable(time_format):
+        time_format = time_format(entity)
     if time_format is None:
         return None
     if time_format == "epoch_ms":
         return str(int(datetime.now(timezone.utc).timestamp() * 1000))
     return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def _camera_type(data: Dict) -> str | None:
+    device_model = data.get("deviceModel") or {}
+    for value in (
+        data.get("modelNo"),
+        data.get("displayModelNo"),
+        device_model.get("modelName"),
+    ):
+        text = str(value or "").upper()
+        for camera_type in CAMERA_TYPES:
+            if camera_type in text:
+                return camera_type
+    return None
 
 
 def _camera_data(data: Dict) -> Dict:

--- a/custom_components/xsense/api/entity_map.py
+++ b/custom_components/xsense/api/entity_map.py
@@ -43,7 +43,7 @@ def MuteAction(
     return data
 
 
-def TestAction(shadow="appSelfTest", extra: Optional[Dict] = None):
+def TestAction(shadow="appSelfTest", extra: Optional[Dict] = None, target=None):
     data = {
         "action": "test",
         "topic": lambda x: f"2nd_selftest_{x.sn}",
@@ -52,6 +52,8 @@ def TestAction(shadow="appSelfTest", extra: Optional[Dict] = None):
     }
     if extra:
         data["extra"] = extra
+    if target:
+        data["target"] = target
     return data
 
 
@@ -59,8 +61,22 @@ def SBS50SecondGenTestAction():
     return TestAction("app2ndSelfTest", extra={"userParam": "source=1"})
 
 
+def _smoke_rf_test_shadow(entity) -> str:
+    return "app2ndSelfTest" if _is_smoke_v9(entity) else "appSelfTest"
+
+
+def _smoke_rf_test_extra(entity) -> Dict:
+    return {"userParam": "source=1"} if _is_smoke_v9(entity) else {}
+
+
+def SmokeRFTestAction():
+    return TestAction(_smoke_rf_test_shadow, extra=_smoke_rf_test_extra)
+
+
 def WifiSelfTestAction():
-    return TestAction("appSelfTest", extra={"userParam": "source=1"})
+    return TestAction(
+        "appSelfTest", extra={"userParam": "source=1"}, target=lambda entity: entity
+    )
 
 
 def _fire_drill_alarm_type(entity) -> str:
@@ -101,6 +117,24 @@ def SATestAction(shadow="appSelfTest"):
     }
 
 
+def XS01WXTestAction():
+    """XS01-WX self test for standalone and SBS50-linked Wi-Fi smoke devices."""
+    return {
+        "action": "test",
+        "topic": lambda entity: (
+            f"2nd_selftest_{entity.sn}"
+            if getattr(getattr(entity, "station", None), "type", None) == "SBS50"
+            else f"appselftest_{entity.sn}"
+        ),
+        "shadow": "appSelfTest",
+        "time_format": lambda entity: (
+            "epoch_ms"
+            if getattr(getattr(entity, "station", None), "type", None) == "SBS50"
+            else None
+        ),
+    }
+
+
 def _is_smoke_v9(entity) -> bool:
     try:
         return int(entity.data.get("smokeEdition", 0)) >= 9
@@ -127,12 +161,14 @@ entities = {
     "SAL51": {
         "type": EntityType.LISTENER,
         "actions": [
+            TestAction("listenerSelfTest"),
             MuteAction("appListener", mute_type="1"),
         ],
     },
     "SAL100": {
         "type": EntityType.LISTENER,
         "actions": [
+            TestAction("listenerSelfTest"),
             MuteAction("appListener", mute_type="1"),
         ],
     },
@@ -168,9 +204,6 @@ entities = {
     "SC06-WX": {
         "identifier": lambda entity: f"SC06-WX-{entity.sn}",
         "type": EntityType.COMBI,
-        "actions": [
-            TestAction(),
-        ],
     },
     "SC07-MR": {
         "identifier": lambda entity: f"SC07-MR-{entity.sn}",
@@ -189,7 +222,7 @@ entities = {
     "SD11-MR": {
         "type": EntityType.SMOKE,
         "actions": [
-            TestAction(),
+            SBS50SecondGenTestAction(),
             FireDrillAction(),
         ],
     },
@@ -213,6 +246,9 @@ entities = {
     },
     "SDS0A": {
         "type": EntityType.DOOR,
+        "actions": [
+            SBS50SecondGenTestAction(),
+        ],
     },
     "SES01": {
         "type": EntityType.DOOR,
@@ -232,6 +268,9 @@ entities = {
     },
     "SKP0A": {
         "type": EntityType.KEYPAD,
+        "actions": [
+            SBS50SecondGenTestAction(),
+        ],
     },
     "SMA51": {
         "type": EntityType.MAILBOX,
@@ -246,6 +285,9 @@ entities = {
     },
     "SMS0A": {
         "type": EntityType.MOTION,
+        "actions": [
+            SBS50SecondGenTestAction(),
+        ],
     },
     "SMS01": {
         "type": EntityType.MOTION,
@@ -297,6 +339,9 @@ entities = {
     },
     "SWS0A": {
         "type": EntityType.WATER,
+        "actions": [
+            TestAction("waterSelfTest", extra={"userParam": "source=1"}),
+        ],
     },
     "SWS0B": {
         "type": EntityType.WATER,
@@ -387,7 +432,7 @@ entities = {
     "XS01-M": {
         "type": EntityType.SMOKE,
         "actions": [
-            TestAction(),
+            SmokeRFTestAction(),
             MuteAction(),
             FireDrillAction(),
         ],
@@ -395,7 +440,7 @@ entities = {
     "XS01-WX": {
         "type": EntityType.SMOKE,
         "actions": [
-            TestAction(),
+            XS01WXTestAction(),
             XS01WXMuteAction(),
         ],
     },
@@ -411,7 +456,7 @@ entities = {
         # Smoke RF
         "type": EntityType.SMOKE,
         "actions": [
-            TestAction(),
+            SmokeRFTestAction(),
         ],
     },
     "XS03-WX": {
@@ -420,7 +465,7 @@ entities = {
     "XS0D-MR": {
         "type": EntityType.SMOKE,
         "actions": [
-            TestAction(),
+            SBS50SecondGenTestAction(),
             FireDrillAction(),
         ],
     },
@@ -448,6 +493,7 @@ entities = {
     "XP0J-iA": {
         "type": EntityType.COMBI,
         "actions": [
+            WifiSelfTestAction(),
             FireDrillAction(),
         ],
     },

--- a/custom_components/xsense/api/house.py
+++ b/custom_components/xsense/api/house.py
@@ -26,6 +26,10 @@ class House:
         self.region = region
         self.mqtt_region = mqtt_region
         self.mqtt_server = mqtt_server
+        self.rooms = {}
+        self.room_order = []
+        self.stations = {}
+        self.station_order = []
 
         self.mqtt = MQTTHelper(signer, self)
 

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import partial
 
-from .api.async_xsense import CAMERA_TYPES
+from .api.async_xsense import is_camera_entity
 from .api.device import Device
 from .api.entity import Entity
 
@@ -72,7 +72,7 @@ BUTTONS: tuple[XSenseButtonEntityDescription, ...] = (
         icon="mdi:power-sleep",
         entity_category=EntityCategory.CONFIG,
         exists_fn=lambda entity, xsense: (
-            entity.type in CAMERA_TYPES and entity.data.get("supportSleep", False)
+            is_camera_entity(entity) and entity.data.get("supportSleep", False)
         ),
         press_fn=wake_camera,
     ),

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .api.async_xsense import CAMERA_TYPES
+from .api.async_xsense import is_camera_entity
 from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
@@ -43,7 +43,7 @@ async def async_setup_entry(
     async_add_entities(
         XSenseCameraEntity(coordinator, station, CAMERA_DESCRIPTION)
         for station in coordinator.data["stations"].values()
-        if station.type in CAMERA_TYPES
+        if is_camera_entity(station)
     )
 
 

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util.logging import catch_log_exception
 
 from .api import AsyncXSense, House
+from .api.async_xsense import is_camera_entity
 from .api.exceptions import APIFailure, AuthFailed, NotFoundError, SessionExpired
 from .const import (
     DEFAULT_SCAN_INTERVAL,
@@ -213,8 +214,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 with suppress(NotFoundError):
                     await self.xsense.get_house_state(h)
                 for s in h.stations.values():
-                    await self.xsense.get_station_state(s)
-                    await self.xsense.get_state(s)
+                    if not is_camera_entity(s):
+                        await self.xsense.get_station_state(s)
+                        await self.xsense.get_state(s)
                     if s.type == "SBS50":
                         await self._update_safe_mode(s)
                     devices.update(s.devices.items())

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .api.entity import Entity
 
 from homeassistant.const import ATTR_VIA_DEVICE
@@ -13,12 +15,15 @@ from homeassistant.helpers.device_registry import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
-from .coordinator import XSenseDataUpdateCoordinator
+
+if TYPE_CHECKING:
+    from .coordinator import XSenseDataUpdateCoordinator
+
 
 OFFLINE_STATES = {False, 0, "0", "false", "False", "offline", "Offline"}
 
 
-class XSenseEntity(CoordinatorEntity[XSenseDataUpdateCoordinator]):
+class XSenseEntity(CoordinatorEntity):
     """Represent a XSense Entity."""
 
     _attr_has_entity_name = True

--- a/custom_components/xsense/icons.json
+++ b/custom_components/xsense/icons.json
@@ -36,6 +36,20 @@
       "wifi_sw": {
         "default": "mdi:chip"
       }
+    },
+    "number": {
+      "alarm_volume": {
+        "default": "mdi:volume-high"
+      },
+      "voice_volume": {
+        "default": "mdi:volume-high"
+      },
+      "chirp_volume": {
+        "default": "mdi:volume-high"
+      },
+      "reminder_volume": {
+        "default": "mdi:volume-high"
+      }
     }
   }
 }

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -12,5 +12,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/custom_components/xsense/number.py
+++ b/custom_components/xsense/number.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .api.async_xsense import CAMERA_TYPES
+from .api.async_xsense import is_camera_entity
 from .api.device import Device
 from .api.entity import Entity
 from .const import DOMAIN
@@ -28,9 +28,19 @@ def has_data(key: str) -> Callable[[Entity], bool]:
 def has_supported_data(key: str, support_key: str) -> Callable[[Entity], bool]:
     """Return if the app exposes a supported camera setting."""
     return lambda entity: (
-        key in entity.data
+        is_camera_entity(entity)
+        and key in entity.data
         and entity.data.get("isAdmin", True)
         and entity.data.get(support_key, True)
+    )
+
+
+def has_shadow_volume(key: str) -> Callable[[Entity], bool]:
+    """Return if a non-camera X-Sense shadow exposes a writable volume field."""
+    return lambda entity: (
+        not is_camera_entity(entity)
+        and key in entity.data
+        and entity.data.get("isAdmin", True)
     )
 
 
@@ -39,12 +49,56 @@ class XSenseNumberEntityDescription(NumberEntityDescription):
     """Describes X-Sense number entity."""
 
     data_key: str
-    addx_key: str
     exists_fn: Callable[[Entity], bool]
+    addx_key: str | None = None
     entity_category: EntityCategory | None = EntityCategory.CONFIG
 
 
 NUMBERS: tuple[XSenseNumberEntityDescription, ...] = (
+    XSenseNumberEntityDescription(
+        key="alarm_volume",
+        data_key="alarmVol",
+        translation_key="alarm_volume",
+        icon="mdi:volume-high",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        exists_fn=has_shadow_volume("alarmVol"),
+    ),
+    XSenseNumberEntityDescription(
+        key="voice_volume",
+        data_key="voiceVol",
+        translation_key="voice_volume",
+        icon="mdi:volume-high",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        exists_fn=has_shadow_volume("voiceVol"),
+    ),
+    XSenseNumberEntityDescription(
+        key="chirp_volume",
+        data_key="chirpVol",
+        translation_key="chirp_volume",
+        icon="mdi:volume-high",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        exists_fn=has_shadow_volume("chirpVol"),
+    ),
+    XSenseNumberEntityDescription(
+        key="reminder_volume",
+        data_key="remindVol",
+        translation_key="reminder_volume",
+        icon="mdi:volume-high",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        exists_fn=has_shadow_volume("remindVol"),
+    ),
     XSenseNumberEntityDescription(
         key="camera_alarm_volume",
         data_key="alarmVol",
@@ -160,14 +214,23 @@ async def async_setup_entry(
         devices.extend(
             XSenseNumberEntity(coordinator, station, description)
             for description in NUMBERS
-            if station.type in CAMERA_TYPES and description.exists_fn(station)
+            if description.exists_fn(station)
+        )
+
+    for dev in coordinator.data["devices"].values():
+        devices.extend(
+            XSenseNumberEntity(
+                coordinator, dev, description, station_id=dev.station.entity_id
+            )
+            for description in NUMBERS
+            if description.exists_fn(dev)
         )
 
     async_add_entities(devices)
 
 
 class XSenseNumberEntity(XSenseEntity, NumberEntity):
-    """Numeric settings for X-Sense cameras."""
+    """Numeric settings for X-Sense devices."""
 
     entity_description: XSenseNumberEntityDescription
 
@@ -176,11 +239,13 @@ class XSenseNumberEntity(XSenseEntity, NumberEntity):
         coordinator: XSenseDataUpdateCoordinator,
         entity: Entity,
         entity_description: XSenseNumberEntityDescription,
+        station_id: str | None = None,
     ) -> None:
         """Set up the instance."""
+        self._station_id = station_id
         self.entity_description = entity_description
         self._attr_available = False
-        super().__init__(coordinator, entity)
+        super().__init__(coordinator, entity, station_id)
 
     @property
     def native_value(self) -> float | None:
@@ -192,13 +257,17 @@ class XSenseNumberEntity(XSenseEntity, NumberEntity):
         return None if value is None else float(value)
 
     async def async_set_native_value(self, value: float) -> None:
-        """Write the camera setting through the ADDX user-config endpoint."""
+        """Write the X-Sense numeric setting."""
         entity = self._current_entity()
         if entity is None:
             raise HomeAssistantError("X-Sense entity is no longer available")
 
         int_value = round(value)
-        if self.entity_description.addx_key == "cooldown.value":
+        if self.entity_description.addx_key is None:
+            await self.coordinator.xsense.update_shadow_volume(
+                entity, self.entity_description.data_key, int_value
+            )
+        elif self.entity_description.addx_key == "cooldown.value":
             await self.coordinator.xsense.update_camera_cooldown(
                 entity,
                 user_enable=bool(entity.data.get("cooldownEnabled")),

--- a/custom_components/xsense/select.py
+++ b/custom_components/xsense/select.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .api.async_xsense import CAMERA_TYPES
+from .api.async_xsense import is_camera_entity
 from .api.device import Device
 from .api.entity import Entity
 from .const import DOMAIN
@@ -190,7 +190,7 @@ async def async_setup_entry(
         devices.extend(
             XSenseSelectEntity(coordinator, station, description)
             for description in SELECTS
-            if station.type in CAMERA_TYPES and description.exists_fn(station)
+            if is_camera_entity(station) and description.exists_fn(station)
         )
 
     async_add_entities(devices)

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from .api.device import Device
 from .api.entity import Entity
+from .api.entity_map import EntityType
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
@@ -28,8 +30,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN, STATE_SIGNAL
-from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
+
+
+if TYPE_CHECKING:
+    from .coordinator import XSenseDataUpdateCoordinator
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -105,6 +110,11 @@ def data_timestamp(key: str) -> Callable[[Entity], datetime | None]:
 def has_data(key: str) -> Callable[[Entity], bool]:
     """Return an exists function for a X-Sense data key."""
     return lambda entity: key in entity.data
+
+
+def has_report_time(entity: Entity) -> bool:
+    """Return whether a report timestamp should be exposed as a sensor."""
+    return "time" in entity.data and entity.entity_type is not EntityType.BASESTATION
 
 
 SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
@@ -641,7 +651,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=data_timestamp("time"),
-        exists_fn=has_data("time"),
+        exists_fn=has_report_time,
     ),
     XSenseSensorEntityDescription(
         key="utc_time",

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -97,6 +97,20 @@
       "wifi_sw": {
         "name": "Wifi Module Firmware"
       }
+    },
+    "number": {
+      "alarm_volume": {
+        "name": "Alarm Volume"
+      },
+      "voice_volume": {
+        "name": "Voice Volume"
+      },
+      "chirp_volume": {
+        "name": "Chirp Volume"
+      },
+      "reminder_volume": {
+        "name": "Reminder Volume"
+      }
     }
   }
 }

--- a/custom_components/xsense/switch.py
+++ b/custom_components/xsense/switch.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from .api.device import Device
 from .api.entity import Entity
-from .api.async_xsense import CAMERA_TYPES
+from .api.async_xsense import is_camera_entity
 
 from homeassistant import config_entries
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -87,6 +87,19 @@ SWITCHES: tuple[XSenseSwitchEntityDescription, ...] = (
         icon="mdi:led-on",
         exists_fn=has_data("ledLight"),
         value_fn=data_bool("ledLight"),
+    ),
+    XSenseSwitchEntityDescription(
+        key="light_power",
+        data_key="on",
+        name="Light Power",
+        icon="mdi:lightbulb",
+        exists_fn=lambda entity: (
+            entity.entity_type is not None
+            and entity.entity_type.value == "light"
+            and entity.type != "group-L"
+            and "on" in entity.data
+        ),
+        value_fn=data_bool("on"),
     ),
     XSenseSwitchEntityDescription(
         key="alarm_enabled",
@@ -424,7 +437,13 @@ class XSenseSwitchEntity(XSenseEntity, SwitchEntity):
             raise HomeAssistantError("X-Sense entity is no longer available")
 
         station = getattr(entity, "station", entity)
-        if entity.type in CAMERA_TYPES and self.entity_description.addx_key:
+        if self.entity_description.data_key == "on" and entity.type != "group-L":
+            await xsense.update_light_power(entity, enabled)
+            entity.data[self.entity_description.data_key] = enabled
+            self.coordinator.async_update_listeners()
+            return
+
+        if is_camera_entity(entity) and self.entity_description.addx_key:
             if self.entity_description.addx_key == "cooldown.userEnable":
                 await xsense.update_camera_cooldown(
                     entity,

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -97,6 +97,20 @@
             "wifi_sw": {
                 "name": "Wifi Module Firmware"
             }
+        },
+        "number": {
+            "alarm_volume": {
+                "name": "Alarm Volume"
+            },
+            "voice_volume": {
+                "name": "Voice Volume"
+            },
+            "chirp_volume": {
+                "name": "Chirp Volume"
+            },
+            "reminder_volume": {
+                "name": "Reminder Volume"
+            }
         }
     }
 }

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -27,7 +27,9 @@ def load_api_module(module_name: str):
 
 
 async_xsense = load_api_module("async_xsense")
+entity_map = load_api_module("entity_map")
 exceptions = load_api_module("exceptions")
+house = load_api_module("house")
 
 
 class FakeResponse:
@@ -121,18 +123,24 @@ async def test_get_state_raises_for_malformed_non_404_response():
 
 
 class FakeXSenseStation:
-    def __init__(self) -> None:
-        self.type = "SBS50"
+    def __init__(self, station_type: str = "SBS50") -> None:
+        self.type = station_type
         self.sn = "station-sn"
-        self.shadow_name = "SBS50station-sn"
+        self.shadow_name = "SBS50station-sn" if station_type == "SBS50" else "station-sn"
+        self.data = {}
 
 
 class FakeXSenseDevice:
-    def __init__(self, device_type: str = "XS0B-MR") -> None:
+    def __init__(
+        self,
+        device_type: str = "XS0B-MR",
+        entity_type=entity_map.EntityType.SMOKE,
+    ) -> None:
         self.type = device_type
         self.sn = "device-sn"
         self.station = FakeXSenseStation()
         self.data = {}
+        self.entity_type = entity_type
 
 
 @pytest.mark.asyncio
@@ -160,6 +168,263 @@ async def test_second_gen_self_test_uses_apk_payload_shape():
     assert desired["deviceSN"] == "device-sn"
     assert desired["userId"] == "user-id"
     assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_xs01_wx_standalone_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS01-WX")
+    device.station = FakeXSenseStation("XS01-WX")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "appselftest_device-sn"
+    assert desired == {
+        "shadow": "appSelfTest",
+        "stationSN": "station-sn",
+        "deviceSN": "device-sn",
+        "userId": "user-id",
+    }
+
+
+@pytest.mark.asyncio
+async def test_xs01_wx_sbs50_linked_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS01-WX")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "appSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_smoke_rf_v9_self_test_uses_apk_device_test_v2_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS01-M")
+    device.data = {"smokeEdition": "9"}
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "app2ndSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_smoke_rf_older_self_test_keeps_apk_smoke_test_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS01-M")
+    device.data = {"smokeEdition": "8"}
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "appSelfTest"
+    assert "userParam" not in desired
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_wifi_device_test_v2_targets_wifi_thing_like_apk():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XP0J-iA", entity_map.EntityType.COMBI)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "appSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_sd11_mr_self_test_uses_device_test_v2_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("SD11-MR")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "app2ndSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_sws0a_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("SWS0A", entity_map.EntityType.WATER)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "waterSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_sbs50_accessory_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("SDS0A", entity_map.EntityType.DOOR)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "app2ndSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+async def test_listener_self_test_uses_apk_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("SAL51", entity_map.EntityType.LISTENER)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "test")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_selftest_device-sn"
+    assert desired["shadow"] == "listenerSelfTest"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
     assert desired["time"].isdigit()
     assert len(desired["time"]) == 13
 
@@ -276,3 +541,330 @@ async def test_do_thing_raises_on_shadow_update_failure():
             "2nd_selftest_device-sn",
             {"state": {"desired": {"a": 1}}},
         )
+
+
+@pytest.mark.asyncio
+async def test_sbs50_station_voice_volume_uses_station_config_shadow():
+    client = async_xsense.AsyncXSense()
+    station = FakeXSenseStation("SBS50")
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(station, "voiceVol", 35)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is station
+    assert page == "2nd_cfg_station-sn"
+    assert desired == {
+        "shadow": "infoBase",
+        "stationSN": "station-sn",
+        "voiceVol": "35",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sbs50_child_alarm_volume_uses_device_config_shadow():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("XS0B-MR")
+    device.data = {"alarmTone": "2"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "alarmVol", 65)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "stationSN": "station-sn",
+        "alarmVol": "65",
+        "deviceSN": "device-sn",
+        "alarmTone": "2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sbs10_station_alarm_volume_keeps_companion_voice_value():
+    client = async_xsense.AsyncXSense()
+    station = FakeXSenseStation("SBS10")
+    station.data = {"voiceVol": 45, "alarmTone": "3"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(station, "alarmVol", 55)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is station
+    assert page == "info_station-sn"
+    assert desired == {
+        "shadow": "infoBase",
+        "stationSN": "station-sn",
+        "alarmVol": "55",
+        "voiceVol": "45",
+        "alarmTone": "3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_light_power_uses_lamp_power_payload_shape():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("SSL51", entity_map.EntityType.LIGHT)
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_light_power(device, True)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_lamppower"
+    assert desired["shadow"] == "lampPower"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["dev"] == "device-sn"
+    assert desired["isOn"] == "1"
+    assert desired["userId"] == "user-id"
+    assert desired["userParam"] == "source=1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 14
+
+
+@pytest.mark.asyncio
+async def test_sbs50_child_chirp_volume_uses_device_info_payload_without_station_sn():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("SDS0A")
+    device.data = {"chirpTone": "3"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "chirpVol", 40)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "chirpVol": "40",
+        "deviceSN": "device-sn",
+        "chirpTone": "3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sbs50_child_reminder_volume_preserves_reminder_tone():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("SDS0A")
+    device.data = {"remindTone": "2"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "remindVol", 30)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "remindVol": "30",
+        "deviceSN": "device-sn",
+        "remindTone": "2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_light_alarm_volume_uses_light_info_payload_without_station_sn():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("CB0Z-3S", entity_map.EntityType.LIGHT)
+    device.data = {"alarmTone": "1"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "alarmVol", 70)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "alarmVol": "70",
+        "deviceSN": "device-sn",
+        "alarmTone": "1",
+    }
+
+
+
+@pytest.mark.asyncio
+async def test_co_alarm_volume_uses_co_info_payload_without_station_sn():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("XC0C-MR", entity_map.EntityType.CO)
+    device.data = {"alarmTone": "3"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "alarmVol", 80)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "alarmVol": "80",
+        "deviceSN": "device-sn",
+        "alarmTone": "3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_temperature_alarm_volume_uses_temp_info_payload_without_station_sn():
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice("STH0B", entity_map.EntityType.TEMPERATURE)
+    device.data = {"alarmTone": "2"}
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.update_shadow_volume(device, "alarmVol", 60)
+
+    assert len(calls) == 1
+    station_arg, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station_arg is device.station
+    assert page == "2nd_cfg_device-sn"
+    assert desired == {
+        "shadow": "infoDev",
+        "alarmVol": "60",
+        "deviceSN": "device-sn",
+        "alarmTone": "2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_creates_cameras_from_addx_device_list():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.stations = {}
+    test_house.station_order = []
+    client.houses = {"house-id": test_house}
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "cam-sn",
+                        "deviceName": "Front Camera",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                        "batteryLevel": 3,
+                        "deviceModel": {"streamProtocol": "webrtc"},
+                        "deviceSupport": {"supportWebrtc": 1},
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    assert "cam-sn" in test_house.stations
+    camera = test_house.stations["cam-sn"]
+    assert async_xsense.is_camera_entity(camera)
+    assert camera.name == "Front Camera"
+    assert camera.type == "SSC0A"
+    assert camera.sn == "cam-sn"
+    assert camera.data["batteryLevel"] == 3
+    assert camera.data["streamProtocol"] == "webrtc"
+    assert ("/device/getuserconfig", {"serialNumber": "cam-sn", "voiceReminder": False}) in calls
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_skips_unsupported_addx_camera_models():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.stations = {}
+    test_house.station_order = []
+    client.houses = {"house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "unknown-cam",
+                        "deviceName": "New Camera",
+                        "displayModelNo": "Future Cam",
+                        "deviceModel": {"modelName": "G2"},
+                        "deviceSupport": {},
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    assert test_house.stations == {}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from custom_components.xsense.api.entity_map import EntityType
+from custom_components.xsense.sensor import has_report_time
+
+
+def test_base_station_report_time_is_internal_metadata():
+    entity = SimpleNamespace(
+        data={"time": "20260531150149"},
+        entity_type=EntityType.BASESTATION,
+    )
+
+    assert not has_report_time(entity)
+
+
+def test_device_report_time_remains_available():
+    entity = SimpleNamespace(
+        data={"time": "20260531150149"},
+        entity_type=EntityType.TEMPERATURE,
+    )
+
+    assert has_report_time(entity)


### PR DESCRIPTION
## Summary
- Fix camera discovery so SSC0A/SSC0B cameras exposed by the APK IPC/ADDX device list are created even when they are absent from the normal station list.
- Align supported test actions, light power, and volume payloads with the Android app shadow behavior.
- Stop exposing base-station report time as a changing sensor to avoid activity-log spam.
- Bump the integration version to 1.2.4.

## Validation
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 /root/.venvs/ha-xsense-test/bin/python -m pytest -q`
