### PR TITLE
Stop automatic Release Drafter version guesses

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,10 +2,10 @@
 
 name: Release Drafter
 
+# Keep this manual only. Tagged releases are created by release.yaml from
+# GITHUB_REF_NAME, so the published version always comes from the tag instead
+# of Release Drafter guessing the next version on every main push.
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Release Drafter was running on every push to main and creating a guessed next-version draft, such as v.1.2.7 immediately after publishing v.1.2.6.2. This keeps Release Drafter manual-only so tagged releases remain the source of truth through release.yaml and GITHUB_REF_NAME.