### PR TITLE
Prepare 1.2.5.1 release

### DIFF
--- a/.github/release-notes/v.1.2.5.1.md
+++ b/.github/release-notes/v.1.2.5.1.md
@@ -1,0 +1,18 @@
+## What changed
+
+This hotfix addresses a Home Assistant startup warning introduced by MQTT setup work after the 1.2.5 release.
+
+## Fixes
+
+- Fixed MQTT TLS certificate setup so default certificate loading no longer runs on the Home Assistant event loop during integration setup.
+- Moved MQTT connection preparation through the Home Assistant executor for both initial connect and reconnect paths.
+
+## Improvements
+
+- Added regression coverage to ensure TLS setup is deferred until connection preparation.
+- Added regression coverage to ensure MQTT connection preparation is routed through the Home Assistant executor.
+
+## Validation
+
+- `git diff --check`
+- `pytest -q`

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -19,5 +19,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.5"
+  "version": "1.2.5.1"
 }


### PR DESCRIPTION
## Summary
- bump integration manifest version to 1.2.5.1
- add explicit release notes for the MQTT event-loop hotfix

## Validation
- python3 -m json.tool custom_components/xsense/manifest.json
- git diff --check
- pytest -q