### PR TITLE
fix: align camera discovery with ADDX device list

### DIFF
--- a/.github/release-notes/v.1.2.6.3.md
+++ b/.github/release-notes/v.1.2.6.3.md
@@ -1,0 +1,25 @@
+## 📷 v.1.2.6.3
+
+A focused camera and MQTT polish release. This version improves APK-aligned camera discovery for accounts where the Android app reports cameras only through the ADDX camera device list, and quiets clean MQTT disconnect noise.
+
+### ✨ Highlights
+
+- 📷 Uses the APK/ADDX camera device list as the camera authority for SSC0A and SSC0B cameras.
+- 🔁 Creates camera entities even when the normal home device list has no camera stub.
+- 🧭 Reconciles stale camera stubs against the camera serials returned by the Android app API path.
+- 📡 Treats clean MQTT disconnect code 0 as a normal debug event instead of a warning.
+- 🎥 Starts live view with the APK default empty liveResolution when no camera-specific live ratio is saved.
+- 🧩 Derives WebRTC support from the APK streamProtocol rule instead of relying on optional metadata.
+
+### 🛠️ Fixed
+
+- Fixed missing cameras for accounts where the ADDX camera list returns the camera but the normal home device list does not.
+- Fixed camera replacement when an old home-list camera stub does not match the current ADDX camera serial.
+- Fixed unnecessary Home Assistant log warnings for clean MQTT disconnects.
+- Fixed live-stream startup payloads to match the APK when no saved live ratio exists.
+- Fixed WebRTC support reporting for RTSP/RTMP cameras using the APK DeviceBean.isWebRTC() rule.
+
+### 🔎 Validation
+
+- ✅ Deep APK-alignment pass completed for API metadata, ADDX camera paths, shadow commands, MQTT topics, thing names, and online-state behavior.
+- ✅ Full test suite passed.

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -117,6 +117,14 @@ def is_camera_entity(entity: Entity) -> bool:
     return entity.type in CAMERA_TYPES
 
 
+def _normalized_camera_serial(value) -> str | None:
+    """Return a camera serial in the comparison form used for ADDX matching."""
+    if value is None:
+        return None
+    serial = "".join(char for char in str(value).upper() if char.isalnum())
+    return serial or None
+
+
 def _camera_resolution(value) -> str | None:
     """Return an APK-style camera video resolution value."""
     if value is None:
@@ -139,7 +147,7 @@ def _camera_live_resolution(camera: Entity) -> str:
         for option in options:
             if resolution := _camera_resolution(option):
                 return resolution
-    return "auto"
+    return ""
 
 
 class AsyncXSense(XSenseBase):
@@ -405,24 +413,36 @@ class AsyncXSense(XSenseBase):
 
     async def update_camera_data(self):
         """Merge camera metadata and config from the Android app ADDX API."""
-        cameras = [
-            station
-            for house in self.houses.values()
-            for station in house.stations.values()
-            if is_camera_entity(station)
+        data = await self.addx_call("/device/listuserdevices")
+        devices = [
+            device
+            for device in (data or {}).get("list") or []
+            if _camera_type(device)
+            and _normalized_camera_serial(device.get("serialNumber"))
         ]
+        if not devices:
+            return
+
+        camera_serials = {
+            _normalized_camera_serial(device.get("serialNumber")) for device in devices
+        }
+        for house in self.houses.values():
+            for station_id, station in list(house.stations.items()):
+                if (
+                    is_camera_entity(station)
+                    and _normalized_camera_serial(station.sn) not in camera_serials
+                ):
+                    del house.stations[station_id]
+
+        cameras = []
+        for device in devices:
+            camera = self._camera_from_addx_device(device)
+            if camera is not None:
+                cameras.append((camera, device))
         if not cameras:
             return
 
-        data = await self.addx_call("/device/listuserdevices")
-        devices = (data or {}).get("list") or []
-        by_sn = {device.get("serialNumber"): device for device in devices}
-
-        for camera in cameras:
-            addx_device = by_sn.get(camera.sn)
-            if not addx_device:
-                continue
-
+        for camera, addx_device in cameras:
             camera.set_data(_camera_data(addx_device))
             try:
                 config = await self.addx_call(
@@ -464,6 +484,49 @@ class AsyncXSense(XSenseBase):
                     doorbell = None
                 if doorbell:
                     camera.set_data(_camera_doorbell_data(doorbell))
+
+    def _camera_from_addx_device(self, data: Dict) -> Station | None:
+        """Return the X-Sense camera entity backed by an ADDX DeviceBean."""
+        serial = data.get("serialNumber")
+        normalized_serial = _normalized_camera_serial(serial)
+        if normalized_serial is None:
+            return None
+
+        device_house_id = data.get("houseId")
+        target_houses = [
+            house
+            for house in self.houses.values()
+            if device_house_id in (None, "")
+            or str(device_house_id) == str(house.house_id)
+        ]
+        if not target_houses:
+            return None
+
+        for house in target_houses:
+            for station in house.stations.values():
+                if (
+                    is_camera_entity(station)
+                    and _normalized_camera_serial(station.sn) == normalized_serial
+                ):
+                    return station
+
+        house = target_houses[0]
+        station_id = str(serial)
+        station = Station(
+            house,
+            stationId=station_id,
+            stationSn=serial,
+            stationName=data.get("deviceName")
+            or data.get("displayModelNo")
+            or station_id,
+            category=_camera_type(data),
+            deviceType=_camera_type(data),
+            onLine=data.get("online", 1),
+            devices=[],
+        )
+        station.set_devices({"devices": []})
+        house.stations[station.entity_id] = station
+        return station
 
     async def update_camera_config(self, camera: Entity, **updates):
         """Write camera user config through the Android app endpoint."""
@@ -856,6 +919,16 @@ def _camera_type(data: Dict) -> str | None:
     return None
 
 
+def _camera_is_webrtc(data: Dict) -> bool:
+    """Return DeviceBean.isWebRTC() from the Android app."""
+    device_model = data.get("deviceModel") or {}
+    stream_protocol = device_model.get("streamProtocol")
+    if stream_protocol is None:
+        return True
+    protocol = str(stream_protocol).lower()
+    return "rtsp" not in protocol and "rtmp" not in protocol
+
+
 def _camera_data(data: Dict) -> Dict:
     device_model = data.get("deviceModel") or {}
     device_support = data.get("deviceSupport") or {}
@@ -927,7 +1000,7 @@ def _camera_data(data: Dict) -> Dict:
         ),
         "supportedRecordingResolutions": device_support.get("deviceSupportResolution"),
         "supportVoiceVolume": _addx_bool(device_support.get("supportVoiceVolume")),
-        "supportWebrtc": _addx_bool(device_support.get("supportWebrtc")),
+        "supportWebrtc": _camera_is_webrtc(data),
         "thumbImgTime": data.get("thumbImgTime"),
         "thumbImgUrl": data.get("thumbImgUrl"),
         "timeZone": data.get("timeZone"),

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -19,5 +19,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.2"
+  "version": "1.2.6.3"
 }

--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -711,6 +711,9 @@ class XSenseMQTT:
         # result is set make sure the first connection result is set
         self._async_connection_result(False)
         self.connected = False
+        if result_code == mqtt.MQTT_ERR_SUCCESS:
+            _LOGGER.debug("Disconnected from MQTT server cleanly")
+            return
         _LOGGER.warning(
             "Disconnected from MQTT server (%s)",
             result_code,

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import importlib
 import json
+import logging
 import sys
 import types
 from pathlib import Path
@@ -128,6 +129,34 @@ def test_mqtt_helper_publish_uses_compact_utf8_json():
             False,
         )
     ]
+
+
+def test_xsense_mqtt_clean_disconnect_is_not_a_warning(caplog):
+    caplog.set_level(logging.DEBUG)
+    client = object.__new__(xsense_mqtt.XSenseMQTT)
+    client.connected = True
+    results = []
+    client._async_connection_result = results.append
+
+    client._async_on_disconnect(xsense_mqtt.mqtt.MQTT_ERR_SUCCESS)
+
+    assert client.connected is False
+    assert results == [False]
+    assert "Disconnected from MQTT server (0)" not in caplog.text
+    assert "Disconnected from MQTT server cleanly" in caplog.text
+
+
+def test_xsense_mqtt_nonzero_disconnect_still_warns(caplog):
+    client = object.__new__(xsense_mqtt.XSenseMQTT)
+    client.connected = True
+    results = []
+    client._async_connection_result = results.append
+
+    client._async_on_disconnect(7)
+
+    assert client.connected is False
+    assert results == [False]
+    assert "Disconnected from MQTT server (7)" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1674,13 +1703,104 @@ async def test_update_camera_data_updates_known_camera_from_addx_device_list():
 
 
 @pytest.mark.asyncio
+async def test_update_camera_data_uses_addx_device_as_camera_authority():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "stub-id",
+                    "ipcSn": "stub-sn",
+                    "ipcName": "Stub Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "real-sn",
+                        "deviceName": "Front Camera",
+                        "houseId": "house-id",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                        "batteryLevel": 2,
+                        "deviceModel": {"streamProtocol": "webrtc"},
+                        "deviceSupport": {"supportWebrtc": 1},
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    assert "stub-id" not in test_house.stations
+    camera = test_house.get_station_by_sn("real-sn")
+    assert camera is not None
+    assert camera.entity_id == "real-sn"
+    assert camera.name == "Front Camera"
+    assert camera.type == "SSC0A"
+    assert camera.online is True
+    assert camera.data["batteryLevel"] == 2
+    assert camera.data["streamProtocol"] == "webrtc"
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_creates_camera_from_addx_without_home_stub():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "1234", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
+    client.houses = {"1234": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-sn",
+                        "deviceName": "Driveway Camera",
+                        "houseId": 1234,
+                        "displayModelNo": "SSC0B",
+                        "online": 1,
+                        "deviceModel": {
+                            "modelName": "SSC0B",
+                            "streamProtocol": "webrtc",
+                        },
+                        "deviceSupport": {"supportWebrtc": 1},
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    camera = test_house.get_station_by_sn("camera-sn")
+    assert camera is not None
+    assert camera.name == "Driveway Camera"
+    assert camera.type == "SSC0B"
+    assert camera.data["streamProtocol"] == "webrtc"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("camera_data", "expected"),
     [
         ({"liveResolution": "VIDEO_SIZE_1920x1080"}, "1920x1080"),
         ({"liveResolution": "HD"}, "1920x1080"),
         ({"supportedRecordingResolutions": ["P1296", "P1080"]}, "2304x1296"),
-        ({"supportedRecordingResolutions": []}, "auto"),
+        ({"supportedRecordingResolutions": []}, ""),
     ],
 )
 async def test_start_camera_live_uses_apk_live_resolution_fallback(
@@ -1927,19 +2047,22 @@ async def test_register_ipc_requires_house_region_instead_of_defaulting_to_us():
 
 
 @pytest.mark.asyncio
-async def test_update_camera_data_skips_addx_when_normal_device_list_has_no_camera():
+async def test_update_camera_data_handles_empty_addx_camera_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
     test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
     client.houses = {"house-id": test_house}
+    calls = []
 
     async def addx_call(endpoint, **kwargs):
-        raise AssertionError("ADDX should not be queried without APK camera entries")
+        calls.append((endpoint, kwargs))
+        return {"list": []}
 
     client.addx_call = addx_call
 
     await client.update_camera_data()
 
+    assert calls == [("/device/listuserdevices", {})]
     assert test_house.stations == {}
 
 
@@ -2000,6 +2123,28 @@ def test_camera_data_normalizes_apk_integer_support_flags():
         "supportWebrtc",
     ):
         assert data[key] is True
+
+
+def test_camera_data_uses_apk_webrtc_stream_protocol_rule():
+    assert async_xsense._camera_data({"deviceModel": {}})["supportWebrtc"] is True
+    assert (
+        async_xsense._camera_data(
+            {"deviceModel": {"streamProtocol": "webrtc"}}
+        )["supportWebrtc"]
+        is True
+    )
+    assert (
+        async_xsense._camera_data({"deviceModel": {"streamProtocol": "rtsp"}})[
+            "supportWebrtc"
+        ]
+        is False
+    )
+    assert (
+        async_xsense._camera_data({"deviceModel": {"streamProtocol": "RTMP"}})[
+            "supportWebrtc"
+        ]
+        is False
+    )
 
 
 def test_camera_user_config_payload_sends_only_changed_cloud_fields_like_apk():


### PR DESCRIPTION
## 📷 v.1.2.6.3

A focused camera and MQTT polish release. This version improves APK-aligned camera discovery for accounts where the Android app reports cameras only through the ADDX camera device list, and quiets clean MQTT disconnect noise.

### ✨ Highlights

- 📷 Uses the APK/ADDX camera device list as the camera authority for SSC0A and SSC0B cameras.
- 🔁 Creates camera entities even when the normal home device list has no camera stub.
- 🧭 Reconciles stale camera stubs against the camera serials returned by the Android app API path.
- 📡 Treats clean MQTT disconnect code 0 as a normal debug event instead of a warning.
- 🎥 Starts live view with the APK default empty liveResolution when no camera-specific live ratio is saved.
- 🧩 Derives WebRTC support from the APK streamProtocol rule instead of relying on optional metadata.

### 🛠️ Fixed

- Fixed missing cameras for accounts where the ADDX camera list returns the camera but the normal home device list does not.
- Fixed camera replacement when an old home-list camera stub does not match the current ADDX camera serial.
- Fixed unnecessary Home Assistant log warnings for clean MQTT disconnects.
- Fixed live-stream startup payloads to match the APK when no saved live ratio exists.
- Fixed WebRTC support reporting for RTSP/RTMP cameras using the APK DeviceBean.isWebRTC() rule.

### 🔎 Validation

- ✅ Deep APK-alignment pass completed for API metadata, ADDX camera paths, shadow commands, MQTT topics, thing names, and online-state behavior.
- ✅ Full test suite passed.
