### PR TITLE
Refresh recent release notes

### DIFF
--- a/.github/release-notes/v.1.2.5.1.md
+++ b/.github/release-notes/v.1.2.5.1.md
@@ -1,20 +1,17 @@
-## v.1.2.5.1
+## 🔧 v.1.2.5.1
 
-### Summary
+A focused MQTT startup hotfix. This release removes a Home Assistant event-loop warning introduced by the MQTT setup work in 1.2.5.
 
-This hotfix addresses a Home Assistant startup warning introduced by MQTT setup work after the 1.2.5 release.
+### ✨ Highlights
 
-### Fixed
+- 🏠 Moved MQTT connection preparation through the Home Assistant executor.
+- 🔐 Deferred TLS certificate loading so it no longer runs on the Home Assistant event loop.
 
-- Fixed MQTT TLS certificate setup so default certificate loading no longer runs on the Home Assistant event loop during integration setup.
-- Moved MQTT connection preparation through the Home Assistant executor for both initial connect and reconnect paths.
+### 🛠️ Fixed
 
-### Improved
+- Fixed MQTT TLS setup during both initial connect and reconnect paths.
 
-- Added regression coverage to ensure TLS setup is deferred until connection preparation.
-- Added regression coverage to ensure MQTT connection preparation is routed through the Home Assistant executor.
+### 🔎 Validation
 
-### Validation
-
-- git diff --check
-- Full test suite passed
+- ✅ Full test suite passed.
+- ✅ Diff checks passed.

--- a/.github/release-notes/v.1.2.5.2.md
+++ b/.github/release-notes/v.1.2.5.2.md
@@ -1,19 +1,18 @@
-## v.1.2.5.2
+## 📷 v.1.2.5.2
 
-### Summary
+A camera discovery hotfix for accounts where X-Sense cameras are returned through the APK/ADDX camera device list instead of the normal station list.
 
-This hotfix improves camera discovery for accounts where cameras are returned through the APK/ADDX camera device list.
+### ✨ Highlights
 
-### Fixed
+- 📷 Improved SSC0A and SSC0B camera discovery from the ADDX `/device/listuserdevices` response.
+- 🔍 Kept IPC/ADDX camera discovery errors visible so future camera API issues are easier to diagnose.
 
-- Fixed camera discovery for accounts where X-Sense cameras are returned through the same APK/ADDX camera device list used by the mobile app, but are not present in the normal X-Sense station list.
-- Created SSC0A and SSC0B camera entities from the ADDX /device/listuserdevices response before camera metadata is loaded.
-- Kept IPC/ADDX camera discovery errors visible instead of silently treating them as no camera support.
+### 🛠️ Fixed
 
-### Improved
+- Fixed camera creation before camera metadata is fully loaded.
+- Fixed accounts where APK-visible cameras were missing from Home Assistant.
 
-- Added regression coverage for APK-aligned camera discovery from the ADDX device list.
+### 🔎 Validation
 
-### Validation
-
-- Full test suite passed
+- ✅ Full test suite passed.
+- ✅ Added regression coverage for APK-aligned camera discovery.

--- a/.github/release-notes/v.1.2.5.md
+++ b/.github/release-notes/v.1.2.5.md
@@ -1,27 +1,21 @@
-## v.1.2.5
+## 🚀 v.1.2.5
 
-### Summary
+A major APK-alignment release after the 1.2.4 cloud/API refactor. This version improves device actions, self-test reporting, camera gating, and API efficiency so Home Assistant behaves much closer to the X-Sense Android app.
 
-This release tightens integration behavior to match the X-Sense Android app more closely after the 1.2.4 cloud/API refactor.
+### ✨ Highlights
 
-### Fixed
+- 📱 Matched more Wi-Fi, SBS50 child-device, smoke, CO, water, temperature, and radon actions to the APK paths.
+- 🧪 Added readable self-test result and time sensors using the APK self-test update topics.
+- 📷 Avoided unnecessary camera API probing unless APK-supported SSC0A/SSC0B cameras are present.
+- 🕒 Stopped base station report-time updates from filling the Home Assistant activity log.
 
-- Fixed camera API probing so accounts without SSC0A/SSC0B cameras do not call the IPC/ADDX camera API unnecessarily.
-- Fixed camera-only entities so camera controls and diagnostics are exposed only for APK-supported camera models.
-- Fixed self-test reporting to follow the APK self-test update topics and expose readable result/time sensors.
-- Fixed base station report-time entities from filling the Home Assistant activity log.
-- Fixed additional APK-supported mute actions for Wi-Fi, SBS50 child, smoke, CO, water, temperature, and radon devices.
-- Fixed Wi-Fi action thing names to match the APK, including dashed and non-dashed models plus the special XS01-WX EN/UL serial path.
+### 🛠️ Fixed
+
+- Fixed Wi-Fi action thing names, including dashed/non-dashed models and the special XS01-WX EN/UL serial path.
 - Fixed Wi-Fi fire-drill and self-test action targets to use the same shadow targets as the APK.
+- Fixed camera-only entities so camera controls and diagnostics appear only for APK-supported camera models.
 
-### Improved
+### 🔎 Validation
 
-- Added regression coverage for APK thing-name rules, camera gating, action payloads, self-test updates, report-time handling, and shadow volume writes.
-- Kept API usage lighter by skipping camera-specific API calls unless APK-supported cameras are present in the normal device list.
-
-### Validation
-
-- git diff --check
-- JSON parse checks for integration strings and translations
-- Python AST and duplicate-key checks for integration and test files
-- Full test suite passed
+- ✅ Full test suite passed.
+- ✅ Diff, JSON, translation, AST, and duplicate-key checks passed.

--- a/.github/release-notes/v.1.2.6.1.md
+++ b/.github/release-notes/v.1.2.6.1.md
@@ -1,19 +1,20 @@
-## v.1.2.6.1
+## 🧹 v.1.2.6.1
 
-### Summary
+A cleanup and availability hotfix after 1.2.6. This release removes stale identifier entities, improves device availability behavior, and keeps diagnostics useful without cluttering normal device views.
 
-This hotfix cleans up stale entities and improves availability handling after the 1.2.6 release.
+### ✨ Highlights
 
-### Fixed
+- 🧹 Removed obsolete serial number and MAC address sensor entities left behind by older releases.
+- 🟢 Kept control entities unavailable until X-Sense reports the device online, while still showing sensor data when available.
+- 🧭 Matched APK online-time offline thresholds so stale reports do not make devices look controllable.
 
-- Removed obsolete serial number and MAC address sensor entities left behind by older releases.
+### 🛠️ Fixed
+
 - Hardened obsolete sensor cleanup so stale identifier entries are removed without touching current device entities.
-- Renamed legacy X-Sense entities that were left with none-suffixed IDs when a clean device-based entity ID is available.
-- Kept control entities unavailable until X-Sense reports the device online, while still showing sensor data when it exists.
-- Matched the APK online-time offline thresholds so stale reports do not make devices look controllable.
+- Renamed legacy X-Sense entities that were left with old none-suffixed IDs when a clean device-based entity ID is available.
 - Kept static identifiers out of normal sensors and visible device metadata while leaving them available in Home Assistant diagnostics.
 
-### Validation
+### 🔎 Validation
 
-- Home Assistant install check completed before release
-- Full test suite passed
+- ✅ Installed and checked on Steve Home Assistant before release.
+- ✅ Full test suite passed.

--- a/.github/release-notes/v.1.2.6.2.md
+++ b/.github/release-notes/v.1.2.6.2.md
@@ -1,22 +1,23 @@
-## v.1.2.6.2
+## 🚀 v.1.2.6.2
 
-### Summary
+A focused stability release for X-Sense cloud/API communication. This version brings the integration closer to the current Android app behavior, especially around request signing, MQTT/shadow payloads, online status, and camera handling.
 
-This hotfix aligns app metadata, signing, MQTT/shadow payloads, presence updates, and camera handling with the current Android APK.
+### ✨ Highlights
 
-### Fixed
+- 📱 Updated X-Sense app request metadata to match the current Android app.
+- 🔐 Fixed request signing for Unicode payloads, empty lists, booleans, null values, and mixed list values.
+- 📡 Matched AWS shadow and MQTT command payloads to the Android app compact JSON format.
+- 🟢 Added AWS IoT presence handling so online/offline state updates more like the app.
+- 📷 Tightened camera handling for APK-supported camera models and live-stream resolution fallback.
 
-- Updated X-Sense app request metadata to match the current Android app.
-- Matched the Android app compact JSON format for AWS shadow and MQTT command payloads.
-- Fixed request signing for Unicode payloads, empty lists, booleans, null values, and mixed list values.
-- Added AWS IoT presence-event handling so online/offline state updates like it does in the app.
-- Tightened camera support to the APK-supported camera models and improved live-stream resolution fallback.
-- Allowed camera data loading to retry after a failed update instead of suppressing future attempts.
+### 🛠️ Reliability
 
-### Validation
+- 🔁 Camera data loading now retries after a failed update instead of suppressing later attempts.
+- ✅ XS01-WX live readback was verified before release.
+- 🏠 Home Assistant config check passed before publishing.
 
-- Installed and checked on Steve Home Assistant before release
-- Home Assistant config check passed
-- Home Assistant restarted successfully after install
-- XS01-WX live API readback confirmed online with current data
-- Full test suite passed
+### 🔎 Validation
+
+- ✅ Installed and checked on Steve Home Assistant before release.
+- ✅ Home Assistant restarted successfully after install.
+- ✅ Full test suite passed.

--- a/.github/release-notes/v.1.2.6.md
+++ b/.github/release-notes/v.1.2.6.md
@@ -1,21 +1,20 @@
-## v.1.2.6
+## 🌟 v.1.2.6
 
-### Summary
+A larger device-support and polish release. This version expands APK-aligned device behavior, improves camera setup, cleans up diagnostics, and refreshes translated documentation.
 
-This release expands APK-aligned device support, improves camera setup, and refreshes diagnostics and documentation.
+### ✨ Highlights
 
-### Fixed
+- 📱 Expanded APK-aligned update paths for station, child-device, and internal/alternate device payloads.
+- 📷 Improved camera discovery and camera entity setup for devices reported through Android app API paths.
+- 🧹 Cleaned up diagnostics so normal entity views stay useful without unnecessary serial/MAC-style clutter.
+- 🌍 Expanded translated README files with updated screenshots, supported-device guidance, and setup details.
 
-- Fixed additional APK-aligned device update paths so station, child-device, and alternate/internal device payloads update the correct Home Assistant entities more reliably.
-- Improved camera discovery and camera entity setup for devices reported through the X-Sense Android app API paths.
-- Cleaned up diagnostics so user-facing diagnostic sections avoid unnecessary serial/MAC-style identifiers while keeping useful troubleshooting data.
+### 🛠️ Improved
 
-### Improved
+- 🧪 Added and updated regression coverage for the API client, coordinator behavior, sensors, camera guards, and diagnostics.
+- 🔗 Improved documentation structure, link coverage, Markdown formatting, and translated README consistency.
 
-- Expanded and polished the translated README files, including setup screenshots, supported-device/entity guidance, and a canonical Simplified Chinese README with a legacy redirect.
-- Added and updated regression coverage for the X-Sense API client, coordinator behavior, sensors, camera guards, and diagnostics.
+### 🔎 Validation
 
-### Validation
-
-- Full test suite passed
-- Documentation structure, link coverage, Markdown code fences, YAML examples, and stale wording checks passed
+- ✅ Full test suite passed.
+- ✅ Documentation checks passed.


### PR DESCRIPTION
Updates only the release-note source files for the releases we published, v.1.2.5 through v.1.2.6.2, using a more readable announcement-style format with icons, highlights, fixes, and validation sections. No code changes and no new release.