### PR TITLE
Add release notes for earlier 1.2 releases

### DIFF
--- a/.github/release-notes/v.1.2.1.md
+++ b/.github/release-notes/v.1.2.1.md
@@ -1,0 +1,20 @@
+## ✨ v.1.2.1
+
+A polish and follow-up release after 1.2.0. This version improves XS01-WX state handling, MQTT/device matching, translated README coverage, and Home Assistant icon presentation.
+
+### ✨ Highlights
+
+- 🚨 Improved XS01-WX alarm status updates for station-only device reports.
+- 📡 Improved station/device state parsing and MQTT payload matching so updates land on the correct X-Sense device more reliably.
+- 🌍 Expanded translated README coverage with visible language flags and Simplified/Traditional Chinese README links.
+- 🎨 Added Home Assistant icon translations for static entity icons.
+
+### 🛠️ Fixed
+
+- Fixed the XS01-WX alarm-status report path connected to issue #90.
+- Cleaned up translated README coverage and language navigation.
+
+### 🔎 Validation
+
+- ✅ Issue #90 was left open for reporter confirmation instead of being closed prematurely.
+- ✅ Release prepared through the upstream PR flow.

--- a/.github/release-notes/v.1.2.2.md
+++ b/.github/release-notes/v.1.2.2.md
@@ -1,0 +1,21 @@
+## 🔧 v.1.2.2
+
+A hotfix release for setup and control issues reported after 1.2.1. This version aligns standalone Wi-Fi and base station shadow reads more closely with the Android app.
+
+### ✨ Highlights
+
+- 🏠 Fixed setup failures caused by missing station-level X-Sense `mainpage` shadows on some standalone Wi-Fi devices.
+- 📱 Aligned standalone Wi-Fi and base station shadow reads with Android app behavior.
+- 🧪 Fixed smoke detector self-test payload timestamps.
+- 🚨 Fixed fire drill payloads to target the base station serial the same way the Android app does.
+
+### 🛠️ Fixed
+
+- Fixed the setup 404 path for affected standalone Wi-Fi devices.
+- Fixed smoke control payloads that were using the wrong timestamp or target shape.
+- Cleaned up the Release Drafter template so future draft notes render correctly.
+
+### 🔎 Validation
+
+- ✅ Added focused regression tests for setup 404 behavior.
+- ✅ Added focused regression tests for smoke control payloads.

--- a/.github/release-notes/v.1.2.3.md
+++ b/.github/release-notes/v.1.2.3.md
@@ -1,0 +1,20 @@
+## 🧪 v.1.2.3
+
+A focused hotfix for X-Sense Test and Fire Drill controls after reports that 1.2.2 still did not trigger devices correctly.
+
+### ✨ Highlights
+
+- 🔐 Fixed AWS IoT shadow update signing so the exact signed JSON body is also the body sent to X-Sense.
+- 📡 Sent compact pre-serialized shadow update bodies instead of allowing the HTTP client to reserialize them.
+- 🚦 Surfaced rejected shadow updates as API errors instead of treating a failed button press as successful.
+
+### 🛠️ Fixed
+
+- Fixed mismatches between SigV4 payload hashes and transmitted shadow update bodies.
+- Fixed silent success behavior when X-Sense rejected a shadow update.
+
+### 🔎 Validation
+
+- ✅ Added regression coverage proving the signed body and sent body are identical.
+- ✅ Added regression coverage for rejected shadow update responses.
+- ✅ Ran API tests and Python compilation checks.

--- a/.github/release-notes/v.1.2.4.md
+++ b/.github/release-notes/v.1.2.4.md
@@ -1,0 +1,23 @@
+## 🚀 v.1.2.4
+
+A larger APK-alignment release for camera discovery, supported device actions, device settings, and reported timestamps. This release moves more behavior onto the same paths used by the Android app.
+
+### ✨ Highlights
+
+- 📷 Fixed SSC0A/SSC0B camera discovery when cameras are returned by the app IPC/ADDX device list but not the normal station list.
+- 🏠 Fixed standalone Wi-Fi setup for devices such as SC07-WX when there is no station-level `mainpage` shadow.
+- 🕒 Stopped exposing base-station report time as a normal changing sensor, avoiding repeated Home Assistant activity-log entries.
+- 🧪 Adjusted self-test actions for supported smoke, listener, water, keypad, motion, door, and Wi-Fi devices to match Android app shadow names, targets, and timestamp shapes.
+
+### 🛠️ Improved
+
+- 💡 Added supported light power control for SBS50 light devices.
+- 🔊 Added alarm, voice, chirp, and reminder volume controls where devices report writable settings.
+- 📷 Kept camera support scoped to the IPC models explicitly supported by the APK: SSC0A and SSC0B.
+- 🔁 Improved initialization defaults for accounts where camera devices are discovered through the camera API path.
+
+### 🔎 Validation
+
+- ✅ Added regression tests for camera discovery, unsupported camera filtering, action payloads, volume payloads, signed shadow updates, and report-time sensor handling.
+- ✅ Diff checks passed.
+- ✅ Full test suite passed.


### PR DESCRIPTION
Adds release-note source files for the releases after v.1.2.0 that were also part of our release work: v.1.2.1 through v.1.2.4. The visible GitHub release bodies were updated to match these files and now use the same announcement-style format as v.1.2.5 through v.1.2.6.2. No code changes and no new release.