### PR TITLE
Prepare 1.2.5 release

### DIFF
--- a/.github/release-notes/v.1.2.5.md
+++ b/.github/release-notes/v.1.2.5.md
@@ -1,0 +1,26 @@
+## What changed
+
+This release tightens the integration behavior to match the X-Sense Android app more closely after the 1.2.4 cloud/API refactor.
+
+## Fixes
+
+- Fixed camera API probing so accounts without SSC0A/SSC0B cameras do not call the IPC/ADDX camera API unnecessarily.
+- Fixed camera-only entities so camera controls and diagnostics are exposed only for APK-supported camera models.
+- Fixed self-test reporting to follow the APK self-test update topics and expose readable result/time sensors.
+- Fixed base station report-time entities from filling the Home Assistant activity log.
+- Fixed additional APK-supported mute actions for Wi-Fi, SBS50 child, smoke, CO, water, temperature, and radon devices.
+- Fixed Wi-Fi action thing names to match the APK, including dashed vs non-dashed models and the special XS01-WX EN/UL serial path.
+- Fixed Wi-Fi fire-drill and self-test action targets to use the same shadow targets as the APK.
+
+## Improvements
+
+- Added regression coverage for APK thing-name rules, camera gating, action payloads, self-test updates, report-time handling, and shadow volume writes.
+- Kept API usage lighter by skipping camera-specific API calls unless APK-supported cameras are present in the normal device list.
+
+## Validation
+
+- `git diff --check`
+- JSON parse checks for integration strings and translations
+- Python AST/duplicate-key checks for integration and test files
+- `PYTHONDONTWRITEBYTECODE=1 /root/.venvs/ha-xsense-test/bin/python -m pytest -q`
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,20 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6.0.2
 
+      - name: Check for curated release notes
+        id: notes
+        shell: bash
+        run: |
+          notes_file=".github/release-notes/${GITHUB_REF_NAME}.md"
+          if [[ -f "$notes_file" ]]; then
+            echo "body_path=$notes_file" >> "$GITHUB_OUTPUT"
+            echo "generate=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "generate=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3.0.0
         with:
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.body_path }}
+          generate_release_notes: ${{ steps.notes.outputs.generate }}

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -32,11 +32,30 @@ _HOUSE_STATE_DEVICE_TYPES = {
     "XP0A-iR",
     "XP0H-iR",
     "XP0J-iA",
+    "XR0A-iR",
     "XS01-WX",
     "XS03-WX",
     "XS0B-iR",
     "XS0E-iR",
     "XS0R-iA",
+}
+
+# The APK uses 2nd_info directly for the newer standalone Wi-Fi CO,
+# combined, temperature/humidity, water, and radon families. Wi-Fi smoke
+# families still use the legacy info shadow in their settings screens.
+_SECOND_INFO_DEVICE_TYPES = {
+    "SC06-WX",
+    "SC07-WX",
+    "STH0C",
+    "SWS0B",
+    "XC04-WX",
+    "XC0C-iA",
+    "XC0C-iR",
+    "XC0M-iR",
+    "XP0A-iR",
+    "XP0H-iR",
+    "XP0J-iA",
+    "XR0A-iR",
 }
 
 
@@ -50,9 +69,19 @@ def _station_state_shadow_names(station: Station) -> tuple[str, ...]:
     return ("2nd_mainpage",)
 
 
+def _station_info_shadow_names(station: Station) -> tuple[str, ...]:
+    if station.type == "SBS10":
+        return (f"info_{station.sn}",)
+    if station.type == "SBS50" or station.type in _SECOND_INFO_DEVICE_TYPES:
+        return (f"2nd_info_{station.sn}",)
+    return (f"info_{station.sn}", f"2nd_info_{station.sn}")
+
+
 def is_camera_entity(entity: Entity) -> bool:
     """Return if an entity is an IPC camera discovered through the app path."""
-    return entity.type in CAMERA_TYPES or entity.entity_type == EntityType.CAMERA
+    return entity.type in CAMERA_TYPES or (
+        getattr(entity, "entity_type", None) == EntityType.CAMERA
+    )
 
 
 class AsyncXSense(XSenseBase):
@@ -314,10 +343,6 @@ class AsyncXSense(XSenseBase):
 
     async def update_camera_data(self):
         """Merge camera metadata and config from the Android app ADDX API."""
-        data = await self.addx_call("/device/listuserdevices")
-        devices = (data or {}).get("list") or []
-        self._ensure_addx_cameras(devices)
-
         cameras = [
             station
             for house in self.houses.values()
@@ -326,6 +351,16 @@ class AsyncXSense(XSenseBase):
         ]
         if not cameras:
             return
+
+        try:
+            data = await self.addx_call("/device/listuserdevices")
+        except APIFailure as ex:
+            if _is_camera_api_unavailable(ex):
+                return
+            raise
+
+        devices = (data or {}).get("list") or []
+        self._ensure_addx_cameras(devices)
 
         by_sn = {device.get("serialNumber"): device for device in devices}
 
@@ -583,20 +618,16 @@ class AsyncXSense(XSenseBase):
             station.set_alarm_data(res["state"]["reported"])
 
     async def get_station_state(self, station: Station):
-        res = None
+        for page in _station_info_shadow_names(station):
+            res = await self.get_thing(station, page)
 
-        if station.type not in ("SBS50", "SC07-WX", "XC04-WX"):
-            res = await self.get_thing(station, f"info_{station.sn}")
+            if self._lastres.status == 404:
+                continue
 
-        if res is None or self._lastres.status == 404:
-            res = await self.get_thing(station, f"2nd_info_{station.sn}")
+            if "reported" in res.get("state", {}):
+                station.set_data(res["state"]["reported"])
+                return
 
-        if self._lastres.status == 404:
-            return
-
-        if "reported" in res.get("state", {}):
-            station.set_data(res["state"]["reported"])
-        else:
             text = await self._lastres.text()
             raise APIFailure(
                 f"Unable to retrieve station data: {self._lastres.status}/{text}"
@@ -769,6 +800,12 @@ def _action_timestamp(definition: Dict, entity: Entity) -> str | None:
     if time_format == "epoch_ms":
         return str(int(datetime.now(timezone.utc).timestamp() * 1000))
     return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def _is_camera_api_unavailable(error: APIFailure) -> bool:
+    """Return if the ADDX/IPC camera API is not enabled for this account."""
+    message = str(error).lower()
+    return "10000023" in message or "clientid is incorrect" in message
 
 
 def _camera_type(data: Dict) -> str | None:

--- a/custom_components/xsense/api/entity_map.py
+++ b/custom_components/xsense/api/entity_map.py
@@ -29,6 +29,7 @@ def MuteAction(
     topic: Union[str, Callable, None] = "2nd_appmute",
     extra: Optional[Dict] = None,
     mute_type: Optional[str] = None,
+    target=None,
 ):
     data = {
         "action": "mute",
@@ -39,6 +40,8 @@ def MuteAction(
         data["extra"] = extra
     if mute_type is not None:
         data.setdefault("extra", {})["muteType"] = mute_type
+    if target:
+        data["target"] = target
 
     return data
 
@@ -73,9 +76,42 @@ def SmokeRFTestAction():
     return TestAction(_smoke_rf_test_shadow, extra=_smoke_rf_test_extra)
 
 
+class _ThingTarget:
+    def __init__(self, source, shadow_name: str) -> None:
+        self.house = getattr(source, "house", None)
+        self.shadow_name = shadow_name
+
+
+def _xs01_wx_thing_name(station_sn: str) -> str:
+    separator = "-" if "EN" in station_sn.upper() or "UL" in station_sn.upper() else ""
+    return f"XS01-WX{separator}{station_sn}"
+
+
+def _wifi_thing_name(device_type: str, station_sn: str) -> str:
+    if device_type == "XS01-WX":
+        return _xs01_wx_thing_name(station_sn)
+    if device_type in {"XS0E-iR", "XS03-WX"}:
+        return f"{device_type}{station_sn}"
+    return f"{device_type}-{station_sn}"
+
+
+def _wifi_thing_target(entity):
+    station = getattr(entity, "station", entity)
+    return _ThingTarget(station, _wifi_thing_name(entity.type, station.sn))
+
+
+_WIFI_FIRE_DRILL_TYPES = {"XP0J-iA", "XS0R-iA"}
+
+
+def _fire_drill_target(entity):
+    if entity.type in _WIFI_FIRE_DRILL_TYPES:
+        return _wifi_thing_target(entity)
+    return getattr(entity, "station", entity)
+
+
 def WifiSelfTestAction():
     return TestAction(
-        "appSelfTest", extra={"userParam": "source=1"}, target=lambda entity: entity
+        "appSelfTest", extra={"userParam": "source=1"}, target=_wifi_thing_target
     )
 
 
@@ -95,6 +131,7 @@ def FireDrillAction():
         "action": "firedrill",
         "topic": "2nd_firedrill",
         "shadow": "appFireDrill",
+        "target": _fire_drill_target,
         "data": lambda entity: {
             "alarmTone": "1",
             "alarmType": _fire_drill_alarm_type(entity),
@@ -142,9 +179,15 @@ def _is_smoke_v9(entity) -> bool:
         return False
 
 
+def _xs01_wx_target(entity):
+    station = getattr(entity, "station", entity)
+    return _ThingTarget(station, _xs01_wx_thing_name(station.sn))
+
+
 def XS01WXMuteAction():
     return MuteAction(
         topic=lambda entity: "2nd_appmute" if _is_smoke_v9(entity) else "appmute",
+        target=_xs01_wx_target,
         mute_type="0",
     )
 
@@ -155,6 +198,35 @@ def SC07MRMuteAction():
         mute_type="1",
         extra={"userParam": "source=1"},
     )
+
+
+def WifiAlarmMuteAction():
+    return MuteAction(mute_type="1", target=_wifi_thing_target)
+
+
+def WifiExtendedMuteAction():
+    return MuteAction("extendMute", "2nd_appmute", mute_type="1", target=_wifi_thing_target)
+
+
+def WifiWaterMuteAction():
+    return MuteAction("appWater", "2nd_appwater", mute_type="1", target=_wifi_thing_target)
+
+
+def SBS50SmokeMuteAction():
+    return MuteAction("appMute", "2nd_appmute", mute_type="1")
+
+
+def SBS50CoMuteAction():
+    return MuteAction("app2ndMute", "2nd_appmute", mute_type="1")
+
+
+def _station_serial_target(entity):
+    station = getattr(entity, "station", entity)
+    return _ThingTarget(station, station.sn)
+
+
+def SmokeRFAppMuteAction():
+    return MuteAction("appMute", "appmute", target=_station_serial_target, mute_type="1")
 
 
 entities = {
@@ -204,6 +276,7 @@ entities = {
     "SC06-WX": {
         "identifier": lambda entity: f"SC06-WX-{entity.sn}",
         "type": EntityType.COMBI,
+        "actions": [WifiAlarmMuteAction()],
     },
     "SC07-MR": {
         "identifier": lambda entity: f"SC07-MR-{entity.sn}",
@@ -217,12 +290,13 @@ entities = {
     "SC07-WX": {
         "identifier": lambda entity: f"SC07-WX-{entity.sn}",
         "type": EntityType.COMBI,
-        "actions": [MuteAction(mute_type="1")],
+        "actions": [WifiAlarmMuteAction()],
     },
     "SD11-MR": {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -230,6 +304,7 @@ entities = {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -260,6 +335,7 @@ entities = {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -324,6 +400,7 @@ entities = {
     },
     "STH0C": {
         "type": EntityType.TEMPERATURE,
+        "actions": [WifiExtendedMuteAction()],
     },
     "STH51": {
         "type": EntityType.TEMPERATURE,
@@ -345,6 +422,7 @@ entities = {
     },
     "SWS0B": {
         "type": EntityType.WATER,
+        "actions": [WifiWaterMuteAction()],
     },
     "SWS51": {
         "type": EntityType.WATER,
@@ -369,6 +447,7 @@ entities = {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -382,12 +461,15 @@ entities = {
     },
     "XC0C-iA": {
         "type": EntityType.CO,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XC0C-iR": {
         "type": EntityType.CO,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XC0M-iR": {
         "type": EntityType.CO,
+        "actions": [WifiExtendedMuteAction()],
     },
     "XC01-M": {
         # CO RF
@@ -401,7 +483,7 @@ entities = {
     "XC04-WX": {
         "identifier": lambda entity: f"XC04-WX-{entity.sn}",
         "type": EntityType.CO,
-        "actions": [MuteAction(mute_type="1")],
+        "actions": [WifiAlarmMuteAction()],
     },
     "XH02-M": {
         "type": EntityType.HEAT,
@@ -421,11 +503,13 @@ entities = {
     },
     "XR0A-iR": {
         "type": EntityType.RADON,
+        "actions": [WifiExtendedMuteAction()],
     },
     "XP02S-MR": {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -457,15 +541,18 @@ entities = {
         "type": EntityType.SMOKE,
         "actions": [
             SmokeRFTestAction(),
+            SmokeRFAppMuteAction(),
         ],
     },
     "XS03-WX": {
         "type": EntityType.SMOKE,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XS0D-MR": {
         "type": EntityType.SMOKE,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50SmokeMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -473,11 +560,13 @@ entities = {
         "type": EntityType.CO,
         "actions": [
             SBS50SecondGenTestAction(),
+            SBS50CoMuteAction(),
             FireDrillAction(),
         ],
     },
     "XP0A-iR": {
         "type": EntityType.COMBI,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XP0H-MR": {
         "type": EntityType.COMBI,
@@ -489,11 +578,13 @@ entities = {
     },
     "XP0H-iR": {
         "type": EntityType.COMBI,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XP0J-iA": {
         "type": EntityType.COMBI,
         "actions": [
             WifiSelfTestAction(),
+            WifiAlarmMuteAction(),
             FireDrillAction(),
         ],
     },
@@ -507,9 +598,11 @@ entities = {
     },
     "XS0B-iR": {
         "type": EntityType.SMOKE,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XS0E-iR": {
         "type": EntityType.SMOKE,
+        "actions": [WifiAlarmMuteAction()],
     },
     "XS0F-PMA": {
         "type": EntityType.SMOKE,
@@ -523,6 +616,7 @@ entities = {
         "type": EntityType.SMOKE,
         "actions": [
             WifiSelfTestAction(),
+            WifiAlarmMuteAction(),
             FireDrillAction(),
         ],
     },

--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from .api.async_xsense import is_camera_entity
 from .api.device import Device
 from .api.entity import Entity
 from .api.station import Station
@@ -78,6 +79,11 @@ def data_bool(key: str) -> Callable[[Entity], bool]:
 def has_data(key: str) -> Callable[[Entity], bool]:
     """Return an exists function for a X-Sense data key."""
     return lambda entity: key in entity.data
+
+
+def has_camera_data(key: str) -> Callable[[Entity], bool]:
+    """Return an exists function for an IPC camera data key."""
+    return lambda entity: is_camera_entity(entity) and key in entity.data
 
 
 SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
@@ -182,7 +188,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Camera Awake",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:cctv",
-        exists_fn=has_data("awake"),
+        exists_fn=has_camera_data("awake"),
         value_fn=data_bool("awake"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -191,7 +197,9 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:power-sleep",
         exists_fn=lambda entity: (
-            "deviceStatus" in entity.data and entity.data.get("supportSleep", False)
+            is_camera_entity(entity)
+            and "deviceStatus" in entity.data
+            and entity.data.get("supportSleep", False)
         ),
         value_fn=lambda entity: entity.data["deviceStatus"] == 3,
     ),
@@ -243,35 +251,35 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Motion Required",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:motion-sensor",
-        exists_fn=has_data("needMotion"),
+        exists_fn=has_camera_data("needMotion"),
         value_fn=data_bool("needMotion"),
     ),
     XSenseBinarySensorEntityDescription(
         key="video_recording_enabled",
         name="Video Recording Enabled",
         icon="mdi:video-check",
-        exists_fn=has_data("needVideo"),
+        exists_fn=has_camera_data("needVideo"),
         value_fn=data_bool("needVideo"),
     ),
     XSenseBinarySensorEntityDescription(
         key="night_vision_enabled",
         name="Night Vision Enabled",
         icon="mdi:weather-night",
-        exists_fn=has_data("needNightVision"),
+        exists_fn=has_camera_data("needNightVision"),
         value_fn=data_bool("needNightVision"),
     ),
     XSenseBinarySensorEntityDescription(
         key="recording_light_enabled",
         name="Recording Light Enabled",
         icon="mdi:led-on",
-        exists_fn=has_data("recLamp"),
+        exists_fn=has_camera_data("recLamp"),
         value_fn=data_bool("recLamp"),
     ),
     XSenseBinarySensorEntityDescription(
         key="camera_alarm_enabled",
         name="Camera Alarm Enabled",
         icon="mdi:bell-check",
-        exists_fn=has_data("needAlarm"),
+        exists_fn=has_camera_data("needAlarm"),
         value_fn=data_bool("needAlarm"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -279,7 +287,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Mirror Flip",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:flip-horizontal",
-        exists_fn=has_data("mirrorFlip"),
+        exists_fn=has_camera_data("mirrorFlip"),
         value_fn=data_bool("mirrorFlip"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -287,7 +295,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Anti-Flicker",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:lightbulb-on-10",
-        exists_fn=has_data("antiflickerSwitch"),
+        exists_fn=has_camera_data("antiflickerSwitch"),
         value_fn=data_bool("antiflickerSwitch"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -295,7 +303,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Live Audio",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:volume-high",
-        exists_fn=has_data("liveAudioToggleOn"),
+        exists_fn=has_camera_data("liveAudioToggleOn"),
         value_fn=data_bool("liveAudioToggleOn"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -303,7 +311,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Voice Volume Enabled",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:volume-high",
-        exists_fn=has_data("voiceVolumeSwitch"),
+        exists_fn=has_camera_data("voiceVolumeSwitch"),
         value_fn=data_bool("voiceVolumeSwitch"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -311,7 +319,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="Cooldown Enabled",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:timer-sand",
-        exists_fn=has_data("cooldownEnabled"),
+        exists_fn=has_camera_data("cooldownEnabled"),
         value_fn=data_bool("cooldownEnabled"),
     ),
     XSenseBinarySensorEntityDescription(
@@ -319,7 +327,7 @@ SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         name="WebRTC Supported",
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video-wireless-outline",
-        exists_fn=has_data("supportWebrtc"),
+        exists_fn=has_camera_data("supportWebrtc"),
         value_fn=data_bool("supportWebrtc"),
     ),
     XSenseBinarySensorEntityDescription(

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -332,6 +332,11 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 topic,
             )
 
+        if _is_self_test_topic(topic) and "selfTest" in station_data:
+            station_data["lastSelfTest"] = station_data.pop("selfTest")
+            if test_time := station_data.pop("time", None):
+                station_data["lastSelfTestTime"] = test_time
+
         children = station_data.pop("devs", {})
         target_device_sn = station_data.get("deviceSN") or station_data.get(
             "_deviceSN"
@@ -451,3 +456,11 @@ def _mqtt_reported_data(data: dict[str, Any]) -> dict[str, Any]:
         return result
 
     return {}
+
+
+def _is_self_test_topic(topic: str) -> bool:
+    """Return if an MQTT update is an X-Sense self-test report topic."""
+    return (
+        "/shadow/name/selftestup/update" in topic
+        or "/shadow/name/2nd_selftestup/update" in topic
+    )

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -1,16 +1,23 @@
 {
   "domain": "xsense",
   "name": "X-Sense Home Security",
-  "codeowners": ["@theosnel"],
+  "codeowners": [
+    "@theosnel"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/Jarnsen/ha-xsense-component_test",
   "homekit": {},
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["boto3", "botocore", "pycognito", "paho-mqtt>=2.1.0,<3"],
+  "requirements": [
+    "boto3",
+    "botocore",
+    "pycognito",
+    "paho-mqtt>=2.1.0,<3"
+  ],
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.4"
+  "version": "1.2.5"
 }

--- a/custom_components/xsense/number.py
+++ b/custom_components/xsense/number.py
@@ -22,7 +22,11 @@ from .entity import XSenseEntity
 
 def has_data(key: str) -> Callable[[Entity], bool]:
     """Return an exists function for a X-Sense data key."""
-    return lambda entity: key in entity.data and entity.data.get("isAdmin", True)
+    return lambda entity: (
+        is_camera_entity(entity)
+        and key in entity.data
+        and entity.data.get("isAdmin", True)
+    )
 
 
 def has_supported_data(key: str, support_key: str) -> Callable[[Entity], bool]:
@@ -178,7 +182,8 @@ NUMBERS: tuple[XSenseNumberEntityDescription, ...] = (
         native_max_value=300,
         native_step=1,
         exists_fn=lambda entity: (
-            "cooldownValue" in entity.data
+            is_camera_entity(entity)
+            and "cooldownValue" in entity.data
             and entity.data.get("isAdmin", True)
             and "cooldownOptions" not in entity.data
             and entity.data.get("cooldownSupported", True)

--- a/custom_components/xsense/select.py
+++ b/custom_components/xsense/select.py
@@ -23,14 +23,17 @@ from .entity import XSenseEntity
 def has_data(*keys: str) -> Callable[[Entity], bool]:
     """Return an exists function for required X-Sense data keys."""
     return lambda entity: (
-        all(key in entity.data for key in keys) and entity.data.get("isAdmin", True)
+        is_camera_entity(entity)
+        and all(key in entity.data for key in keys)
+        and entity.data.get("isAdmin", True)
     )
 
 
 def has_supported_data(*keys: str, support_key: str) -> Callable[[Entity], bool]:
     """Return if the app exposes a supported camera setting."""
     return lambda entity: (
-        all(key in entity.data for key in keys)
+        is_camera_entity(entity)
+        and all(key in entity.data for key in keys)
         and entity.data.get("isAdmin", True)
         and entity.data.get(support_key, True)
     )
@@ -108,7 +111,8 @@ SELECTS: tuple[XSenseSelectEntityDescription, ...] = (
         name="Default Codec",
         icon="mdi:video-settings",
         exists_fn=lambda entity: (
-            "defaultCodec" in entity.data
+            is_camera_entity(entity)
+            and "defaultCodec" in entity.data
             and entity.data.get("isAdmin", True)
             and entity.data.get("showCodecChange", False)
         ),
@@ -141,7 +145,8 @@ SELECTS: tuple[XSenseSelectEntityDescription, ...] = (
         name="Cooldown",
         icon="mdi:timer-sand",
         exists_fn=lambda entity: (
-            "cooldownValue" in entity.data
+            is_camera_entity(entity)
+            and "cooldownValue" in entity.data
             and entity.data.get("isAdmin", True)
             and "cooldownOptions" in entity.data
             and entity.data.get("cooldownSupported", True)

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from .api.async_xsense import is_camera_entity
 from .api.device import Device
 from .api.entity import Entity
-from .api.entity_map import EntityType
+from .api.entity_map import EntityType, entities
 
 from homeassistant import config_entries
 from homeassistant.components.sensor import (
@@ -107,14 +108,42 @@ def data_timestamp(key: str) -> Callable[[Entity], datetime | None]:
     return lambda entity: timestamp_value(entity.data[key])
 
 
+def optional_data_timestamp(key: str) -> Callable[[Entity], datetime | None]:
+    """Return an optional timestamp value function for late-reporting fields."""
+    return lambda entity: timestamp_value(entity.data.get(key))
+
+
+def self_test_result(entity: Entity) -> str | None:
+    """Return a readable self-test result from the X-Sense selftestup report."""
+    value = entity.data.get("lastSelfTest")
+    if value in (None, ""):
+        return "not_run"
+    if str(value) == "0":
+        return "success"
+    return "failed"
+
+
 def has_data(key: str) -> Callable[[Entity], bool]:
     """Return an exists function for a X-Sense data key."""
     return lambda entity: key in entity.data
 
 
+def has_camera_data(key: str) -> Callable[[Entity], bool]:
+    """Return an exists function for an IPC camera data key."""
+    return lambda entity: is_camera_entity(entity) and key in entity.data
+
+
 def has_report_time(entity: Entity) -> bool:
     """Return whether a report timestamp should be exposed as a sensor."""
     return "time" in entity.data and entity.entity_type is not EntityType.BASESTATION
+
+
+def has_self_test_report(entity: Entity) -> bool:
+    """Return whether the entity can report an app-style self-test result."""
+    entity_def = entities.get(entity.type, {})
+    return "lastSelfTest" in entity.data or any(
+        action.get("action") == "test" for action in entity_def.get("actions", [])
+    )
 
 
 SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
@@ -391,7 +420,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
         value_fn=data_value("batteryLevel"),
-        exists_fn=has_data("batteryLevel"),
+        exists_fn=has_camera_data("batteryLevel"),
     ),
     XSenseSensorEntityDescription(
         key="rf_level",
@@ -420,7 +449,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=data_value("signalStrength"),
-        exists_fn=has_data("signalStrength"),
+        exists_fn=has_camera_data("signalStrength"),
     ),
     XSenseSensorEntityDescription(
         key="serial_number",
@@ -678,6 +707,22 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         exists_fn=has_data("testTime"),
     ),
     XSenseSensorEntityDescription(
+        key="last_self_test",
+        translation_key="last_self_test",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:check-circle-outline",
+        value_fn=self_test_result,
+        exists_fn=has_self_test_report,
+    ),
+    XSenseSensorEntityDescription(
+        key="last_self_test_time",
+        translation_key="last_self_test_time",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=optional_data_timestamp("lastSelfTestTime"),
+        exists_fn=has_self_test_report,
+    ),
+    XSenseSensorEntityDescription(
         key="timezone",
         name="Time Zone",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -811,7 +856,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:cctv",
         value_fn=data_value("cameraModel"),
-        exists_fn=has_data("cameraModel"),
+        exists_fn=has_camera_data("cameraModel"),
     ),
     XSenseSensorEntityDescription(
         key="camera_status_code",
@@ -819,7 +864,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:cctv",
         value_fn=data_value("cameraStatusCode"),
-        exists_fn=has_data("cameraStatusCode"),
+        exists_fn=has_camera_data("cameraStatusCode"),
     ),
     XSenseSensorEntityDescription(
         key="camera_device_status",
@@ -827,7 +872,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:cctv",
         value_fn=data_value("deviceStatus"),
-        exists_fn=has_data("deviceStatus"),
+        exists_fn=has_camera_data("deviceStatus"),
     ),
     XSenseSensorEntityDescription(
         key="camera_sleep_message",
@@ -835,7 +880,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:power-sleep",
         value_fn=data_value("deviceDormancyMessage"),
-        exists_fn=has_data("deviceDormancyMessage"),
+        exists_fn=has_camera_data("deviceDormancyMessage"),
     ),
     XSenseSensorEntityDescription(
         key="camera_wake_time",
@@ -844,7 +889,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:alarm",
         value_fn=data_timestamp("deviceDormancyWakeTime"),
-        exists_fn=has_data("deviceDormancyWakeTime"),
+        exists_fn=has_camera_data("deviceDormancyWakeTime"),
     ),
     XSenseSensorEntityDescription(
         key="camera_firmware_status",
@@ -852,7 +897,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:update",
         value_fn=data_value("firmwareStatus"),
-        exists_fn=has_data("firmwareStatus"),
+        exists_fn=has_camera_data("firmwareStatus"),
     ),
     XSenseSensorEntityDescription(
         key="camera_firmware_version",
@@ -860,7 +905,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:chip",
         value_fn=data_value("firmwareVersion"),
-        exists_fn=has_data("firmwareVersion"),
+        exists_fn=has_camera_data("firmwareVersion"),
     ),
     XSenseSensorEntityDescription(
         key="camera_network_name",
@@ -868,7 +913,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:wifi",
         value_fn=data_value("networkName"),
-        exists_fn=has_data("networkName"),
+        exists_fn=has_camera_data("networkName"),
     ),
     XSenseSensorEntityDescription(
         key="camera_recording_resolution",
@@ -876,7 +921,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video",
         value_fn=data_value("recResolution"),
-        exists_fn=has_data("recResolution"),
+        exists_fn=has_camera_data("recResolution"),
     ),
     XSenseSensorEntityDescription(
         key="camera_stream_protocol",
@@ -884,7 +929,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video-wireless-outline",
         value_fn=data_value("streamProtocol"),
-        exists_fn=has_data("streamProtocol"),
+        exists_fn=has_camera_data("streamProtocol"),
     ),
     XSenseSensorEntityDescription(
         key="camera_codec",
@@ -892,7 +937,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video-settings",
         value_fn=data_value("codec"),
-        exists_fn=has_data("codec"),
+        exists_fn=has_camera_data("codec"),
     ),
     XSenseSensorEntityDescription(
         key="camera_default_codec",
@@ -900,7 +945,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video-settings",
         value_fn=data_value("defaultCodec"),
-        exists_fn=has_data("defaultCodec"),
+        exists_fn=has_camera_data("defaultCodec"),
     ),
     XSenseSensorEntityDescription(
         key="camera_thumbnail_url",
@@ -908,7 +953,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:image",
         value_fn=data_value("thumbImgUrl"),
-        exists_fn=has_data("thumbImgUrl"),
+        exists_fn=has_camera_data("thumbImgUrl"),
     ),
     XSenseSensorEntityDescription(
         key="camera_live_url",
@@ -916,7 +961,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:video-wireless-outline",
         value_fn=data_value("cameraLiveUrl"),
-        exists_fn=has_data("cameraLiveUrl"),
+        exists_fn=has_camera_data("cameraLiveUrl"),
     ),
     XSenseSensorEntityDescription(
         key="camera_video_seconds",
@@ -924,7 +969,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:timer-outline",
         value_fn=data_value("videoSeconds"),
-        exists_fn=has_data("videoSeconds"),
+        exists_fn=has_camera_data("videoSeconds"),
     ),
     XSenseSensorEntityDescription(
         key="camera_alarm_seconds",
@@ -932,7 +977,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:timer-outline",
         value_fn=data_value("alarmSeconds"),
-        exists_fn=has_data("alarmSeconds"),
+        exists_fn=has_camera_data("alarmSeconds"),
     ),
     XSenseSensorEntityDescription(
         key="camera_motion_sensitivity",
@@ -940,7 +985,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:motion-sensor",
         value_fn=data_value("motionSensitivity"),
-        exists_fn=has_data("motionSensitivity"),
+        exists_fn=has_camera_data("motionSensitivity"),
     ),
     XSenseSensorEntityDescription(
         key="camera_night_vision_mode",
@@ -948,7 +993,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:weather-night",
         value_fn=data_value("nightVisionMode"),
-        exists_fn=has_data("nightVisionMode"),
+        exists_fn=has_camera_data("nightVisionMode"),
     ),
     XSenseSensorEntityDescription(
         key="camera_time_zone",
@@ -956,7 +1001,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:map-clock",
         value_fn=data_value("timeZone"),
-        exists_fn=has_data("timeZone"),
+        exists_fn=has_camera_data("timeZone"),
     ),
     XSenseSensorEntityDescription(
         key="camera_time_zone_area",
@@ -964,7 +1009,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:map-clock",
         value_fn=data_value("timeZoneArea"),
-        exists_fn=has_data("timeZoneArea"),
+        exists_fn=has_camera_data("timeZoneArea"),
     ),
     XSenseSensorEntityDescription(
         key="camera_sd_card_used",
@@ -972,7 +1017,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:micro-sd",
         value_fn=data_value("sdCardUsed"),
-        exists_fn=has_data("sdCardUsed"),
+        exists_fn=has_camera_data("sdCardUsed"),
     ),
     XSenseSensorEntityDescription(
         key="camera_sd_card_total",
@@ -980,7 +1025,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:micro-sd",
         value_fn=data_value("sdCardTotal"),
-        exists_fn=has_data("sdCardTotal"),
+        exists_fn=has_camera_data("sdCardTotal"),
     ),
     XSenseSensorEntityDescription(
         key="camera_sd_card_format_status",
@@ -988,7 +1033,7 @@ SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:micro-sd",
         value_fn=data_value("sdCardFormatStatus"),
-        exists_fn=has_data("sdCardFormatStatus"),
+        exists_fn=has_camera_data("sdCardFormatStatus"),
     ),
 )
 

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -96,6 +96,17 @@
       },
       "wifi_sw": {
         "name": "Wifi Module Firmware"
+      },
+      "last_self_test": {
+        "name": "Last Self Test",
+        "state": {
+          "not_run": "Not Run",
+          "success": "Success",
+          "failed": "Failed"
+        }
+      },
+      "last_self_test_time": {
+        "name": "Last Self Test Time"
       }
     },
     "number": {

--- a/custom_components/xsense/switch.py
+++ b/custom_components/xsense/switch.py
@@ -41,13 +41,18 @@ def has_data(key: str) -> Callable[[Entity], bool]:
 
 def has_camera_data(key: str) -> Callable[[Entity], bool]:
     """Return if the app exposes an admin-only camera setting."""
-    return lambda entity: key in entity.data and entity.data.get("isAdmin", True)
+    return lambda entity: (
+        is_camera_entity(entity)
+        and key in entity.data
+        and entity.data.get("isAdmin", True)
+    )
 
 
 def has_supported_data(key: str, support_key: str) -> Callable[[Entity], bool]:
     """Return if the app exposes a supported camera setting."""
     return lambda entity: (
-        key in entity.data
+        is_camera_entity(entity)
+        and key in entity.data
         and entity.data.get("isAdmin", True)
         and entity.data.get(support_key, True)
     )
@@ -271,7 +276,8 @@ SWITCHES: tuple[XSenseSwitchEntityDescription, ...] = (
         name="Cooldown",
         icon="mdi:timer-sand",
         exists_fn=lambda entity: (
-            "cooldownEnabled" in entity.data
+            is_camera_entity(entity)
+            and "cooldownEnabled" in entity.data
             and entity.data.get("cooldownSupported", True)
             and entity.data.get("supportPirCooldown", True)
         ),

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -96,6 +96,17 @@
             },
             "wifi_sw": {
                 "name": "Wifi Module Firmware"
+            },
+            "last_self_test": {
+                "name": "Last Self Test",
+                "state": {
+                    "not_run": "Not Run",
+                    "success": "Success",
+                    "failed": "Failed"
+                }
+            },
+            "last_self_test_time": {
+                "name": "Last Self Test Time"
             }
         },
         "number": {

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -30,6 +30,7 @@ async_xsense = load_api_module("async_xsense")
 entity_map = load_api_module("entity_map")
 exceptions = load_api_module("exceptions")
 house = load_api_module("house")
+station = load_api_module("station")
 
 
 class FakeResponse:
@@ -46,12 +47,102 @@ class FakeStation:
         self.type = station_type
         self.sn = "station-sn"
         self.parsed = []
+        self.data = {}
+
+    def set_data(self, values):
+        self.data.update(values)
+
+
+def test_station_shadow_names_follow_apk_factory_rules():
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+
+    def make_station(device_type, sn="serial"):
+        return station.Station(
+            test_house,
+            stationId=f"{device_type}-{sn}",
+            stationName=device_type,
+            stationSn=sn,
+            category=device_type,
+        )
+
+    assert make_station("SBS50").shadow_name == "SBS50serial"
+    assert make_station("STH0C").shadow_name == "STH0C-serial"
+    assert make_station("SWS0B").shadow_name == "SWS0B-serial"
+    assert make_station("XR0A-iR").shadow_name == "XR0A-iR-serial"
+    assert make_station("XS0R-iA").shadow_name == "XS0R-iA-serial"
+    assert make_station("SC07-WX").shadow_name == "SC07-WX-serial"
+    assert make_station("XC04-WX").shadow_name == "XC04-WX-serial"
+    assert make_station("XS0E-iR").shadow_name == "XS0E-iRserial"
+    assert make_station("XS03-WX").shadow_name == "XS03-WXserial"
+    assert make_station("XS01-WX", "ABC123").shadow_name == "XS01-WXABC123"
+    assert make_station("XS01-WX", "ABCEN123").shadow_name == "XS01-WX-ABCEN123"
 
 
 @pytest.mark.asyncio
-async def test_get_state_skips_house_level_wifi_device_shadows():
+async def test_get_station_state_uses_legacy_info_for_wifi_smoke_like_apk():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation("XS01-WX")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        client._lastres = FakeResponse(200)
+        return {"state": {"reported": {"wifiRSSI": -55}}}
+
+    client.get_thing = get_thing
+
+    await client.get_station_state(station)
+
+    assert calls == ["info_station-sn"]
+    assert station.data == {"wifiRSSI": -55}
+
+
+@pytest.mark.asyncio
+async def test_get_station_state_uses_second_info_for_new_wifi_devices_like_apk():
     client = async_xsense.AsyncXSense()
     station = FakeStation("STH0C")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        client._lastres = FakeResponse(200)
+        return {"state": {"reported": {"temperature": 21}}}
+
+    client.get_thing = get_thing
+
+    await client.get_station_state(station)
+
+    assert calls == ["2nd_info_station-sn"]
+    assert station.data == {"temperature": 21}
+
+
+@pytest.mark.asyncio
+async def test_get_station_state_falls_back_to_second_info_for_unknown_legacy_types():
+    client = async_xsense.AsyncXSense()
+    station = FakeStation("XS01-M")
+    calls = []
+
+    async def get_thing(station_arg, page):
+        calls.append(page)
+        if page == "info_station-sn":
+            client._lastres = FakeResponse(404, "missing")
+            return {"message": "missing"}
+        client._lastres = FakeResponse(200)
+        return {"state": {"reported": {"rfLevel": 2}}}
+
+    client.get_thing = get_thing
+
+    await client.get_station_state(station)
+
+    assert calls == ["info_station-sn", "2nd_info_station-sn"]
+    assert station.data == {"rfLevel": 2}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("station_type", ["STH0C", "XR0A-iR"])
+async def test_get_state_skips_house_level_standalone_device_shadows(station_type):
+    client = async_xsense.AsyncXSense()
+    station = FakeStation(station_type)
     calls = []
 
     async def get_thing(station_arg, page):
@@ -304,7 +395,7 @@ async def test_wifi_device_test_v2_targets_wifi_thing_like_apk():
     assert len(calls) == 1
     station, page, data = calls[0]
     desired = data["state"]["desired"]
-    assert station is device
+    assert station.shadow_name == "XP0J-iA-station-sn"
     assert page == "2nd_selftest_device-sn"
     assert desired["shadow"] == "appSelfTest"
     assert desired["stationSN"] == "station-sn"
@@ -427,6 +518,192 @@ async def test_listener_self_test_uses_apk_payload_shape():
     assert desired["userId"] == "user-id"
     assert desired["time"].isdigit()
     assert len(desired["time"]) == 13
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("station_sn", "smoke_edition", "expected_topic", "expected_thing"),
+    [
+        ("ABC123", "8", "appmute", "XS01-WXABC123"),
+        ("ABCEN123", "9", "2nd_appmute", "XS01-WX-ABCEN123"),
+    ],
+)
+async def test_xs01_wx_mute_targets_apk_thing_name(
+    station_sn, smoke_edition, expected_topic, expected_thing
+):
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS01-WX")
+    device.station.sn = station_sn
+    device.data = {"smokeEdition": smoke_edition}
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "mute")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station.shadow_name == expected_thing
+    assert page == expected_topic
+    assert desired["shadow"] == "appMute"
+    assert desired["stationSN"] == station_sn
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["muteType"] == "0"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("device_type", "expected_shadow", "expected_topic", "expected_thing"),
+    [
+        ("SC06-WX", "appMute", "2nd_appmute", "SC06-WX-station-sn"),
+        ("SC07-WX", "appMute", "2nd_appmute", "SC07-WX-station-sn"),
+        ("XP0H-iR", "appMute", "2nd_appmute", "XP0H-iR-station-sn"),
+        ("XP0A-iR", "appMute", "2nd_appmute", "XP0A-iR-station-sn"),
+        ("XP0J-iA", "appMute", "2nd_appmute", "XP0J-iA-station-sn"),
+        ("XS0B-iR", "appMute", "2nd_appmute", "XS0B-iR-station-sn"),
+        ("XS0E-iR", "appMute", "2nd_appmute", "XS0E-iRstation-sn"),
+        ("XS03-WX", "appMute", "2nd_appmute", "XS03-WXstation-sn"),
+        ("XS0R-iA", "appMute", "2nd_appmute", "XS0R-iA-station-sn"),
+        ("XC04-WX", "appMute", "2nd_appmute", "XC04-WX-station-sn"),
+        ("XC0C-iA", "appMute", "2nd_appmute", "XC0C-iA-station-sn"),
+        ("XC0C-iR", "appMute", "2nd_appmute", "XC0C-iR-station-sn"),
+        ("STH0C", "extendMute", "2nd_appmute", "STH0C-station-sn"),
+        ("XC0M-iR", "extendMute", "2nd_appmute", "XC0M-iR-station-sn"),
+        ("XR0A-iR", "extendMute", "2nd_appmute", "XR0A-iR-station-sn"),
+        ("SWS0B", "appWater", "2nd_appwater", "SWS0B-station-sn"),
+    ],
+)
+async def test_wifi_device_mute_uses_apk_factory_payload_shape(
+    device_type, expected_shadow, expected_topic, expected_thing
+):
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseStation(device_type)
+    calls = []
+
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "mute")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station.shadow_name == expected_thing
+    assert page == expected_topic
+    assert desired["shadow"] == expected_shadow
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "station-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["muteType"] == "1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 14
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("device_type", "expected_shadow"),
+    [
+        ("SD11-MR", "appMute"),
+        ("SD19-MN", "appMute"),
+        ("SK0Z-3S", "appMute"),
+        ("LP/N-SA-0B", "appMute"),
+        ("XP02S-MR", "appMute"),
+        ("XS0D-MR", "appMute"),
+        ("XC0C-MR", "app2ndMute"),
+    ],
+)
+async def test_sbs50_child_mute_uses_apk_payload_shape(
+    device_type, expected_shadow
+):
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice(device_type)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "mute")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station is device.station
+    assert page == "2nd_appmute"
+    assert desired["shadow"] == expected_shadow
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["muteType"] == "1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 14
+
+
+@pytest.mark.asyncio
+async def test_xs03_iwx_mute_uses_apk_station_serial_thing_name():
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice("XS03-iWX")
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "mute")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station.shadow_name == "station-sn"
+    assert page == "appmute"
+    assert desired["shadow"] == "appMute"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "device-sn"
+    assert desired["userId"] == "user-id"
+    assert desired["muteType"] == "1"
+    assert desired["time"].isdigit()
+    assert len(desired["time"]) == 14
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("device_type", ["XP0J-iA", "XS0R-iA"])
+async def test_wifi_fire_drill_targets_apk_wifi_thing_name(device_type):
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice(device_type, entity_map.EntityType.COMBI)
+    calls = []
+
+    async def do_thing(station, page, data):
+        calls.append((station, page, data))
+        return {"ok": True}
+
+    client.do_thing = do_thing
+
+    await client.action(device, "firedrill")
+
+    assert len(calls) == 1
+    station, page, data = calls[0]
+    desired = data["state"]["desired"]
+    assert station.shadow_name == f"{device_type}-station-sn"
+    assert page == "2nd_firedrill"
+    assert desired["stationSN"] == "station-sn"
+    assert desired["deviceSN"] == "station-sn"
 
 
 @pytest.mark.asyncio
@@ -802,8 +1079,15 @@ async def test_temperature_alarm_volume_uses_temp_info_payload_without_station_s
 async def test_update_camera_data_creates_cameras_from_addx_device_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
-    test_house.stations = {}
-    test_house.station_order = []
+    camera_station = station.Station(
+        test_house,
+        stationId="cam-id",
+        stationName="Front Camera",
+        stationSn="cam-sn",
+        category="SSC0A",
+    )
+    test_house.stations = {"cam-id": camera_station}
+    test_house.station_order = ["cam-id"]
     client.houses = {"house-id": test_house}
     calls = []
 
@@ -829,8 +1113,8 @@ async def test_update_camera_data_creates_cameras_from_addx_device_list():
 
     await client.update_camera_data()
 
-    assert "cam-sn" in test_house.stations
-    camera = test_house.stations["cam-sn"]
+    assert "cam-id" in test_house.stations
+    camera = test_house.stations["cam-id"]
     assert async_xsense.is_camera_entity(camera)
     assert camera.name == "Front Camera"
     assert camera.type == "SSC0A"
@@ -841,30 +1125,77 @@ async def test_update_camera_data_creates_cameras_from_addx_device_list():
 
 
 @pytest.mark.asyncio
-async def test_update_camera_data_skips_unsupported_addx_camera_models():
+async def test_update_camera_data_skips_ipc_api_when_normal_device_list_has_no_camera():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
     test_house.stations = {}
     test_house.station_order = []
     client.houses = {"house-id": test_house}
+    calls = []
 
     async def addx_call(endpoint, **kwargs):
-        if endpoint == "/device/listuserdevices":
-            return {
-                "list": [
-                    {
-                        "serialNumber": "unknown-cam",
-                        "deviceName": "New Camera",
-                        "displayModelNo": "Future Cam",
-                        "deviceModel": {"modelName": "G2"},
-                        "deviceSupport": {},
-                    }
-                ]
-            }
-        return {}
+        calls.append((endpoint, kwargs))
+        return {"list": []}
 
     client.addx_call = addx_call
 
     await client.update_camera_data()
 
+    assert calls == []
     assert test_house.stations == {}
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_ignores_accounts_without_camera_ipc_client():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    camera_station = station.Station(
+        test_house,
+        stationId="cam-id",
+        stationName="Front Camera",
+        stationSn="cam-sn",
+        category="SSC0A",
+    )
+    test_house.stations = {"cam-id": camera_station}
+    test_house.station_order = ["cam-id"]
+    client.houses = {"house-id": test_house}
+
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        raise exceptions.APIFailure(
+            "Request for IPC code C10101 failed with error "
+            "10000023/500 clientId is incorrect !"
+        )
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    assert calls == [("/device/listuserdevices", {})]
+    assert test_house.stations == {"cam-id": camera_station}
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_reraises_real_camera_api_errors():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    camera_station = station.Station(
+        test_house,
+        stationId="cam-id",
+        stationName="Front Camera",
+        stationSn="cam-sn",
+        category="SSC0A",
+    )
+    test_house.stations = {"cam-id": camera_station}
+    test_house.station_order = ["cam-id"]
+    client.houses = {"house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        raise exceptions.APIFailure("Request failed with error 123/500 server exploded")
+
+    client.addx_call = addx_call
+
+    with pytest.raises(exceptions.APIFailure):
+        await client.update_camera_data()

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -1,0 +1,85 @@
+import sys
+from types import SimpleNamespace
+
+for module_name in list(sys.modules):
+    if module_name == "custom_components.xsense" or module_name.startswith(
+        "custom_components.xsense."
+    ):
+        del sys.modules[module_name]
+if not hasattr(sys.modules.get("custom_components"), "__path__"):
+    sys.modules.pop("custom_components", None)
+
+from custom_components.xsense import binary_sensor, number, select, sensor, switch
+
+
+def entity(device_type, data):
+    return SimpleNamespace(type=device_type, data=data)
+
+
+def test_switch_camera_controls_require_camera_entity():
+    non_camera = entity("XS01-WX", {"needMotion": 1, "isAdmin": True})
+    camera = entity("SSC0A", {"needMotion": 1, "isAdmin": True})
+
+    assert not switch.has_camera_data("needMotion")(non_camera)
+    assert switch.has_camera_data("needMotion")(camera)
+
+
+def test_switch_supported_camera_controls_require_camera_entity():
+    non_camera = entity("XS01-WX", {"recLamp": 1, "supportRecLamp": True})
+    camera = entity("SSC0B", {"recLamp": 1, "supportRecLamp": True})
+
+    assert not switch.has_supported_data("recLamp", "supportRecLamp")(non_camera)
+    assert switch.has_supported_data("recLamp", "supportRecLamp")(camera)
+
+
+def test_select_camera_controls_require_camera_entity():
+    non_camera = entity(
+        "XS01-WX",
+        {"deviceLanguage": "en", "deviceSupportLanguage": ["en"], "isAdmin": True},
+    )
+    camera = entity(
+        "SSC0A",
+        {"deviceLanguage": "en", "deviceSupportLanguage": ["en"], "isAdmin": True},
+    )
+
+    assert not select.has_data("deviceLanguage", "deviceSupportLanguage")(non_camera)
+    assert select.has_data("deviceLanguage", "deviceSupportLanguage")(camera)
+
+
+def test_all_select_camera_controls_require_camera_entity():
+    non_camera = entity(
+        "XS01-WX",
+        {
+            "antiflicker": 50,
+            "cooldownOptions": [5, 10],
+            "cooldownSupported": True,
+            "cooldownValue": 5,
+            "defaultCodec": "h264",
+            "isAdmin": True,
+            "showCodecChange": True,
+            "supportAntiFlicker": True,
+            "supportPirCooldown": True,
+        },
+    )
+
+    assert not any(
+        description.exists_fn(non_camera) for description in select.SELECTS
+    )
+
+
+def test_number_camera_controls_require_camera_entity():
+    non_camera = entity("XS01-WX", {"nightThresholdLevel": 2, "isAdmin": True})
+    camera = entity("SSC0B", {"nightThresholdLevel": 2, "isAdmin": True})
+
+    assert not number.has_data("nightThresholdLevel")(non_camera)
+    assert number.has_data("nightThresholdLevel")(camera)
+
+
+def test_read_only_camera_entities_require_camera_entity():
+    non_camera = entity("XS01-WX", {"batteryLevel": 2, "needMotion": 1})
+    camera = entity("SSC0A", {"batteryLevel": 2, "needMotion": 1})
+
+    assert not sensor.has_camera_data("batteryLevel")(non_camera)
+    assert sensor.has_camera_data("batteryLevel")(camera)
+    assert not binary_sensor.has_camera_data("needMotion")(non_camera)
+    assert binary_sensor.has_camera_data("needMotion")(camera)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 
 from custom_components.xsense.api.entity_map import EntityType
-from custom_components.xsense.sensor import has_report_time
+from custom_components.xsense.sensor import (
+    has_report_time,
+    has_self_test_report,
+    optional_data_timestamp,
+    self_test_result,
+)
 
 
 def test_base_station_report_time_is_internal_metadata():
@@ -20,3 +25,39 @@ def test_device_report_time_remains_available():
     )
 
     assert has_report_time(entity)
+
+
+def test_self_test_result_success_code_matches_apk():
+    entity = SimpleNamespace(data={"lastSelfTest": "0"})
+
+    assert self_test_result(entity) == "success"
+
+
+def test_self_test_result_preserves_failure_code():
+    entity = SimpleNamespace(data={"lastSelfTest": "3"})
+
+    assert self_test_result(entity) == "failed"
+
+
+def test_self_test_report_sensor_exists_for_testable_device_before_first_report():
+    entity = SimpleNamespace(data={}, type="XS01-WX")
+
+    assert has_self_test_report(entity)
+
+
+def test_self_test_report_sensor_exists_after_report_even_without_action_map():
+    entity = SimpleNamespace(data={"lastSelfTest": "0"}, type="UNKNOWN")
+
+    assert has_self_test_report(entity)
+
+
+def test_self_test_result_not_run_before_first_report():
+    entity = SimpleNamespace(data={})
+
+    assert self_test_result(entity) == "not_run"
+
+
+def test_optional_timestamp_is_none_before_first_report():
+    entity = SimpleNamespace(data={})
+
+    assert optional_data_timestamp("lastSelfTestTime")(entity) is None


### PR DESCRIPTION
## Summary

Prepare the 1.2.5 release with APK-aligned fixes after the 1.2.4 API refactor.

## Changes

- Skip IPC/ADDX camera API calls unless APK-supported SSC0A/SSC0B cameras are present.
- Keep camera-only entities scoped to APK-supported camera devices.
- Add self-test result/time sensors from the APK self-test update topics.
- Stop base station report-time sensor churn in Home Assistant activity logs.
- Add missing APK-supported mute actions across Wi-Fi, SBS50 child, smoke, CO, water, temperature, and radon devices.
- Correct action thing names and targets to match the APK, including XS01-WX EN/UL serial handling and dashed vs non-dashed Wi-Fi models.
- Add curated tag-specific release notes and make the release workflow use them when present.

## Validation

- `git diff --check`
- JSON parse checks for manifest, strings, and translations
- Python AST checks for integration and tests
- `PYTHONDONTWRITEBYTECODE=1 /root/.venvs/ha-xsense-test/bin/python -m pytest -q` (`77 passed`)
