### PR TITLE
Hide static identifiers from device info

### DIFF
--- a/.github/release-notes/v.1.2.6.1.md
+++ b/.github/release-notes/v.1.2.6.1.md
@@ -3,4 +3,4 @@
 ### Fixed
 
 - Remove obsolete serial number and MAC address sensor entities left behind by older releases.
-- Keep static identifier details out of normal sensors while preserving the useful device metadata and redacted diagnostics data.
+- Keep static identifiers out of normal sensors and visible device metadata while leaving them available in Home Assistant diagnostics.

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -7,6 +7,10 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import (
+    CONNECTION_BLUETOOTH,
+    CONNECTION_NETWORK_MAC,
+)
 
 from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
@@ -52,16 +56,89 @@ def _obsolete_sensor_unique_ids(data) -> set[str]:
     return unique_ids
 
 
-def _remove_obsolete_sensor_entities(hass: HomeAssistant, data) -> None:
-    """Remove old serial/MAC diagnostic sensors now stored as device metadata."""
+def _obsolete_sensor_unique_id_suffixes() -> set[str]:
+    """Return old sensor unique ID suffixes independent of the device prefix."""
+    return {f"-{key.replace('_', '-')}" for key in OBSOLETE_SENSOR_KEYS}
+
+
+def _is_obsolete_sensor_entry(registry_entry) -> bool:
+    """Return whether a registry entry is an obsolete X-Sense sensor."""
+    return (
+        registry_entry.domain == Platform.SENSOR
+        and registry_entry.platform == DOMAIN
+        and any(
+            registry_entry.unique_id.endswith(suffix)
+            for suffix in _obsolete_sensor_unique_id_suffixes()
+        )
+    )
+
+
+def _remove_obsolete_sensor_entities(
+    hass: HomeAssistant, data, entry: ConfigEntry
+) -> None:
+    """Remove old serial/MAC diagnostic sensors from prior releases."""
     entity_registry = er.async_get(hass)
-    for unique_id in _obsolete_sensor_unique_ids(data):
+    checked_unique_ids = set()
+
+    for registry_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        checked_unique_ids.add(registry_entry.unique_id)
+        if _is_obsolete_sensor_entry(registry_entry):
+            entity_registry.async_remove(registry_entry.entity_id)
+
+    for unique_id in _obsolete_sensor_unique_ids(data) - checked_unique_ids:
         entity_id = entity_registry.async_get_entity_id(
             Platform.SENSOR, DOMAIN, unique_id
         )
         if entity_id is not None:
             entity_registry.async_remove(entity_id)
 
+
+def _visible_identifier_connections_removed(connections):
+    """Return device connections without visible static hardware identifiers."""
+    return {
+        connection
+        for connection in connections
+        if connection[0] not in {CONNECTION_BLUETOOTH, CONNECTION_NETWORK_MAC}
+    }
+
+
+def _clear_visible_device_metadata(device_registry, device) -> None:
+    """Clear old visible serial/MAC metadata from one registry device."""
+    new_connections = _visible_identifier_connections_removed(device.connections)
+    if device.serial_number is None and new_connections == device.connections:
+        return
+
+    device_registry.async_update_device(
+        device.id,
+        new_connections=new_connections,
+        serial_number=None,
+    )
+
+
+def _remove_obsolete_device_metadata(
+    hass: HomeAssistant, data, entry: ConfigEntry
+) -> None:
+    """Clear old serial/MAC metadata from existing device registry entries."""
+    device_registry = dr.async_get(hass)
+    checked_device_ids = set()
+
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        checked_device_ids.add(device.id)
+        _clear_visible_device_metadata(device_registry, device)
+
+    for entity in (
+        *data.get("stations", {}).values(),
+        *data.get("devices", {}).values(),
+    ):
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, entity.entity_id)}
+        )
+        if device is None or device.id in checked_device_ids:
+            continue
+
+        _clear_visible_device_metadata(device_registry, device)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -70,7 +147,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    _remove_obsolete_sensor_entities(hass, coordinator.data)
+    _remove_obsolete_sensor_entities(hass, coordinator.data, entry)
+    _remove_obsolete_device_metadata(hass, coordinator.data, entry)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -85,7 +85,6 @@ class XSenseAlarmControlPanel(
             "name": station.name,
             "manufacturer": MANUFACTURER,
             "model": station.type,
-            "serial_number": station.sn,
         }
         self._safemode: str | None = None
 

--- a/custom_components/xsense/diagnostics.py
+++ b/custom_components/xsense/diagnostics.py
@@ -20,24 +20,14 @@ TO_REDACT = {
     "cameraLiveId",
     "cameraLiveUrl",
     "deviceId",
-    "deviceSN",
-    "ip",
-    "ipAddress",
     "ipcId",
     "ipcSn",
-    "mac",
-    "macAddress",
-    "macBT",
     "networkName",
-    "serialNumber",
-    "sn",
     "stationId",
-    "stationSN",
     "thumbImgUrl",
     "title",
     "unique_id",
     "userId",
-    "wiredMacAddress",
 }
 
 
@@ -45,6 +35,7 @@ def entity_diagnostics(entity) -> dict[str, Any]:
     """Return diagnostic data for an X-Sense entity."""
     return {
         "type": entity.type,
+        "serial_number": getattr(entity, "sn", None),
         "data": async_redact_data(entity.data, TO_REDACT),
     }
 

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING
 from .api.entity import Entity
 
 from homeassistant.const import ATTR_VIA_DEVICE
-from homeassistant.helpers.device_registry import (
-    CONNECTION_BLUETOOTH,
-    CONNECTION_NETWORK_MAC,
-    DeviceInfo,
-)
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
@@ -45,17 +41,9 @@ class XSenseEntity(CoordinatorEntity):
             ).lower()
         )
 
-        connections = set()
-        if "mac" in entity.data and entity.data["mac"]:
-            connections.add((CONNECTION_NETWORK_MAC, entity.data["mac"]))
-        if "macBT" in entity.data and entity.data["macBT"]:
-            connections.add((CONNECTION_BLUETOOTH, entity.data["macBT"]))
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entity.entity_id)},
-            connections=connections,
             manufacturer=MANUFACTURER,
-            serial_number=entity.sn,
             model=entity.type,
             name=entity.name,
         )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,13 +3,19 @@ from types import SimpleNamespace
 from custom_components.xsense.diagnostics import entity_diagnostics
 
 
-def test_entity_diagnostics_redacts_network_and_device_identifiers():
+def test_entity_diagnostics_keeps_static_identifiers_visible():
     entity = SimpleNamespace(
         type="SBS50",
+        sn="entity-sn",
         data={
             "deviceSN": "device-sn",
             "ip": "192.0.2.10",
             "ipAddress": "192.0.2.11",
+            "mac": "00:11:22:33:44:55",
+            "macBT": "AA:BB:CC:DD:EE:FF",
+            "serialNumber": "serial-number",
+            "sn": "sn-value",
+            "wiredMacAddress": "66:77:88:99:AA:BB",
             "ipcId": "ipc-id",
             "ipcSn": "ipc-sn",
             "stationId": "station-id",
@@ -18,13 +24,30 @@ def test_entity_diagnostics_redacts_network_and_device_identifiers():
         },
     )
 
-    data = entity_diagnostics(entity)["data"]
+    diagnostics = entity_diagnostics(entity)
+    data = diagnostics["data"]
 
-    assert data["deviceSN"] == "**REDACTED**"
-    assert data["ip"] == "**REDACTED**"
-    assert data["ipAddress"] == "**REDACTED**"
+    assert diagnostics["serial_number"] == "entity-sn"
+
+    assert data["deviceSN"] == "device-sn"
+    assert data["ip"] == "192.0.2.10"
+    assert data["ipAddress"] == "192.0.2.11"
+    assert data["mac"] == "00:11:22:33:44:55"
+    assert data["macBT"] == "AA:BB:CC:DD:EE:FF"
+    assert data["serialNumber"] == "serial-number"
+    assert data["sn"] == "sn-value"
     assert data["ipcId"] == "**REDACTED**"
     assert data["ipcSn"] == "**REDACTED**"
     assert data["stationId"] == "**REDACTED**"
-    assert data["stationSN"] == "**REDACTED**"
+    assert data["stationSN"] == "station-sn"
+    assert data["wiredMacAddress"] == "66:77:88:99:AA:BB"
     assert data["wifiRSSI"] == -55
+
+
+def test_entity_diagnostics_handles_missing_serial_number():
+    entity = SimpleNamespace(type="UNKNOWN", data={})
+
+    diagnostics = entity_diagnostics(entity)
+
+    assert diagnostics["serial_number"] is None
+    assert diagnostics["data"] == {}

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -2,8 +2,13 @@ from types import SimpleNamespace
 
 from custom_components.xsense import (
     OBSOLETE_SENSOR_KEYS,
+    _is_obsolete_sensor_entry,
     _obsolete_sensor_unique_ids,
     _sensor_unique_id,
+    _clear_visible_device_metadata,
+    _remove_obsolete_device_metadata,
+    _remove_obsolete_sensor_entities,
+    _visible_identifier_connections_removed,
 )
 
 
@@ -26,3 +31,295 @@ def test_obsolete_sensor_cleanup_targets_static_identifier_entities_only():
     assert "device-1-bluetooth-mac" in unique_ids
     assert "station-1-ip" not in unique_ids
     assert "device-1-wifi-rssi" not in unique_ids
+
+
+def test_static_identifiers_are_not_exposed_in_device_info():
+    from custom_components.xsense.entity import XSenseEntity
+
+    class ProbeEntity(XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    source = SimpleNamespace(
+        entity_id="station_1",
+        data={
+            "mac": "00:11:22:33:44:55",
+            "macBT": "AA:BB:CC:DD:EE:FF",
+            "sw": "v1.0",
+        },
+        sn="serial-number",
+        type="SBS50",
+        name="Base Station",
+    )
+
+    device_info = ProbeEntity(SimpleNamespace(), source).device_info
+
+    assert device_info["identifiers"] == {("xsense", "station_1")}
+    assert device_info["model"] == "SBS50"
+    assert device_info["sw_version"] == "1.0"
+    assert "serial_number" not in device_info
+    assert "connections" not in device_info
+
+
+def test_alarm_panel_device_info_does_not_expose_serial_number():
+    from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
+
+    station = SimpleNamespace(
+        entity_id="station_1",
+        name="Base Station",
+        type="SBS50",
+        sn="serial-number",
+    )
+
+    device_info = XSenseAlarmControlPanel(SimpleNamespace(), station).device_info
+
+    assert device_info["identifiers"] == {("xsense", "station_1")}
+    assert device_info["model"] == "SBS50"
+    assert "serial_number" not in device_info
+
+
+def test_visible_identifier_connections_are_removed_from_registry_metadata():
+    connections = {
+        ("bluetooth", "AA:BB:CC:DD:EE:FF"),
+        ("mac", "00:11:22:33:44:55"),
+        ("something_else", "kept"),
+    }
+
+    assert _visible_identifier_connections_removed(connections) == {
+        ("something_else", "kept")
+    }
+
+
+def test_clear_visible_device_metadata_clears_registry_identifiers():
+    device = SimpleNamespace(
+        id="device-id",
+        serial_number="serial-number",
+        connections={
+            ("bluetooth", "AA:BB:CC:DD:EE:FF"),
+            ("mac", "00:11:22:33:44:55"),
+            ("something_else", "kept"),
+        },
+    )
+    calls = []
+
+    class FakeDeviceRegistry:
+        def async_update_device(self, device_id, **kwargs):
+            calls.append((device_id, kwargs))
+
+    _clear_visible_device_metadata(FakeDeviceRegistry(), device)
+
+    assert calls == [
+        (
+            "device-id",
+            {
+                "new_connections": {("something_else", "kept")},
+                "serial_number": None,
+            },
+        )
+    ]
+
+
+def test_obsolete_device_metadata_cleanup_skips_clean_registry_entries(monkeypatch):
+    device = SimpleNamespace(
+        id="device-id",
+        serial_number=None,
+        connections={("something_else", "kept")},
+    )
+    calls = []
+
+    class FakeDeviceRegistry:
+        def async_get_device(self, *, identifiers):
+            assert identifiers == {("xsense", "station_1")}
+            return device
+
+        def async_update_device(self, device_id, **kwargs):
+            calls.append((device_id, kwargs))
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+
+    monkeypatch.setattr(
+        xsense.dr,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [],
+    )
+
+    _remove_obsolete_device_metadata(
+        SimpleNamespace(),
+        {
+            "stations": {
+                "station_1": SimpleNamespace(entity_id="station_1")
+            },
+            "devices": {},
+        },
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert calls == []
+
+
+def test_obsolete_device_metadata_cleanup_handles_child_devices(monkeypatch):
+    devices_by_identifier = {
+        ("xsense", "station_1"): None,
+        ("xsense", "device_1"): SimpleNamespace(
+            id="child-device-id",
+            serial_number="child-serial",
+            connections={("mac", "00:11:22:33:44:55")},
+        ),
+    }
+    calls = []
+
+    class FakeDeviceRegistry:
+        def async_get_device(self, *, identifiers):
+            return devices_by_identifier[next(iter(identifiers))]
+
+        def async_update_device(self, device_id, **kwargs):
+            calls.append((device_id, kwargs))
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+
+    monkeypatch.setattr(
+        xsense.dr,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [],
+    )
+
+    _remove_obsolete_device_metadata(
+        SimpleNamespace(),
+        {
+            "stations": {
+                "station_1": SimpleNamespace(entity_id="station_1")
+            },
+            "devices": {
+                "device_1": SimpleNamespace(entity_id="device_1")
+            },
+        },
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert calls == [
+        (
+            "child-device-id",
+            {"new_connections": set(), "serial_number": None},
+        )
+    ]
+
+
+def test_obsolete_device_metadata_cleanup_scans_config_entry_devices(monkeypatch):
+    stale_device = SimpleNamespace(
+        id="stale-device-id",
+        serial_number="stale-serial",
+        connections={("mac", "00:11:22:33:44:55")},
+    )
+    calls = []
+
+    class FakeDeviceRegistry:
+        def async_get_device(self, *, identifiers):
+            return None
+
+        def async_update_device(self, device_id, **kwargs):
+            calls.append((device_id, kwargs))
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+    monkeypatch.setattr(
+        xsense.dr,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [stale_device],
+    )
+
+    _remove_obsolete_device_metadata(
+        SimpleNamespace(),
+        {"stations": {}, "devices": {}},
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert calls == [
+        (
+            "stale-device-id",
+            {"new_connections": set(), "serial_number": None},
+        )
+    ]
+
+
+def test_obsolete_sensor_entry_detection_is_scoped_to_xsense_sensors():
+    assert _is_obsolete_sensor_entry(
+        SimpleNamespace(
+            domain="sensor",
+            platform="xsense",
+            unique_id="old-device-serial-number",
+        )
+    )
+    assert not _is_obsolete_sensor_entry(
+        SimpleNamespace(
+            domain="binary_sensor",
+            platform="xsense",
+            unique_id="old-device-serial-number",
+        )
+    )
+    assert not _is_obsolete_sensor_entry(
+        SimpleNamespace(
+            domain="sensor",
+            platform="other",
+            unique_id="old-device-serial-number",
+        )
+    )
+    assert not _is_obsolete_sensor_entry(
+        SimpleNamespace(
+            domain="sensor",
+            platform="xsense",
+            unique_id="station-1-ip",
+        )
+    )
+
+
+def test_obsolete_sensor_cleanup_removes_stale_registry_entries(monkeypatch):
+    removed = []
+
+    class FakeEntityRegistry:
+        def async_get_entity_id(self, platform, domain, unique_id):
+            return None
+
+        def async_remove(self, entity_id):
+            removed.append(entity_id)
+
+    registry = FakeEntityRegistry()
+    entries = [
+        SimpleNamespace(
+            domain="sensor",
+            platform="xsense",
+            unique_id="missing-device-serial-number",
+            entity_id="sensor.missing_device_serial_number",
+        ),
+        SimpleNamespace(
+            domain="sensor",
+            platform="xsense",
+            unique_id="station-1-ip",
+            entity_id="sensor.station_1_ip",
+        ),
+    ]
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _remove_obsolete_sensor_entities(
+        SimpleNamespace(),
+        {
+            "stations": {
+                "station_1": SimpleNamespace(entity_id="station_1")
+            },
+            "devices": {},
+        },
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert removed == ["sensor.missing_device_serial_number"]


### PR DESCRIPTION
## Summary
- remove obsolete serial number and MAC address sensors left behind by older releases
- keep static identifiers out of normal sensors and visible device metadata
- leave serial/MAC/IP details available in Home Assistant diagnostics for troubleshooting

## Tests
- python -m pytest -q
