### PR TITLE
Use APK client info for camera IPC login

### DIFF
--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -107,29 +107,33 @@ class AsyncXSense(XSenseBase):
     async def __aexit__(self, exc_type, exc, traceback):
         await self.close()
 
-    async def api_call(self, code, unauth=False, **kwargs):
+    async def api_call(self, code, unauth=False, use_ipc_client=False, **kwargs):
         data = {**kwargs}
 
         if unauth:
             headers = None
-            mac = "abcdefg"
+            body = (
+                self._signed_body(data, code, ipc=True)
+                if use_ipc_client
+                else {
+                    **data,
+                    "clientType": self.CLIENTYPE,
+                    "mac": "abcdefg",
+                    "appVersion": self.VERSION,
+                    "bizCode": code,
+                    "appCode": self.APPCODE,
+                }
+            )
         else:
             if self._access_token_expiring():
                 await self.refresh()
             headers = {"Authorization": self.access_token}
-            mac = self._calculate_mac(data)
+            body = self._signed_body(data, code)
 
         session = await self._get_session()
         async with session.post(
             f"{self.API}/app",
-            json={
-                **data,
-                "clientType": self.CLIENTYPE,
-                "mac": mac,
-                "appVersion": self.VERSION,
-                "bizCode": code,
-                "appCode": self.APPCODE,
-            },
+            json=body,
             headers=headers,
         ) as response:
             self._lastres = response
@@ -569,7 +573,7 @@ class AsyncXSense(XSenseBase):
         camera.set_data(updates)
 
     async def get_client_info(self):
-        data = await self.api_call("101001", unauth=True)
+        data = await self.api_call("101001", unauth=True, use_ipc_client=True)
         self.clientid = data["clientId"]
         self.clientsecret = self._decode_secret(data["clientSecret"])
         self.region = data["cgtRegion"]

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -152,7 +152,7 @@ class XSenseBase:
                     values.append(str(value))
 
         concatenated_string = "".join(values)
-        mac_data = concatenated_string.encode("utf-8") + self.clientsecret
+        mac_data = concatenated_string.encode("utf-8") + (self.clientsecret or b"")
         return hashlib.md5(mac_data).hexdigest()
 
     def _signed_body(self, data: Dict | None, code: str, *, ipc: bool = False) -> Dict:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1199,3 +1199,78 @@ async def test_update_camera_data_reraises_real_camera_api_errors():
 
     with pytest.raises(exceptions.APIFailure):
         await client.update_camera_data()
+
+
+class FakeJsonResponse:
+    def __init__(self, body, status=200):
+        self._body = body
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._body
+
+
+class FakeApiSession:
+    def __init__(self, body):
+        self.body = body
+        self.calls = []
+
+    def post(self, url, data=None, json=None, headers=None):
+        self.calls.append({"url": url, "data": data, "json": json, "headers": headers})
+        return FakeJsonResponse(self.body)
+
+
+@pytest.mark.asyncio
+async def test_get_client_info_uses_apk_ipc_client_header():
+    client = async_xsense.AsyncXSense()
+    session = FakeApiSession(
+        {
+            "reCode": 200,
+            "reData": {
+                "clientId": "ipc-client",
+                "clientSecret": "MTM2MHNlY3JldHg=",
+                "cgtRegion": "us-east-1",
+                "userPoolId": "pool",
+            },
+        }
+    )
+
+    async def get_session():
+        return session
+
+    client._get_session = get_session
+
+    await client.get_client_info()
+
+    assert client.clientid == "ipc-client"
+    assert client.clientsecret == b"secret"
+    body = session.calls[0]["json"]
+    assert body["bizCode"] == "101001"
+    assert body["appCode"] == client.IPC_APPCODE
+    assert body["appVersion"] == client.IPC_VERSION
+    assert body["clientType"] == client.IPC_CLIENTTYPE
+    assert body["mac"] == "d41d8cd98f00b204e9800998ecf8427e"
+
+
+@pytest.mark.asyncio
+async def test_legacy_unauth_api_call_keeps_app_client_header():
+    client = async_xsense.AsyncXSense()
+    session = FakeApiSession({"reCode": 200, "reData": {"ok": True}})
+
+    async def get_session():
+        return session
+
+    client._get_session = get_session
+
+    assert await client.api_call("101001", unauth=True) == {"ok": True}
+    body = session.calls[0]["json"]
+    assert body["appCode"] == client.APPCODE
+    assert body["appVersion"] == client.VERSION
+    assert body["clientType"] == client.CLIENTYPE
+    assert body["mac"] == "abcdefg"


### PR DESCRIPTION
Fixes camera IPC registration by fetching client info with the same APK v1.36/clientType 2 header that the Android app uses before login. The old app-client credentials could cause IPC registration to fail with \ for real SSC0A/SSC0B camera users.\n\nValidation:\n- \\n- \