### PR TITLE
Fix MQTT certificate loading on HA event loop

### DIFF
--- a/custom_components/xsense/api/mqtt_helper.py
+++ b/custom_components/xsense/api/mqtt_helper.py
@@ -90,15 +90,26 @@ class MQTTHelper:
             transport="websockets",
         )
 
+        self._tls_context_configured = False
         self.client.username_pw_set(USERNAME, "")
+
+    def ensure_tls_context(self):
+        """Configure TLS after certificate loading has moved off the event loop."""
+        if self._tls_context_configured:
+            return
         ssl_context = ssl.create_default_context()
         self.client.tls_set_context(ssl_context)
+        self._tls_context_configured = True
 
     def prepare_connect(self):
         self.client.ws_set_options(path=self._get_path())
 
-    def connect(self, port: int = 443, keepalive: int = 60):
+    def prepare_connection(self):
         self.prepare_connect()
+        self.ensure_tls_context()
+
+    def connect(self, port: int = 443, keepalive: int = 60):
+        self.prepare_connection()
         result = self.client.connect(self.house.mqtt_server, port, keepalive)
         self.active = result == 0
         return result

--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -272,6 +272,10 @@ class XSenseMQTT:
         )
         await self._async_wait_for_mid_or_raise(msg_info.mid, msg_info.rc)
 
+    async def _async_prepare_connection(self) -> None:
+        """Prepare MQTT connection settings without blocking the event loop."""
+        await self.hass.async_add_executor_job(self.mqtt_helper.prepare_connection)
+
     # updated call, added exception handler
     async def async_connect(self) -> None:
         """Connect to the host. Does not process messages yet."""
@@ -281,7 +285,7 @@ class XSenseMQTT:
         self._should_reconnect = True
         try:
             async with self._connection_lock, self._async_connect_in_executor():
-                self.mqtt_helper.prepare_connect()
+                await self._async_prepare_connection()
                 result = await self.hass.async_add_executor_job(
                     self._mqttc.connect, self.mqtt_helper.house.mqtt_server, 443
                 )
@@ -335,7 +339,7 @@ class XSenseMQTT:
             _LOGGER.debug("Reconnecting to XSense MQTT server")
             try:
                 async with self._connection_lock, self._async_connect_in_executor():
-                    self.mqtt_helper.prepare_connect()
+                    await self._async_prepare_connection()
                     await self.hass.async_add_executor_job(self._mqttc.reconnect)
                 delay = 1
             except OSError as err:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 asyncio_mode = auto
+pythonpath = .

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -30,7 +30,91 @@ async_xsense = load_api_module("async_xsense")
 entity_map = load_api_module("entity_map")
 exceptions = load_api_module("exceptions")
 house = load_api_module("house")
+mqtt_helper = load_api_module("mqtt_helper")
 station = load_api_module("station")
+xsense_mqtt = importlib.import_module("custom_components.xsense.mqtt")
+
+
+def test_mqtt_helper_defers_tls_context_loading_until_connect_setup(monkeypatch):
+    calls = []
+    clients = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.contexts = []
+            self.ws_paths = []
+            clients.append(self)
+
+        def username_pw_set(self, username, password):
+            self.username = username
+            self.password = password
+
+        def tls_set_context(self, context):
+            self.contexts.append(context)
+
+        def ws_set_options(self, path):
+            self.ws_paths.append(path)
+
+    def fake_create_default_context():
+        calls.append("created")
+        return "ssl-context"
+
+    monkeypatch.setattr(mqtt_helper.mqtt_client, "Client", FakeClient)
+    monkeypatch.setattr(
+        mqtt_helper.ssl, "create_default_context", fake_create_default_context
+    )
+
+    helper = mqtt_helper.MQTTHelper(
+        signer=types.SimpleNamespace(
+            presign_url=lambda *args: "wss://mqtt.example/mqtt?sig=abc"
+        ),
+        house=types.SimpleNamespace(
+            mqtt_server="mqtt.example",
+            mqtt_region="us-east-1",
+        ),
+    )
+
+    assert calls == []
+    assert clients[0].contexts == []
+    assert clients[0].ws_paths == []
+
+    helper.prepare_connection()
+
+    assert calls == ["created"]
+    assert clients[0].contexts == ["ssl-context"]
+    assert clients[0].ws_paths == ["/mqtt?sig=abc"]
+
+    helper.prepare_connection()
+
+    assert calls == ["created"]
+    assert clients[0].contexts == ["ssl-context"]
+    assert clients[0].ws_paths == ["/mqtt?sig=abc", "/mqtt?sig=abc"]
+
+
+@pytest.mark.asyncio
+async def test_xsense_mqtt_prepares_connection_in_executor():
+    calls = []
+    prepared = []
+
+    class FakeHass:
+        async def async_add_executor_job(self, func, *args):
+            calls.append(func)
+            return func(*args)
+
+    class FakeHelper:
+        def prepare_connection(self):
+            prepared.append(True)
+
+    client = object.__new__(xsense_mqtt.XSenseMQTT)
+    client.hass = FakeHass()
+    client.mqtt_helper = FakeHelper()
+
+    await client._async_prepare_connection()
+
+    assert calls[0].__self__ is client.mqtt_helper
+    assert calls[0].__name__ == "prepare_connection"
+    assert prepared == [True]
 
 
 class FakeResponse:


### PR DESCRIPTION
## Summary
- defer MQTT TLS context creation until connection setup instead of during API object construction
- run MQTT connection preparation through Home Assistant executor for connect and reconnect
- add regression coverage for deferred TLS setup and executor-routed MQTT preparation

## Why
Home Assistant reported blocking calls from ssl.create_default_context() during integration setup. Certificate loading can touch system certificate paths, so it should not run on the event loop.

## Validation
- pytest -q
- git diff --check