### PR TITLE
Prepare 1.2.5.2 release

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -19,5 +19,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.5.1"
+  "version": "1.2.5.2"
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest version to 1.2.5.2 for the camera discovery fix release

## Tests
- /root/codex-work/ha-xsense-component_test/.venv/bin/python -m pytest -q
