### PR TITLE
Fix X-Sense availability and legacy entity cleanup

### DIFF
--- a/.github/release-notes/v.1.2.6.1.md
+++ b/.github/release-notes/v.1.2.6.1.md
@@ -3,4 +3,8 @@
 ### Fixed
 
 - Remove obsolete serial number and MAC address sensor entities left behind by older releases.
+- Harden obsolete sensor cleanup so stale identifier entries are removed without touching current device entities.
+- Rename legacy X-Sense entities that were left with none-suffixed IDs when a clean device-based entity ID is available.
+- Keep control entities unavailable until X-Sense reports the device online, while still showing sensor data when it exists.
+- Match the APK online-time offline thresholds so stale reports do not make devices look controllable.
 - Keep static identifiers out of normal sensors and visible device metadata while leaving them available in Home Assistant diagnostics.

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import (
     CONNECTION_BLUETOOTH,
     CONNECTION_NETWORK_MAC,
 )
+from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
@@ -35,6 +36,7 @@ OBSOLETE_SENSOR_KEYS: tuple[str, ...] = (
     "device_mac",
     "mac",
     "bluetooth_mac",
+    "online_time",
 )
 
 
@@ -80,9 +82,16 @@ def _remove_obsolete_sensor_entities(
     entity_registry = er.async_get(hass)
     checked_unique_ids = set()
 
-    for registry_entry in er.async_entries_for_config_entry(
-        entity_registry, entry.entry_id
-    ):
+    seen_entity_ids = set()
+    registry_entries = list(
+        er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    )
+    registry_entries.extend(getattr(entity_registry, "entities", {}).values())
+
+    for registry_entry in registry_entries:
+        if registry_entry.entity_id in seen_entity_ids:
+            continue
+        seen_entity_ids.add(registry_entry.entity_id)
         checked_unique_ids.add(registry_entry.unique_id)
         if _is_obsolete_sensor_entry(registry_entry):
             entity_registry.async_remove(registry_entry.entity_id)
@@ -93,6 +102,101 @@ def _remove_obsolete_sensor_entities(
         )
         if entity_id is not None:
             entity_registry.async_remove(entity_id)
+
+
+def _legacy_entity_key(registry_entry) -> str | None:
+    # Return a usable entity key from legacy registry metadata.
+    for value in (
+        getattr(registry_entry, "object_id_base", None),
+        getattr(registry_entry, "original_name", None),
+        getattr(registry_entry, "translation_key", None),
+    ):
+        if value:
+            return str(value)
+
+    unique_id = getattr(registry_entry, "unique_id", "")
+    if "-" in unique_id:
+        return unique_id.rsplit("-", 1)[1]
+
+    return None
+
+
+def _legacy_device_name(device, entity_id: str) -> str | None:
+    # Return the stable visible name for a legacy registry device.
+    if device is not None:
+        for value in (
+            getattr(device, "name_by_user", None),
+            getattr(device, "name", None),
+        ):
+            if value:
+                return str(value)
+
+    object_id = entity_id.split(".", 1)[-1]
+    if object_id.endswith("_none"):
+        return object_id[: -len("_none")]
+
+    return None
+
+
+def _legacy_none_entity_target(
+    entity_registry, device_registry, registry_entry
+) -> str | None:
+    # Return the clean entity ID for an old *_none entity when safe.
+    entity_id = getattr(registry_entry, "entity_id", "")
+    if (
+        not entity_id.endswith("_none")
+        or getattr(registry_entry, "platform", None) != DOMAIN
+    ):
+        return None
+
+    device_id = getattr(registry_entry, "device_id", None)
+    device = device_registry.async_get(device_id) if device_id else None
+    device_name = _legacy_device_name(device, entity_id)
+    key = _legacy_entity_key(registry_entry)
+    if not device_name or not key:
+        return None
+
+    domain = entity_id.split(".", 1)[0]
+    object_id = slugify(f"{device_name} {key}")
+    if not domain or not object_id:
+        return None
+
+    new_entity_id = f"{domain}.{object_id}"
+    if new_entity_id == entity_id:
+        return None
+
+    existing_entry = entity_registry.async_get(new_entity_id)
+    if (
+        existing_entry is not None
+        and getattr(existing_entry, "entity_id", None) != entity_id
+    ):
+        return None
+
+    return new_entity_id
+
+
+def _migrate_legacy_none_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    # Rename old *_none entity IDs left by earlier releases.
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    seen_entity_ids = set()
+    registry_entries = list(
+        er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    )
+    registry_entries.extend(getattr(entity_registry, "entities", {}).values())
+
+    for registry_entry in registry_entries:
+        if registry_entry.entity_id in seen_entity_ids:
+            continue
+        seen_entity_ids.add(registry_entry.entity_id)
+        new_entity_id = _legacy_none_entity_target(
+            entity_registry, device_registry, registry_entry
+        )
+        if new_entity_id is not None:
+            entity_registry.async_update_entity(
+                registry_entry.entity_id, new_entity_id=new_entity_id
+            )
 
 
 def _visible_identifier_connections_removed(connections):
@@ -149,10 +253,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _remove_obsolete_sensor_entities(hass, coordinator.data, entry)
     _remove_obsolete_device_metadata(hass, coordinator.data, entry)
+    _migrate_legacy_none_entity_ids(hass, entry)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    _remove_obsolete_sensor_entities(hass, coordinator.data, entry)
 
     return True
 

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -95,8 +95,12 @@ class XSenseAlarmControlPanel(
 
     @property
     def available(self) -> bool:
-        """Return if the alarm control panel is available."""
-        return self._station is not None and super().available
+        """Return if the alarm control panel can be used."""
+        station = self._station
+        if station is None:
+            return False
+
+        return station.online is True and super().available
 
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:

--- a/custom_components/xsense/api/entity.py
+++ b/custom_components/xsense/api/entity.py
@@ -1,5 +1,41 @@
+from datetime import UTC, datetime, timedelta
+
 from .entity_map import entities
 from .mapping import bool_state, map_values
+
+
+_ONLINE_TIME_EXCLUDED_TYPES = {"XP0J-iA", "XS0R-iA", "STH0C"}
+_EXTENDED_OFFLINE_HOUR_TYPES = {"SWS0B", "XR0A-iR"}
+
+
+def _offline_over_hours(entity_type: str | None) -> int:
+    return 49 if entity_type in _EXTENDED_OFFLINE_HOUR_TYPES else 34
+
+
+def _parse_xsense_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+
+    try:
+        return datetime.strptime(str(value), "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _online_from_report_time(data: dict, entity_type: str | None) -> bool | None:
+    if entity_type in _ONLINE_TIME_EXCLUDED_TYPES:
+        return None
+
+    online_time = data.get("onlineTime")
+    if not online_time:
+        return None
+
+    reported = _parse_xsense_time(online_time)
+    utc_time = _parse_xsense_time(data.get("utcTime")) or datetime.now(UTC)
+    if reported is None:
+        return True
+
+    return utc_time <= reported + timedelta(hours=_offline_over_hours(entity_type))
 
 
 class Entity:
@@ -28,10 +64,16 @@ class Entity:
 
     def set_data(self, values: dict):
         data = values.copy()
+        has_online_flag = False
         for key in ("online", "onLine"):
             if key in data:
                 self._set_online(data.pop(key))
+                has_online_flag = True
                 break
+        if not has_online_flag:
+            online = _online_from_report_time(data, self.type)
+            if online is not None:
+                self.online = online
         status_data = data.pop("status", {}) or {}
         if isinstance(status_data, dict):
             data.update(status_data)

--- a/custom_components/xsense/api/entity_map.py
+++ b/custom_components/xsense/api/entity_map.py
@@ -469,7 +469,7 @@ entities = {
     },
     "XC0M-iR": {
         "type": EntityType.CO,
-        "actions": [WifiExtendedMuteAction()],
+        "actions": [WifiAlarmMuteAction()],
     },
     "XC01-M": {
         # CO RF

--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -592,5 +592,7 @@ class XSenseMQTTConnectedEntity(XSenseBinarySensorEntity):
         if device is None:
             return None
 
-        mqtt_server = self.coordinator.mqtt_server(device.house.mqtt_server)
-        return bool(mqtt_server and mqtt_server.connected)
+        if device.online is None:
+            return None
+
+        return device.online is True

--- a/custom_components/xsense/button.py
+++ b/custom_components/xsense/button.py
@@ -126,6 +126,11 @@ class XSenseButtonEntity(XSenseEntity, ButtonEntity):
 
         super().__init__(coordinator, entity, station_id)
 
+    @property
+    def available(self) -> bool:
+        """Return if this control can be used."""
+        return self._current_entity_is_online()
+
     async def async_press(self) -> None:
         """Press the button."""
 

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -64,11 +64,15 @@ class XSenseEntity(CoordinatorEntity):
         self._handle_coordinator_update()
         await super().async_added_to_hass()
 
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
+    def _current_entity_is_online(self) -> bool:
+        """Return if the current X-Sense entity is online."""
         entity = self._current_entity()
         if entity is None:
             return False
 
-        return entity.online not in OFFLINE_STATES and super().available
+        return entity.online is True and super().available
+
+    @property
+    def available(self) -> bool:
+        """Return if entity data is available."""
+        return self._current_entity() is not None and super().available

--- a/custom_components/xsense/number.py
+++ b/custom_components/xsense/number.py
@@ -267,6 +267,11 @@ class XSenseNumberEntity(XSenseEntity, NumberEntity):
         super().__init__(coordinator, entity, station_id)
 
     @property
+    def available(self) -> bool:
+        """Return if this control can be used."""
+        return self._current_entity_is_online()
+
+    @property
     def native_value(self) -> float | None:
         """Return the number value."""
         entity = self._current_entity()

--- a/custom_components/xsense/select.py
+++ b/custom_components/xsense/select.py
@@ -236,6 +236,11 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
         super().__init__(coordinator, entity)
 
     @property
+    def available(self) -> bool:
+        """Return if this control can be used."""
+        return self._current_entity_is_online()
+
+    @property
     def options(self) -> list[str]:
         """Return the API-provided valid options."""
         entity = self._current_entity()

--- a/custom_components/xsense/switch.py
+++ b/custom_components/xsense/switch.py
@@ -432,6 +432,11 @@ class XSenseSwitchEntity(XSenseEntity, SwitchEntity):
         super().__init__(coordinator, entity, station_id)
 
     @property
+    def available(self) -> bool:
+        """Return if this control can be used."""
+        return self._current_entity_is_online()
+
+    @property
     def is_on(self) -> bool | None:
         """Return the state of the switch."""
         entity = self._current_entity()

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -166,11 +166,14 @@ def test_station_shadow_names_follow_apk_factory_rules():
     assert make_station("XS01-WX", "ABCEN123").shadow_name == "XS01-WX-ABCEN123"
 
 
-def test_entity_online_state_uses_explicit_online_value_only():
+def test_entity_online_state_uses_online_time_report_without_explicit_status():
     device = entity.Entity()
 
-    device.set_data({"onlineTime": "20260531010101"})
-    assert device.online is None
+    device.set_data({"onlineTime": "20260531010101", "utcTime": "20260601010101"})
+    assert device.online is True
+
+    device.set_data({"onlineTime": "20260531010101", "utcTime": "20260602090102"})
+    assert device.online is False
 
     device.set_data({"online": False})
     assert device.online is False
@@ -180,6 +183,23 @@ def test_entity_online_state_uses_explicit_online_value_only():
 
     device.set_data({"online": "unexpected"})
     assert device.online is True
+
+
+def test_entity_online_time_uses_apk_device_specific_thresholds():
+    sws0b = entity.Entity()
+    sws0b.type = "SWS0B"
+    sws0b.set_data({"onlineTime": "20260531010101", "utcTime": "20260602010100"})
+    assert sws0b.online is True
+
+    normal = entity.Entity()
+    normal.type = "XS01-WX"
+    normal.set_data({"onlineTime": "20260531010101", "utcTime": "20260602010100"})
+    assert normal.online is False
+
+    excluded = entity.Entity()
+    excluded.type = "STH0C"
+    excluded.set_data({"onlineTime": "20260531010101", "utcTime": "20260602010100"})
+    assert excluded.online is None
 
 
 def test_station_set_devices_matches_apk_child_device_normalization():
@@ -959,7 +979,7 @@ async def test_xs01_wx_mute_targets_apk_thing_name(
         ("XC0C-iA", "appMute", "2nd_appmute", "XC0C-iA-station-sn"),
         ("XC0C-iR", "appMute", "2nd_appmute", "XC0C-iR-station-sn"),
         ("STH0C", "extendMute", "2nd_appmute", "STH0C-station-sn"),
-        ("XC0M-iR", "extendMute", "2nd_appmute", "XC0M-iR-station-sn"),
+        ("XC0M-iR", "appMute", "2nd_appmute", "XC0M-iR-station-sn"),
         ("XR0A-iR", "extendMute", "2nd_appmute", "XR0A-iR-station-sn"),
         ("SWS0B", "appWater", "2nd_appwater", "SWS0B-station-sn"),
     ],

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1,0 +1,188 @@
+from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
+from custom_components.xsense.api.station import Station
+from custom_components.xsense.binary_sensor import (
+    XSenseBinarySensorEntity,
+    XSenseBinarySensorEntityDescription,
+    XSenseMQTTConnectedEntity,
+    MQTTSensor,
+)
+from custom_components.xsense.button import (
+    XSenseButtonEntity,
+    XSenseButtonEntityDescription,
+)
+from custom_components.xsense.sensor import (
+    XSenseSensorEntity,
+    XSenseSensorEntityDescription,
+)
+from custom_components.xsense.switch import (
+    XSenseSwitchEntity,
+    XSenseSwitchEntityDescription,
+)
+
+
+class Coordinator:
+    last_update_success = True
+    xsense = None
+    mqtt_servers = {}
+
+    def __init__(self, entity):
+        self.data = {"stations": {entity.entity_id: entity}, "devices": {}}
+
+    def mqtt_server(self, host):
+        return self.mqtt_servers.get(host)
+
+
+class House:
+    mqtt_server = "us-east-1.x-sense-iot.com"
+
+
+async def _noop_press(entity, xsense):
+    return None
+
+
+def _xs01_wx_from_real_shadow():
+    station = Station(
+        House(),
+        stationId="74C7ADBA59CB11F0ABBF3701E4DE53F0",
+        stationName="Smoke Alarm",
+        stationSn="00532DA5",
+        category="XS01-WX",
+        online=0,
+    )
+    station.set_data(
+        {
+            "batInfo": "3",
+            "houseId": "AE612FA5573411F0A1E7DD41C95847B4",
+            "onlineTime": "20260602063003",
+            "utcTime": "20260602063103",
+            "stationSN": "00532DA5",
+            "status": {"alarmStatus": "0", "muteStatus": "1", "time": "20260602063003"},
+            "time": "20260602063003",
+            "type": "XS01-WX",
+            "wifiRssi": "-38",
+        }
+    )
+    station.set_data(
+        {
+            "_deviceSN": "00532DA5",
+            "_stationSN": "00532DA5",
+            "ip": "192.168.1.86",
+            "ledLight": "1",
+            "ssid": "Reid",
+            "sw": "v1.1.0",
+            "swMain": "v1.9.0",
+            "type": "XS01-WX",
+        }
+    )
+    return station
+
+
+def test_xs01_wx_online_time_report_marks_station_online():
+    station = _xs01_wx_from_real_shadow()
+
+    assert station.online is True
+
+
+def test_xs01_wx_shadow_data_entities_stay_available():
+    station = _xs01_wx_from_real_shadow()
+    coordinator = Coordinator(station)
+
+    sensor = XSenseSensorEntity(
+        coordinator,
+        station,
+        XSenseSensorEntityDescription(
+            key="battery", value_fn=lambda current: current.data["batInfo"]
+        ),
+    )
+    binary_sensor = XSenseBinarySensorEntity(
+        coordinator,
+        station,
+        XSenseBinarySensorEntityDescription(
+            key="alarm_status", value_fn=lambda current: current.data["alarmStatus"]
+        ),
+    )
+    connected = XSenseMQTTConnectedEntity(coordinator, station, MQTTSensor)
+
+    assert sensor.available
+    assert sensor.native_value == 3
+    assert binary_sensor.available
+    assert binary_sensor.is_on is False
+    assert connected.available
+    assert connected.is_on is True
+
+
+def test_xs01_wx_controls_are_available_when_shadow_reports_online_time():
+    station = _xs01_wx_from_real_shadow()
+    coordinator = Coordinator(station)
+
+    button = XSenseButtonEntity(
+        coordinator,
+        station,
+        XSenseButtonEntityDescription(key="test", press_fn=_noop_press),
+    )
+    switch = XSenseSwitchEntity(
+        coordinator,
+        station,
+        XSenseSwitchEntityDescription(
+            key="led_light",
+            data_key="ledLight",
+            exists_fn=lambda current: True,
+            value_fn=lambda current: current.data["ledLight"] == "1",
+        ),
+    )
+
+    assert button.available
+    assert switch.available
+
+
+def test_controls_are_unavailable_when_online_state_is_unknown():
+    station = _xs01_wx_from_real_shadow()
+    station.online = None
+    coordinator = Coordinator(station)
+
+    button = XSenseButtonEntity(
+        coordinator,
+        station,
+        XSenseButtonEntityDescription(key="test", press_fn=_noop_press),
+    )
+    switch = XSenseSwitchEntity(
+        coordinator,
+        station,
+        XSenseSwitchEntityDescription(
+            key="led_light",
+            data_key="ledLight",
+            exists_fn=lambda current: True,
+            value_fn=lambda current: current.data["ledLight"] == "1",
+        ),
+    )
+
+    assert not button.available
+    assert not switch.available
+
+
+
+def test_alarm_control_panel_requires_reported_online_station():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    coordinator = Coordinator(station)
+    panel = XSenseAlarmControlPanel(coordinator, station)
+
+    assert panel.available
+
+    station.online = None
+    assert not panel.available
+
+    station.online = False
+    assert not panel.available
+
+
+
+def test_connected_sensor_does_not_assume_unknown_online_state():
+    station = _xs01_wx_from_real_shadow()
+    coordinator = Coordinator(station)
+    connected = XSenseMQTTConnectedEntity(coordinator, station, MQTTSensor)
+
+    station.online = None
+
+    assert connected.available
+    assert connected.is_on is None

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -1,8 +1,18 @@
+import sys
 from types import SimpleNamespace
+
+for module_name in list(sys.modules):
+    if module_name == "custom_components.xsense" or module_name.startswith(
+        "custom_components.xsense."
+    ):
+        del sys.modules[module_name]
+if not hasattr(sys.modules.get("custom_components"), "__path__"):
+    sys.modules.pop("custom_components", None)
 
 from custom_components.xsense import (
     OBSOLETE_SENSOR_KEYS,
     _is_obsolete_sensor_entry,
+    _migrate_legacy_none_entity_ids,
     _obsolete_sensor_unique_ids,
     _sensor_unique_id,
     _clear_visible_device_metadata,
@@ -323,3 +333,344 @@ def test_obsolete_sensor_cleanup_removes_stale_registry_entries(monkeypatch):
     )
 
     assert removed == ["sensor.missing_device_serial_number"]
+
+
+def test_obsolete_sensor_cleanup_keeps_current_device_entities(monkeypatch):
+    removed = []
+
+    class FakeEntityRegistry:
+        def async_get_entity_id(self, platform, domain, unique_id):
+            return None
+
+        def async_remove(self, entity_id):
+            removed.append(entity_id)
+
+    current_unique_ids = [
+        "xs01-wx-alarm-status",
+        "xs01-wx-battery",
+        "xs01-wx-connected",
+        "xs01-wx-ip-address",
+        "xs01-wx-last-self-test",
+        "xs01-wx-last-self-test-time",
+        "xs01-wx-led-light",
+        "xs01-wx-mute-status",
+        "xs01-wx-report-time",
+        "xs01-wx-signal-strength",
+        "xs01-wx-software-version",
+        "xs01-wx-ssid",
+    ]
+    entries = [
+        SimpleNamespace(
+            domain="sensor",
+            platform="xsense",
+            unique_id=unique_id,
+            entity_id="sensor." + unique_id.replace("-", "_"),
+        )
+        for unique_id in current_unique_ids
+    ]
+    entries.extend(
+        [
+            SimpleNamespace(
+                domain="sensor",
+                platform="xsense",
+                unique_id="xs01-wx-online-time",
+                entity_id="sensor.xs01_wx_online_time",
+            ),
+            SimpleNamespace(
+                domain="sensor",
+                platform="xsense",
+                unique_id="xs01-wx-serial-number",
+                entity_id="sensor.xs01_wx_serial_number",
+            ),
+        ]
+    )
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _remove_obsolete_sensor_entities(
+        SimpleNamespace(),
+        {"stations": {}, "devices": {"xs01_wx": SimpleNamespace(entity_id="xs01_wx")}},
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert removed == ["sensor.xs01_wx_online_time", "sensor.xs01_wx_serial_number"]
+
+
+def test_obsolete_sensor_cleanup_scans_all_xsense_sensor_entries(monkeypatch):
+    removed = []
+
+    class FakeEntityRegistry:
+        entities = {
+            "sensor.orphan_serial_number": SimpleNamespace(
+                domain="sensor",
+                platform="xsense",
+                unique_id="orphan-serial-number",
+                entity_id="sensor.orphan_serial_number",
+            ),
+            "sensor.orphan_ip": SimpleNamespace(
+                domain="sensor",
+                platform="xsense",
+                unique_id="orphan-ip",
+                entity_id="sensor.orphan_ip",
+            ),
+        }
+
+        def async_get_entity_id(self, platform, domain, unique_id):
+            return None
+
+        def async_remove(self, entity_id):
+            removed.append(entity_id)
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: [],
+    )
+
+    _remove_obsolete_sensor_entities(
+        SimpleNamespace(),
+        {"stations": {}, "devices": {}},
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert removed == ["sensor.orphan_serial_number"]
+
+
+def test_legacy_none_entity_id_migration_renames_safe_entries(monkeypatch):
+    renamed = []
+    entries = [
+        SimpleNamespace(
+            domain="binary_sensor",
+            platform="xsense",
+            entity_id="binary_sensor.smoke_alarm_none",
+            unique_id="device-connected",
+            device_id="device-id",
+            object_id_base="Connected",
+            original_name=None,
+            translation_key="connected",
+        ),
+        SimpleNamespace(
+            domain="button",
+            platform="xsense",
+            entity_id="button.smoke_alarm_none",
+            unique_id="device-test",
+            device_id="device-id",
+            object_id_base="Test",
+            original_name=None,
+            translation_key="test",
+        ),
+        SimpleNamespace(
+            domain="sensor",
+            platform="other",
+            entity_id="sensor.other_none",
+            unique_id="other-test",
+            device_id="device-id",
+            object_id_base="Test",
+            original_name=None,
+            translation_key="test",
+        ),
+    ]
+
+    class FakeEntityRegistry:
+        def async_get(self, entity_id):
+            return None
+
+        def async_update_entity(self, entity_id, **kwargs):
+            renamed.append((entity_id, kwargs))
+
+    class FakeDeviceRegistry:
+        def async_get(self, device_id):
+            assert device_id == "device-id"
+            return SimpleNamespace(name_by_user=None, name="Smoke Alarm")
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _migrate_legacy_none_entity_ids(
+        SimpleNamespace(), SimpleNamespace(entry_id="entry-id")
+    )
+
+    assert renamed == [
+        (
+            "binary_sensor.smoke_alarm_none",
+            {"new_entity_id": "binary_sensor.smoke_alarm_connected"},
+        ),
+        ("button.smoke_alarm_none", {"new_entity_id": "button.smoke_alarm_test"}),
+    ]
+
+
+def test_legacy_none_entity_id_migration_applies_to_other_xsense_devices(monkeypatch):
+    renamed = []
+    entries = [
+        SimpleNamespace(
+            domain="binary_sensor",
+            platform="xsense",
+            entity_id="binary_sensor.water_leak_sensor_none",
+            unique_id="leak-device-connected",
+            device_id="leak-device-id",
+            object_id_base="Connected",
+            original_name="Connected",
+            translation_key="connected",
+        ),
+        SimpleNamespace(
+            domain="button",
+            platform="xsense",
+            entity_id="button.base_station_none",
+            unique_id="base-device-test",
+            device_id="base-device-id",
+            object_id_base="Test",
+            original_name="Test",
+            translation_key="test",
+        ),
+    ]
+
+    class FakeEntityRegistry:
+        entities = {}
+
+        def async_get(self, entity_id):
+            return None
+
+        def async_update_entity(self, entity_id, **kwargs):
+            renamed.append((entity_id, kwargs))
+
+    class FakeDeviceRegistry:
+        def async_get(self, device_id):
+            devices = {
+                "leak-device-id": SimpleNamespace(
+                    name_by_user=None, name="Water Leak Sensor"
+                ),
+                "base-device-id": SimpleNamespace(
+                    name_by_user=None, name="Base Station"
+                ),
+            }
+            return devices[device_id]
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _migrate_legacy_none_entity_ids(
+        SimpleNamespace(), SimpleNamespace(entry_id="entry-id")
+    )
+
+    assert renamed == [
+        (
+            "binary_sensor.water_leak_sensor_none",
+            {"new_entity_id": "binary_sensor.water_leak_sensor_connected"},
+        ),
+        ("button.base_station_none", {"new_entity_id": "button.base_station_test"}),
+    ]
+
+
+def test_legacy_none_entity_id_migration_uses_entity_id_base_without_device(monkeypatch):
+    renamed = []
+    entries = [
+        SimpleNamespace(
+            domain="button",
+            platform="xsense",
+            entity_id="button.smoke_alarm_none",
+            unique_id="device-test",
+            device_id=None,
+            object_id_base="Test",
+            original_name=None,
+            translation_key="test",
+        )
+    ]
+
+    class FakeEntityRegistry:
+        entities = {}
+
+        def async_get(self, entity_id):
+            return None
+
+        def async_update_entity(self, entity_id, **kwargs):
+            renamed.append((entity_id, kwargs))
+
+    class FakeDeviceRegistry:
+        def async_get(self, device_id):
+            return None
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _migrate_legacy_none_entity_ids(
+        SimpleNamespace(), SimpleNamespace(entry_id="entry-id")
+    )
+
+    assert renamed == [
+        ("button.smoke_alarm_none", {"new_entity_id": "button.smoke_alarm_test"})
+    ]
+
+
+def test_legacy_none_entity_id_migration_skips_existing_target(monkeypatch):
+    renamed = []
+    entries = [
+        SimpleNamespace(
+            domain="button",
+            platform="xsense",
+            entity_id="button.smoke_alarm_none",
+            unique_id="device-test",
+            device_id="device-id",
+            object_id_base="Test",
+            original_name=None,
+            translation_key="test",
+        )
+    ]
+
+    class FakeEntityRegistry:
+        def async_get(self, entity_id):
+            assert entity_id == "button.smoke_alarm_test"
+            return SimpleNamespace(entity_id="button.smoke_alarm_test")
+
+        def async_update_entity(self, entity_id, **kwargs):
+            renamed.append((entity_id, kwargs))
+
+    class FakeDeviceRegistry:
+        def async_get(self, device_id):
+            return SimpleNamespace(name_by_user=None, name="Smoke Alarm")
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(xsense.er, "async_get", lambda hass: FakeEntityRegistry())
+    monkeypatch.setattr(xsense.dr, "async_get", lambda hass: FakeDeviceRegistry())
+    monkeypatch.setattr(
+        xsense.er,
+        "async_entries_for_config_entry",
+        lambda entity_registry, entry_id: entries,
+    )
+
+    _migrate_legacy_none_entity_ids(
+        SimpleNamespace(), SimpleNamespace(entry_id="entry-id")
+    )
+
+    assert renamed == []


### PR DESCRIPTION
## Summary
- match the APK online-time offline thresholds before marking devices online
- keep sensor data readable while gating controls until X-Sense reports the device online
- clean up stale serial/MAC/online-time sensors and legacy `_none` entity IDs
- correct the XC0M-iR mute action mapping

## Testing
- `PYTHONPATH=/root/codex-work/ha-xsense-release-fix /root/codex-work/ha-xsense-component_test/.venv/bin/python -m pytest -q`
- installed on live Home Assistant test instance and verified X-Sense setup/state after restart
