### PR TITLE
Prepare 1.2.6.1 release

### DIFF
--- a/.github/release-notes/v.1.2.6.1.md
+++ b/.github/release-notes/v.1.2.6.1.md
@@ -1,0 +1,6 @@
+## v.1.2.6.1
+
+### Fixed
+
+- Remove obsolete serial number and MAC address sensor entities left behind by older releases.
+- Keep static identifier details out of normal sensors while preserving the useful device metadata and redacted diagnostics data.

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
@@ -21,12 +22,55 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 
+OBSOLETE_SENSOR_KEYS: tuple[str, ...] = (
+    "serial_number",
+    "station_sn",
+    "device_sn",
+    "language_count",
+    "language_index",
+    "device_mac",
+    "mac",
+    "bluetooth_mac",
+)
+
+
+def _sensor_unique_id(entity_id: str, key: str) -> str:
+    """Return the unique ID format used by X-Sense sensor entities."""
+    return f"{entity_id}-{key}".replace("_", "-").lower()
+
+
+def _obsolete_sensor_unique_ids(data) -> set[str]:
+    """Return obsolete static diagnostic sensor unique IDs from old releases."""
+    unique_ids: set[str] = set()
+    for entity in (
+        *data.get("stations", {}).values(),
+        *data.get("devices", {}).values(),
+    ):
+        unique_ids.update(
+            _sensor_unique_id(entity.entity_id, key) for key in OBSOLETE_SENSOR_KEYS
+        )
+    return unique_ids
+
+
+def _remove_obsolete_sensor_entities(hass: HomeAssistant, data) -> None:
+    """Remove old serial/MAC diagnostic sensors now stored as device metadata."""
+    entity_registry = er.async_get(hass)
+    for unique_id in _obsolete_sensor_unique_ids(data):
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SENSOR, DOMAIN, unique_id
+        )
+        if entity_id is not None:
+            entity_registry.async_remove(entity_id)
+
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up X-Sense Home Security from a config entry."""
     coordinator = XSenseDataUpdateCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
+
+    _remove_obsolete_sensor_entities(hass, coordinator.data)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -19,5 +19,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6"
+  "version": "1.2.6.1"
 }

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from custom_components.xsense import (
+    OBSOLETE_SENSOR_KEYS,
+    _obsolete_sensor_unique_ids,
+    _sensor_unique_id,
+)
+
+
+def test_obsolete_sensor_unique_ids_match_old_sensor_format():
+    assert _sensor_unique_id("base_SN", "serial_number") == "base-sn-serial-number"
+
+
+def test_obsolete_sensor_cleanup_targets_static_identifier_entities_only():
+    station = SimpleNamespace(entity_id="station_1")
+    device = SimpleNamespace(entity_id="device_1")
+
+    unique_ids = _obsolete_sensor_unique_ids(
+        {"stations": {"station_1": station}, "devices": {"device_1": device}}
+    )
+
+    assert len(unique_ids) == len(OBSOLETE_SENSOR_KEYS) * 2
+    assert "station-1-serial-number" in unique_ids
+    assert "station-1-station-sn" in unique_ids
+    assert "station-1-device-mac" in unique_ids
+    assert "device-1-bluetooth-mac" in unique_ids
+    assert "station-1-ip" not in unique_ids
+    assert "device-1-wifi-rssi" not in unique_ids


### PR DESCRIPTION
Prepares the 1.2.6.1 release.\n\nThis removes obsolete serial/MAC diagnostic sensor entities left behind by older releases while preserving useful device metadata and redacted diagnostics data.\n\nTests: `python -m pytest -q`