### PR TITLE
Fix release notes publishing flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -20,20 +20,26 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6.0.2
 
-      - name: Check for curated release notes
-        id: notes
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          notes_file=".github/release-notes/${GITHUB_REF_NAME}.md"
-          if [[ -f "$notes_file" ]]; then
-            echo "body_path=$notes_file" >> "$GITHUB_OUTPUT"
-            echo "generate=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "generate=true" >> "$GITHUB_OUTPUT"
+          tag="${GITHUB_REF_NAME}"
+          notes_file=".github/release-notes/${tag}.md"
+          title="Release ${tag}"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            args=(--verify-tag --title "$title" --draft=false --latest)
+            if [[ -f "$notes_file" ]]; then
+              args+=(--notes-file "$notes_file")
+            fi
+            gh release edit "$tag" "${args[@]}"
+            exit 0
           fi
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.0
-        with:
-          body_path: ${{ steps.notes.outputs.body_path }}
-          generate_release_notes: ${{ steps.notes.outputs.generate }}
+          if [[ -f "$notes_file" ]]; then
+            gh release create "$tag" --verify-tag --title "$title" --notes-file "$notes_file" --latest
+          else
+            gh release create "$tag" --verify-tag --title "$title" --generate-notes --latest
+          fi


### PR DESCRIPTION
Fixes the tag release workflow so curated release notes are applied even when Release Drafter already created a draft for the tag. This avoids the generated one-line release notes that happened on v.1.2.5.\n\nNo new release or tag is created by this PR.