### PR TITLE
Prepare 1.2.6.2 release

### DIFF
--- a/.github/release-notes/v.1.2.6.2.md
+++ b/.github/release-notes/v.1.2.6.2.md
@@ -1,0 +1,10 @@
+## v.1.2.6.2
+
+### Fixed
+
+- Update X-Sense app request metadata to match the current Android app.
+- Match the Android app compact-style JSON payloads for AWS shadow and MQTT commands.
+- Fix X-Sense request signing for Unicode payloads, empty lists, booleans, and null values.
+- Handle AWS IoT presence events so device online status updates like the app.
+- Tighten camera handling to the APK-supported camera models and live-stream resolution fallback.
+- Retry camera data loading after a failed camera update instead of suppressing future retries.

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -189,7 +189,12 @@ class XSenseAlarmControlPanel(
             raise HomeAssistantError("X-Sense MQTT is not connected")
 
         try:
-            await mqtt.async_publish(topic, json.dumps(payload), qos=0, retain=False)
+            await mqtt.async_publish(
+                topic,
+                json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+                qos=0,
+                retain=False,
+            )
             LOGGER.debug(
                 "Station %s published appMode command %s on %s",
                 station.sn,

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -15,6 +15,41 @@ from .station import Station
 
 CAMERA_TYPES = {"SSC0A", "SSC0B"}
 CAMERA_LIVE_URL_MAX_AGE_SECONDS = 240
+_CAMERA_VIDEO_RESOLUTIONS = {
+    "auto",
+    "640x360",
+    "640x480",
+    "960x720",
+    "1280x720",
+    "1280x960",
+    "1920x1080",
+    "2048x1440",
+    "2048x1536",
+    "2304x1296",
+    "2560x1440",
+    "3840x2160",
+    "7680x4320",
+}
+_CAMERA_RESOLUTION_ALIASES = {
+    "AUTO": "auto",
+    "SD": "1280x720",
+    "HD": "1920x1080",
+    "2K": "2560x1440",
+    "360P": "640x360",
+    "P360": "640x360",
+    "480P": "640x480",
+    "P480": "640x480",
+    "720P": "1280x720",
+    "P720": "1280x720",
+    "1080P": "1920x1080",
+    "P1080": "1920x1080",
+    "1296P": "2304x1296",
+    "P1296": "2304x1296",
+    "1440P": "2560x1440",
+    "P1440": "2560x1440",
+    "1536P": "2048x1536",
+    "P1536": "2048x1536",
+}
 
 # The Android app reads these standalone Wi-Fi device categories from the
 # house-level mainpage/2nd_mainpage shadows, not from station-level mainpage
@@ -78,10 +113,33 @@ def _station_info_shadow_names(station: Station) -> tuple[str, ...]:
 
 
 def is_camera_entity(entity: Entity) -> bool:
-    """Return if an entity is an IPC camera discovered through the app path."""
-    return entity.type in CAMERA_TYPES or (
-        getattr(entity, "entity_type", None) == EntityType.CAMERA
-    )
+    """Return if an entity is an APK-supported IPC camera."""
+    return entity.type in CAMERA_TYPES
+
+
+def _camera_resolution(value) -> str | None:
+    """Return an APK-style camera video resolution value."""
+    if value is None:
+        return None
+    resolution = str(value).strip().replace("VIDEO_SIZE_", "")
+    if not resolution:
+        return None
+    normalized = resolution.replace("×", "x")
+    if normalized in _CAMERA_VIDEO_RESOLUTIONS:
+        return normalized
+    return _CAMERA_RESOLUTION_ALIASES.get(normalized.upper())
+
+
+def _camera_live_resolution(camera: Entity) -> str:
+    """Return the APK start-live resolution fallback for a camera."""
+    if resolution := _camera_resolution(camera.data.get("liveResolution")):
+        return resolution
+    options = camera.data.get("supportedRecordingResolutions")
+    if isinstance(options, list):
+        for option in options:
+            if resolution := _camera_resolution(option):
+                return resolution
+    return "auto"
 
 
 class AsyncXSense(XSenseBase):
@@ -337,7 +395,7 @@ class AsyncXSense(XSenseBase):
         if not self.houses:
             raise APIFailure("Cannot register IPC without an X-Sense house")
         house = next(iter(self.houses.values()))
-        node_type = _ipc_node_type(house.region)
+        node_type = _ipc_node_type(house.mqtt_region)
         return await self.ipc_call(
             "C10101",
             userName=self.username,
@@ -480,7 +538,7 @@ class AsyncXSense(XSenseBase):
         data = await self.addx_call(
             "/device/newstartlive",
             serialNumber=camera.sn,
-            liveResolution=str(camera.data.get("liveResolution") or ""),
+            liveResolution=_camera_live_resolution(camera),
         )
         if isinstance(data, dict):
             camera.set_data(
@@ -763,7 +821,7 @@ def _volume_tone_key(data_key: str) -> str | None:
 
 
 def _shadow_update_body(data: Dict) -> str:
-    return json.dumps(data, separators=(",", ":"))
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
 
 
 def _action_timestamp(definition: Dict, entity: Entity) -> str | None:
@@ -777,11 +835,12 @@ def _action_timestamp(definition: Dict, entity: Entity) -> str | None:
     return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
 
 
-def _ipc_node_type(house_region: str | None) -> str:
-    """Return the IPC node type derived from the app's current house region."""
-    if not house_region or len(house_region) <= 2:
+def _ipc_node_type(mqtt_region: str | None) -> str:
+    """Return the IPC node type from the APK current-house MQTT region."""
+    if not mqtt_region or len(mqtt_region) <= 2:
         return "US"
-    return house_region[:2].upper()
+    node_type = mqtt_region[:2].upper()
+    return node_type if node_type in {"CN", "EU", "US"} else "US"
 
 
 def _camera_type(data: Dict) -> str | None:
@@ -917,9 +976,6 @@ _CAMERA_BOOLEAN_USER_CONFIG_KEYS = {"deviceCallToggleOn"}
 def _camera_user_config_payload(camera: Entity, updates: Dict) -> Dict:
     """Return the APK UserConfigBean-style camera config payload."""
     payload = {"serialNumber": camera.sn}
-    for key in _CAMERA_USER_CONFIG_KEYS:
-        if key in camera.data and camera.data[key] is not None:
-            payload[key] = _camera_config_payload_value(key, camera.data[key])
     payload.update(
         {
             key: _camera_config_payload_value(key, value)
@@ -927,7 +983,26 @@ def _camera_user_config_payload(camera: Entity, updates: Dict) -> Dict:
             if key in _CAMERA_USER_CONFIG_KEYS and value is not None
         }
     )
+    _add_camera_config_companions(camera, payload)
     return payload
+
+
+def _add_camera_config_companions(camera: Entity, payload: Dict) -> None:
+    """Add companion config fields the APK sends with selected toggles."""
+    if "needMotion" in payload and camera.data.get("motionSensitivity") is None:
+        payload["motionSensitivity"] = 1
+    if "needVideo" in payload and camera.data.get("videoSeconds") == 0:
+        payload["videoSeconds"] = -1
+    if "needAlarm" in payload:
+        if camera.data.get("supportRocker") is True:
+            payload["alarmSeconds"] = 10
+        elif camera.data.get("alarmSeconds") is not None:
+            payload["alarmSeconds"] = camera.data["alarmSeconds"]
+    if (
+        "needNightVision" in payload
+        and camera.data.get("nightThresholdLevel") is not None
+    ):
+        payload["nightThresholdLevel"] = camera.data["nightThresholdLevel"]
 
 
 def _camera_config_payload_value(key: str, value):

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -16,6 +16,20 @@ from .station import Station
 from .house import House
 
 
+def _mac_json(value) -> str:
+    """Return compact Gson-style JSON for X-Sense MAC input."""
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _mac_scalar(value) -> str:
+    """Return the Java StringBuilder text used by the APK MAC input."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
 class XSenseBase:
     API = "https://api.x-sense-iot.com"
     IPC_API = "https://ipc.x-sense-iot.com"
@@ -24,12 +38,12 @@ class XSenseBase:
         "EU": "https://api-eu.vicohome.io",
         "US": "https://api-us.vicohome.io",
     }
-    VERSION = "v1.22.0_20240914.1"
-    APPCODE = "1220"
-    CLIENTYPE = "1"
-    IPC_VERSION = "v1.36.0_20260130"
-    IPC_APPCODE = "1360"
-    IPC_CLIENTTYPE = "2"
+    VERSION = "v1.36.0_20260130"
+    APPCODE = "1360"
+    CLIENTYPE = "2"
+    IPC_VERSION = VERSION
+    IPC_APPCODE = APPCODE
+    IPC_CLIENTTYPE = CLIENTYPE
 
     userid = None
     username = None
@@ -142,14 +156,16 @@ class XSenseBase:
             for key in data:
                 value = data[key]
                 if isinstance(value, list):
-                    if value and isinstance(value[0], str):
-                        values.extend(value)
+                    if not value:
+                        continue
+                    if isinstance(value[0], str):
+                        values.extend(_mac_scalar(item) for item in value)
                     else:
-                        values.append(json.dumps(value))
+                        values.append(_mac_json(value))
                 elif isinstance(value, dict):
-                    values.append(json.dumps(value, separators=(",", ":")))
+                    values.append(_mac_json(value))
                 else:
-                    values.append(str(value))
+                    values.append(_mac_scalar(value))
 
         concatenated_string = "".join(values)
         mac_data = concatenated_string.encode("utf-8") + self.clientsecret

--- a/custom_components/xsense/api/mqtt_helper.py
+++ b/custom_components/xsense/api/mqtt_helper.py
@@ -134,7 +134,7 @@ class MQTTHelper:
         retain: bool = DEFAULT_RETAIN,
     ):
         if not isinstance(payload, str):
-            payload = json.dumps(payload, separators=(",", ":"))
+            payload = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         return self.client.publish(topic, payload, qos=qos, retain=retain)
 
     def subscribe(self, topic: str, qos: int = DEFAULT_QOS):

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -245,12 +245,15 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ):
             return
 
-        self._camera_initialized = True
         self._last_camera_update_attempt = now
         try:
             await self.xsense.update_camera_data()
         except APIFailure as ex:
+            self._camera_initialized = False
+            self._last_camera_update_attempt = None
             LOGGER.warning("Could not update X-Sense camera data: %s", ex)
+        else:
+            self._camera_initialized = True
 
     async def _update_safe_mode(self, station) -> None:
         """Fetch safeMode from the 2nd_safemode AWS IoT shadow as a fallback."""
@@ -312,6 +315,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if station is None:
             station = self._get_station_by_device_sn(device_sn)
 
+        if station is None and _is_presence_topic(topic):
+            station = self._get_station_by_shadow_name(data.get("clientId"))
+
         if station is None and isinstance(topic, str):
             parts = topic.split("/")
             if len(parts) > 2:
@@ -319,6 +325,12 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if station is None:
             LOGGER.debug("No station found for MQTT topic: %s", topic)
+            return
+
+        if _is_presence_topic(topic):
+            if event_type := data.get("eventType"):
+                station._set_online(event_type == "connected")
+                self.async_update_listeners()
             return
 
         is_safemode_topic = "/shadow/name/2nd_safemode/update" in topic
@@ -431,7 +443,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             }
             await mqtt.async_publish(
                 f"$aws/things/{s.shadow_name}/shadow/name/2nd_apptempdata/update",
-                json.dumps(msg),
+                json.dumps(msg, ensure_ascii=False, separators=(",", ":")),
                 0,
                 False,
             )
@@ -471,3 +483,8 @@ def _is_self_test_topic(topic: str) -> bool:
             "selftestup_v2/update",
         )
     )
+
+
+def _is_presence_topic(topic: str) -> bool:
+    """Return if an MQTT topic is an AWS IoT presence update."""
+    return "/events/presence/" in topic

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -19,5 +19,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.1"
+  "version": "1.2.6.2"
 }

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1,4 +1,7 @@
+import base64
+import hashlib
 import importlib
+import json
 import sys
 import types
 from pathlib import Path
@@ -94,6 +97,37 @@ def test_mqtt_helper_defers_tls_context_loading_until_connect_setup(monkeypatch)
     assert calls == ["created"]
     assert clients[0].contexts == ["ssl-context"]
     assert clients[0].ws_paths == ["/mqtt?sig=abc", "/mqtt?sig=abc"]
+
+
+def test_mqtt_helper_publish_uses_compact_utf8_json():
+    published = []
+
+    class FakeClient:
+        def publish(self, topic, payload, qos=0, retain=False):
+            published.append((topic, payload, qos, retain))
+            return "published"
+
+    helper = mqtt_helper.MQTTHelper(
+        signer=types.SimpleNamespace(
+            presign_url=lambda *args: "wss://mqtt.example/mqtt?sig=abc"
+        ),
+        house=types.SimpleNamespace(
+            mqtt_server="mqtt.example",
+            mqtt_region="us-east-1",
+        ),
+    )
+    helper.client = FakeClient()
+    payload = {"label": "中文", "enabled": True}
+
+    assert helper.publish("topic", payload) == "published"
+    assert published == [
+        (
+            "topic",
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            0,
+            False,
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -1187,7 +1221,7 @@ async def test_do_thing_signs_and_sends_same_serialized_body():
 
     client._thing_request = thing_request
 
-    payload = {"state": {"desired": {"b": 2, "a": 1}}}
+    payload = {"state": {"desired": {"b": 2, "a": 1, "label": "中文"}}}
     result = await client.do_thing(
         FakeXSenseStation(), "2nd_selftest_device-sn", payload
     )
@@ -1198,7 +1232,9 @@ async def test_do_thing_signs_and_sends_same_serialized_body():
     assert session.calls[0]["json"] is None
     assert session.calls[0]["data"] == signed_payloads[0]
     assert session.calls[0]["data"] == async_xsense._shadow_update_body(payload)
-    assert session.calls[0]["data"] == '{"state":{"desired":{"b":2,"a":1}}}'
+    assert session.calls[0]["data"] == json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":")
+    )
 
 
 @pytest.mark.asyncio
@@ -1638,7 +1674,18 @@ async def test_update_camera_data_updates_known_camera_from_addx_device_list():
 
 
 @pytest.mark.asyncio
-async def test_start_camera_live_uses_live_resolution_preference_not_recording_resolution():
+@pytest.mark.parametrize(
+    ("camera_data", "expected"),
+    [
+        ({"liveResolution": "VIDEO_SIZE_1920x1080"}, "1920x1080"),
+        ({"liveResolution": "HD"}, "1920x1080"),
+        ({"supportedRecordingResolutions": ["P1296", "P1080"]}, "2304x1296"),
+        ({"supportedRecordingResolutions": []}, "auto"),
+    ],
+)
+async def test_start_camera_live_uses_apk_live_resolution_fallback(
+    camera_data, expected
+):
     client = async_xsense.AsyncXSense()
     camera = device_module.Device(
         None,
@@ -1647,7 +1694,7 @@ async def test_start_camera_live_uses_live_resolution_preference_not_recording_r
         deviceSn="cam-sn",
         deviceType="SSC0A",
     )
-    camera.set_data({"recResolution": "HD"})
+    camera.set_data(camera_data)
     calls = []
 
     async def addx_call(endpoint, **kwargs):
@@ -1660,32 +1707,9 @@ async def test_start_camera_live_uses_live_resolution_preference_not_recording_r
     assert calls == [
         (
             "/device/newstartlive",
-            {"serialNumber": "cam-sn", "liveResolution": ""},
+            {"serialNumber": "cam-sn", "liveResolution": expected},
         )
     ]
-
-
-@pytest.mark.asyncio
-async def test_start_camera_live_uses_explicit_live_resolution_when_available():
-    client = async_xsense.AsyncXSense()
-    camera = device_module.Device(
-        None,
-        deviceId="cam-id",
-        deviceName="Camera",
-        deviceSn="cam-sn",
-        deviceType="SSC0A",
-    )
-    camera.set_data({"liveResolution": "FHD"})
-    calls = []
-
-    async def addx_call(endpoint, **kwargs):
-        calls.append((endpoint, kwargs))
-        return {"url": "rtsp://example/live"}
-
-    client.addx_call = addx_call
-
-    assert await client.start_camera_live(camera) == "rtsp://example/live"
-    assert calls[0][1]["liveResolution"] == "FHD"
 
 def test_addx_body_requires_ipc_country():
     client = async_xsense.AsyncXSense()
@@ -1705,6 +1729,152 @@ def test_addx_body_requires_ipc_language():
         client._addx_body({"countryNo": "US"}, {})
 
 
+class CapturePostResponse:
+    def __init__(self, body):
+        self.status = 200
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        return self._body
+
+
+class CapturePostSession:
+    def __init__(self, response_body):
+        self.response_body = response_body
+        self.posts = []
+        self.closed = False
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return CapturePostResponse(self.response_body)
+
+
+def test_calculate_mac_uses_compact_gson_json_for_container_values():
+    client = async_xsense.AsyncXSense()
+    client.clientsecret = b"secret"
+
+    data = {
+        "items": [{"name": "é", "value": 1}],
+        "settings": {"label": "中文", "enabled": True},
+        "plain": "x",
+    }
+
+    mac_input = "[{\"name\":\"é\",\"value\":1}]" + "{\"label\":\"中文\",\"enabled\":true}" + "x" + "secret"
+    assert client._calculate_mac(data) == hashlib.md5(
+        mac_input.encode("utf-8")
+    ).hexdigest()
+
+
+def test_calculate_mac_uses_java_scalar_text_for_bool_and_null():
+    client = async_xsense.AsyncXSense()
+    client.clientsecret = b"secret"
+
+    data = {"enabled": True, "disabled": False, "missing": None}
+
+    assert client._calculate_mac(data) == hashlib.md5(
+        b"truefalsenullsecret"
+    ).hexdigest()
+
+
+def test_calculate_mac_skips_empty_lists_like_apk():
+    client = async_xsense.AsyncXSense()
+    client.clientsecret = b"secret"
+
+    data = {"empty": [], "plain": "x"}
+
+    assert client._calculate_mac(data) == hashlib.md5(b"xsecret").hexdigest()
+
+
+def test_calculate_mac_string_led_lists_use_java_scalar_text():
+    client = async_xsense.AsyncXSense()
+    client.clientsecret = b"secret"
+
+    data = {"values": ["a", True, None], "plain": "z"}
+
+    assert client._calculate_mac(data) == hashlib.md5(
+        b"atruenullzsecret"
+    ).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_get_client_info_uses_apk_1360_client_metadata():
+    encoded_secret = base64.b64encode(b"1360secretx").decode()
+    session = CapturePostSession(
+        {
+            "reCode": 200,
+            "reData": {
+                "clientId": "client-id",
+                "clientSecret": encoded_secret,
+                "cgtRegion": "us-east-1",
+                "userPoolId": "pool-id",
+            },
+        }
+    )
+    client = async_xsense.AsyncXSense(session)
+
+    await client.get_client_info()
+
+    body = session.posts[0][1]["json"]
+    assert body["bizCode"] == "101001"
+    assert body["appCode"] == "1360"
+    assert body["appVersion"] == "v1.36.0_20260130"
+    assert body["clientType"] == "2"
+    assert client.clientid == "client-id"
+    assert client.clientsecret == b"secret"
+
+
+@pytest.mark.asyncio
+async def test_authenticated_app_call_uses_apk_1360_client_metadata():
+    session = CapturePostSession({"reCode": 200, "reData": {"ok": True}})
+    client = async_xsense.AsyncXSense(session)
+    client.access_token = "access-token"
+    client.access_token_expiry = async_xsense.datetime(
+        2099, 1, 1, tzinfo=async_xsense.timezone.utc
+    )
+    client.clientsecret = b"secret"
+
+    await client.api_call("102007", houseId="house-id")
+
+    body = session.posts[0][1]["json"]
+    assert body["bizCode"] == "102007"
+    assert body["appCode"] == "1360"
+    assert body["appVersion"] == "v1.36.0_20260130"
+    assert body["clientType"] == "2"
+    assert body["houseId"] == "house-id"
+    assert session.posts[0][1]["headers"] == {"Authorization": "access-token"}
+
+
+@pytest.mark.asyncio
+async def test_ipc_call_uses_same_apk_1360_client_metadata():
+    session = CapturePostSession({"reCode": 200, "reData": {"token": "token"}})
+    client = async_xsense.AsyncXSense(session)
+    client.access_token = "access-token"
+    client.access_token_expiry = async_xsense.datetime(
+        2099, 1, 1, tzinfo=async_xsense.timezone.utc
+    )
+    client.clientsecret = b"secret"
+
+    await client.ipc_call(
+        "C10101", userName="user@example.com", nodeType="US", language="en"
+    )
+
+    body = session.posts[0][1]["json"]
+    assert body["bizCode"] == "C10101"
+    assert body["appCode"] == "1360"
+    assert body["appVersion"] == "v1.36.0_20260130"
+    assert body["clientType"] == "2"
+    assert body["userName"] == "user@example.com"
+    assert body["nodeType"] == "US"
+    assert body["language"] == "en"
+    assert session.posts[0][1]["headers"] == {"Authorization": "access-token"}
+
+
 @pytest.mark.asyncio
 async def test_addx_call_rejects_unknown_node_type():
     client = async_xsense.AsyncXSense()
@@ -1715,10 +1885,10 @@ async def test_addx_call_rejects_unknown_node_type():
 
 
 @pytest.mark.asyncio
-async def test_register_ipc_uses_house_region_for_node_type_like_apk():
+async def test_register_ipc_uses_mqtt_region_for_node_type_like_apk():
     client = async_xsense.AsyncXSense()
     client.username = "user@example.com"
-    test_house = house.House(None, "house-id", "Home", "eu-central-1", "us-east-1", "mqtt")
+    test_house = house.House(None, "house-id", "Home", "Canada", "eu-central-1", "mqtt")
     client.houses = {"house-id": test_house}
     calls = []
 
@@ -1737,9 +1907,11 @@ async def test_register_ipc_uses_house_region_for_node_type_like_apk():
     ]
 
 
-def test_ipc_node_type_uses_apk_short_region_fallback():
-    assert async_xsense._ipc_node_type("DE") == "US"
-    assert async_xsense._ipc_node_type("US") == "US"
+def test_ipc_node_type_uses_apk_mqtt_region_prefix():
+    assert async_xsense._ipc_node_type("eu-central-1") == "EU"
+    assert async_xsense._ipc_node_type("us-east-1") == "US"
+    assert async_xsense._ipc_node_type("cn-north-1") == "CN"
+    assert async_xsense._ipc_node_type("Canada") == "US"
     assert async_xsense._ipc_node_type(None) == "US"
 
 
@@ -1830,7 +2002,7 @@ def test_camera_data_normalizes_apk_integer_support_flags():
         assert data[key] is True
 
 
-def test_camera_user_config_payload_preserves_known_config_like_apk():
+def test_camera_user_config_payload_sends_only_changed_cloud_fields_like_apk():
     camera = device_module.Device(
         None,
         deviceId="cam-id",
@@ -1841,7 +2013,6 @@ def test_camera_user_config_payload_preserves_known_config_like_apk():
     camera.set_data(
         {
             "needMotion": True,
-            "needVideo": False,
             "deviceCallToggleOn": True,
             "deviceSupportLanguage": ["en"],
             "supportDeviceCall": True,
@@ -1852,11 +2023,65 @@ def test_camera_user_config_payload_preserves_known_config_like_apk():
         camera, {"needVideo": 1, "supportDeviceCall": False}
     )
 
-    assert payload == {
+    assert payload == {"serialNumber": "cam-sn", "needVideo": 1}
+
+
+def test_camera_user_config_payload_adds_apk_toggle_companions():
+    camera = device_module.Device(
+        None,
+        deviceId="cam-id",
+        deviceName="Camera",
+        deviceSn="cam-sn",
+        deviceType="SSC0A",
+    )
+    camera.set_data(
+        {
+            "alarmSeconds": 20,
+            "motionSensitivity": None,
+            "nightThresholdLevel": 3,
+            "supportRocker": False,
+            "videoSeconds": 0,
+        }
+    )
+
+    assert async_xsense._camera_user_config_payload(camera, {"needMotion": 1}) == {
         "serialNumber": "cam-sn",
-        "deviceCallToggleOn": True,
         "needMotion": 1,
+        "motionSensitivity": 1,
+    }
+    assert async_xsense._camera_user_config_payload(camera, {"needVideo": 1}) == {
+        "serialNumber": "cam-sn",
         "needVideo": 1,
+        "videoSeconds": -1,
+    }
+    assert async_xsense._camera_user_config_payload(camera, {"needAlarm": 1}) == {
+        "serialNumber": "cam-sn",
+        "needAlarm": 1,
+        "alarmSeconds": 20,
+    }
+    assert async_xsense._camera_user_config_payload(
+        camera, {"needNightVision": 1}
+    ) == {
+        "serialNumber": "cam-sn",
+        "needNightVision": 1,
+        "nightThresholdLevel": 3,
+    }
+
+
+def test_camera_user_config_payload_uses_apk_rocker_alarm_seconds():
+    camera = device_module.Device(
+        None,
+        deviceId="cam-id",
+        deviceName="Camera",
+        deviceSn="cam-sn",
+        deviceType="SSC0A",
+    )
+    camera.set_data({"alarmSeconds": 20, "supportRocker": True})
+
+    assert async_xsense._camera_user_config_payload(camera, {"needAlarm": 1}) == {
+        "serialNumber": "cam-sn",
+        "needAlarm": 1,
+        "alarmSeconds": 10,
     }
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from custom_components.xsense.coordinator import _is_self_test_topic
 
 
@@ -17,3 +19,76 @@ def test_self_test_topic_detection_matches_apk_markers():
     assert not _is_self_test_topic(
         "$aws/things/SBS50sn/shadow/name/2nd_safemode/update"
     )
+
+
+class CameraUpdateFailureClient:
+    def __init__(self):
+        self.calls = 0
+
+    async def update_camera_data(self):
+        self.calls += 1
+        from custom_components.xsense import coordinator
+
+        raise coordinator.APIFailure("camera update failed")
+
+
+@pytest.mark.asyncio
+async def test_camera_update_failure_does_not_suppress_next_retry():
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = CameraUpdateFailureClient()
+    coordinator._camera_initialized = False
+    coordinator._last_camera_update_attempt = None
+
+    await coordinator._update_cameras()
+    await coordinator._update_cameras()
+
+    assert coordinator.xsense.calls == 2
+    assert coordinator._camera_initialized is False
+    assert coordinator._last_camera_update_attempt is None
+
+
+class PresenceStation:
+    sn = "station-sn"
+    shadow_name = "XS01-WXstation-sn"
+
+    def __init__(self):
+        self.online = None
+
+    def _set_online(self, value):
+        self.online = value
+
+
+class PresenceHouse:
+    def __init__(self, station):
+        self.stations = {"station-id": station}
+
+    def get_station_by_sn(self, _identifier):
+        return None
+
+
+def test_presence_topic_updates_station_online_like_apk():
+    from types import SimpleNamespace
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    station = PresenceStation()
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(
+        houses={"house-id": PresenceHouse(station)}, parse_get_state=lambda *_: None
+    )
+    updates = []
+    coordinator.async_update_listeners = lambda: updates.append(True)
+
+    coordinator.async_event_received(
+        "/events/presence/connected/XS01-WXstation-sn",
+        "{\"clientId\":\"XS01-WXstation-sn\",\"eventType\":\"connected\",\"timestamp\":1}".encode(),
+    )
+    assert station.online is True
+
+    coordinator.async_event_received(
+        "/events/presence/disconnected/XS01-WXstation-sn",
+        "{\"clientId\":\"XS01-WXstation-sn\",\"eventType\":\"disconnected\",\"timestamp\":2}".encode(),
+    )
+    assert station.online is False
+    assert len(updates) == 2


### PR DESCRIPTION
Summary: update X-Sense app metadata to match the current Android APK, align AWS shadow and MQTT payload JSON with compact Gson-style payloads, harden MAC signing, handle AWS IoT presence events, tighten camera handling, and prepare v.1.2.6.2 release notes and manifest. Validation: installed on Steve home Assistant, ha core check completed successfully, Home Assistant restarted, XS01-WX live API readback is online with current data, pytest tests -q passed with 157 passed and 1 warning, and git diff --check passed.