### PR TITLE
fix: align camera WebRTC and login handling

### DIFF
--- a/.github/release-notes/v.1.2.6.4.md
+++ b/.github/release-notes/v.1.2.6.4.md
@@ -1,0 +1,25 @@
+## 🎥 v.1.2.6.4
+
+A camera playback and login reliability polish release. This version tightens the camera/WebRTC path against the Android app behavior and makes initial X-Sense login failures fail cleanly instead of hanging behind a broad Home Assistant timeout.
+
+### ✨ Highlights
+
+- 🎥 Adds the X-Sense/ADDX WebRTC signaling bridge used by the Android app camera player.
+- 💤 Sends the APK live-view `verifyDormancyStatus` flag when requesting WebRTC camera tickets.
+- 🧭 Uses the APK `auto` live-resolution fallback when no saved camera live ratio is available.
+- ⚙️ Loads camera form options from the same ADDX settings endpoint the app uses.
+- ⏱️ Aligns Cognito login network bounds with the AWS Android SDK defaults used by the app.
+
+### 🛠️ Fixed
+
+- Fixed WebRTC cameras being exposed to Home Assistant stream handling without the ADDX signal bridge they require.
+- Fixed camera ticket requests missing the normal APK live-view dormancy verification flag.
+- Fixed stale camera cleanup when the ADDX camera list is valid but empty.
+- Fixed login attempts waiting too long or surfacing poorly when Cognito cannot be reached.
+- Fixed camera motion sensitivity controls when the settings response omits the option list.
+
+### 🔎 Validation
+
+- ✅ Installed and restarted on a live Home Assistant instance before release prep.
+- ✅ X-Sense platforms loaded cleanly after restart.
+- ✅ Full test suite passed.

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Dict
+from typing import Any, Dict
 
 import aiohttp
 
@@ -138,6 +138,16 @@ def _camera_resolution(value) -> str | None:
     return _CAMERA_RESOLUTION_ALIASES.get(normalized.upper())
 
 
+def _camera_webrtc_ticket_valid(ticket: dict) -> bool:
+    expiration = ticket.get("expirationTime")
+    if expiration in (None, ""):
+        return True
+    try:
+        return int(expiration) > int(datetime.now().timestamp() * 1000) + 60_000
+    except (TypeError, ValueError):
+        return False
+
+
 def _camera_live_resolution(camera: Entity) -> str:
     """Return the APK start-live resolution fallback for a camera."""
     if resolution := _camera_resolution(camera.data.get("liveResolution")):
@@ -147,7 +157,7 @@ def _camera_live_resolution(camera: Entity) -> str:
         for option in options:
             if resolution := _camera_resolution(option):
                 return resolution
-    return ""
+    return "auto"
 
 
 class AsyncXSense(XSenseBase):
@@ -420,9 +430,6 @@ class AsyncXSense(XSenseBase):
             if _camera_type(device)
             and _normalized_camera_serial(device.get("serialNumber"))
         ]
-        if not devices:
-            return
-
         camera_serials = {
             _normalized_camera_serial(device.get("serialNumber")) for device in devices
         }
@@ -454,6 +461,16 @@ class AsyncXSense(XSenseBase):
                 config = None
             if config:
                 camera.set_data(_camera_config_data(config))
+
+            try:
+                setting_options = await self.addx_call(
+                    "/user/getFormOptions",
+                    serialNumber=camera.sn,
+                )
+            except APIFailure:
+                setting_options = None
+            if setting_options:
+                camera.set_data(_camera_settings_options_data(setting_options))
 
             if any(
                 camera.data.get(key)
@@ -587,6 +604,22 @@ class AsyncXSense(XSenseBase):
         )
         camera.set_data({"cooldownEnabled": user_enable, "cooldownValue": value})
 
+    async def get_camera_webrtc_ticket(self, camera: Entity) -> dict | None:
+        """Return an APK WebRTC ticket, reusing it until it is near expiry."""
+        cached = camera.data.get("cameraWebrtcTicket")
+        if isinstance(cached, dict) and _camera_webrtc_ticket_valid(cached):
+            return cached
+
+        data = await self.addx_call(
+            "/device/getWebrtcTicket",
+            serialNumber=camera.sn,
+            verifyDormancyStatus=True,
+        )
+        if isinstance(data, dict):
+            camera.set_data({"cameraWebrtcTicket": data})
+            return data
+        return None
+
     async def start_camera_live(self, camera: Entity) -> str | None:
         """Return the direct live URL from the ADDX start-live endpoint."""
         live_started_at = camera.data.get("cameraLiveStartedAt")
@@ -604,15 +637,17 @@ class AsyncXSense(XSenseBase):
             liveResolution=_camera_live_resolution(camera),
         )
         if isinstance(data, dict):
+            live_url = _camera_live_url(data)
             camera.set_data(
                 {
                     "cameraAudioUrl": data.get("audioUrl"),
                     "cameraLiveId": data.get("liveId"),
                     "cameraLiveStartedAt": datetime.now(),
-                    "cameraLiveUrl": data.get("liveUrl") or data.get("url"),
+                    "cameraLiveUrl": live_url,
+                    "cameraLiveProtocol": _url_scheme(live_url),
                 }
             )
-            return data.get("liveUrl") or data.get("url")
+            return live_url
         return None
 
     async def stop_camera_live(self, camera: Entity) -> None:
@@ -626,6 +661,7 @@ class AsyncXSense(XSenseBase):
                     "cameraLiveId": None,
                     "cameraLiveStartedAt": None,
                     "cameraLiveUrl": None,
+                    "cameraLiveProtocol": None,
                 }
             )
 
@@ -849,6 +885,23 @@ class AsyncXSense(XSenseBase):
         if callable(shadow):
             shadow = shadow(entity)
         return await self.set_state(entity, shadow, topic, action_def)
+
+
+def _url_scheme(url: str | None) -> str | None:
+    """Return the URL scheme without logging or exposing the full URL."""
+    if not isinstance(url, str) or "://" not in url:
+        return None
+    return url.split("://", 1)[0].lower()
+
+
+def _camera_live_url(data: Dict) -> str | None:
+    """Return the live URL transformed the same way as the APK RTMP player."""
+    live_url = data.get("liveUrl") or data.get("url")
+    if not isinstance(live_url, str) or not live_url:
+        return None
+    if live_url.startswith("rtmp://"):
+        return live_url.replace("rtmp://", "rtmps://", 1)
+    return live_url
 
 
 def _shadow_config_topic(entity: Entity) -> str:
@@ -1101,6 +1154,35 @@ def _addx_bool(value) -> bool | None:
     if isinstance(value, int):
         return value == 1
     return None
+
+
+def _enabled_option_values(options: Any) -> list[Any]:
+    """Return enabled option values from the APK SettingOptionsResponse shape."""
+    if not isinstance(options, list):
+        return []
+    values: list[Any] = []
+    for option in options:
+        if not isinstance(option, dict):
+            continue
+        if option.get("enabled") is False:
+            continue
+        value = option.get("value")
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _camera_settings_options_data(data: Dict) -> Dict:
+    """Return APK camera form options from /user/getFormOptions."""
+    form_options = data.get("deviceFormOptions") or {} if isinstance(data, dict) else {}
+    video_seconds = _enabled_option_values(form_options.get("videoSeconds"))
+    cooldown = _enabled_option_values(form_options.get("cooldown_in_s"))
+    result: Dict[str, Any] = {}
+    if video_seconds:
+        result["videoSecondsValues"] = video_seconds
+    if cooldown:
+        result["cooldownOptions"] = cooldown
+    return result
 
 
 def _camera_config_data(data: Dict) -> Dict:

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -6,12 +6,13 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
 from pycognito import AWSSRP
 
 from .entity import Entity
 from .entity_map import entities
-from .exceptions import AuthFailed
+from .exceptions import APIFailure, AuthFailed
 from .station import Station
 from .house import House
 
@@ -28,6 +29,12 @@ def _mac_scalar(value) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     return str(value)
+
+
+_COGNITO_CLIENT_CONFIG = Config(
+    connect_timeout=15,
+    read_timeout=15,
+)
 
 
 class XSenseBase:
@@ -76,7 +83,9 @@ class XSenseBase:
     def sync_login(self, username, password):
         self.username = username
         session = boto3.Session()
-        cognito = session.client("cognito-idp", region_name=self.region)
+        cognito = session.client(
+            "cognito-idp", region_name=self.region, config=_COGNITO_CLIENT_CONFIG
+        )
 
         aws_srp = AWSSRP(
             username=username,
@@ -98,6 +107,8 @@ class XSenseBase:
             )
         except ClientError as e:
             raise AuthFailed(self._parse_client_error(e)) from e
+        except BotoCoreError as e:
+            raise APIFailure(f"Cognito connection failed: {e}") from e
 
         self.userid = response["ChallengeParameters"]["USERNAME"]
 
@@ -127,6 +138,8 @@ class XSenseBase:
 
         except ClientError as e:
             raise AuthFailed(self._parse_client_error(e)) from e
+        except BotoCoreError as e:
+            raise APIFailure(f"Cognito connection failed: {e}") from e
 
     def restore_session(self, username, access_token, refresh_token, id_token):
         self.username = username

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -11,14 +11,23 @@ from homeassistant.components.camera import (
     CameraEntityDescription,
     CameraEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.components.camera.webrtc import (
+    WebRTCClientConfiguration,
+    WebRTCError,
+    WebRTCSendMessage,
+)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api.async_xsense import is_camera_entity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
+from .webrtc_signal import (
+    XSenseWebRTCSession,
+    XSenseWebRTCTicket,
+)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -61,7 +70,7 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         """Set up the camera entity."""
         Camera.__init__(self)
         self.entity_description = entity_description
-        self._attr_supported_features = CameraEntityFeature.STREAM
+        self._webrtc_sessions: dict[str, XSenseWebRTCSession] = {}
         super().__init__(coordinator, entity)
 
     @property
@@ -73,10 +82,22 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         return entity.data.get("cameraModel") or entity.data.get("modelNo")
 
     @property
+    def supported_features(self) -> CameraEntityFeature:
+        """Return native stream support for ffmpeg-compatible camera URLs."""
+        entity = self._current_entity()
+        if entity is not None and (
+            _is_native_stream_camera(entity) or _is_webrtc_camera(entity)
+        ):
+            return CameraEntityFeature.STREAM
+        return CameraEntityFeature(0)
+
+    @property
     def is_streaming(self) -> bool:
         """Return whether the camera has an active live stream session."""
         entity = self._current_entity()
-        return entity is not None and bool(entity.data.get("cameraLiveUrl"))
+        return entity is not None and (
+            bool(entity.data.get("cameraLiveUrl")) or bool(self._webrtc_sessions)
+        )
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
@@ -101,12 +122,115 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         entity = self._current_entity()
         if entity is None:
             return None
-        return await self.coordinator.xsense.start_camera_live(entity)
+        source = await self.coordinator.xsense.start_camera_live(entity)
+        if _url_scheme(source) == "webrtc":
+            LOGGER.info(
+                "X-Sense camera %s returned an ADDX WebRTC stream that Home Assistant's native stream worker cannot open",
+                entity.entity_id,
+            )
+            return None
+        return source
+
+    @callback
+    def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
+        """Return the Home Assistant browser WebRTC client configuration."""
+        return WebRTCClientConfiguration()
+
+    async def async_handle_async_webrtc_offer(
+        self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
+    ) -> None:
+        """Handle a Home Assistant WebRTC offer with ADDX signaling."""
+        entity = self._current_entity()
+        if entity is None or not _is_webrtc_camera(entity):
+            send_message(
+                WebRTCError(
+                    "xsense_webrtc_unsupported",
+                    "Camera does not support X-Sense WebRTC",
+                )
+            )
+            return
+
+        ticket_data = await self.coordinator.xsense.get_camera_webrtc_ticket(entity)
+        if not isinstance(ticket_data, dict):
+            send_message(
+                WebRTCError(
+                    "xsense_webrtc_ticket_failed",
+                    "Unable to get X-Sense WebRTC ticket",
+                )
+            )
+            return
+
+        session = XSenseWebRTCSession(
+            session=async_get_clientsession(self.hass),
+            ticket=XSenseWebRTCTicket.from_api(entity.sn, ticket_data),
+            offer_sdp=offer_sdp,
+            resolution=_camera_live_resolution(entity),
+            send_message=send_message,
+        )
+        self._webrtc_sessions[session_id] = session
+        await session.start()
+
+    async def async_on_webrtc_candidate(self, session_id, candidate) -> None:
+        """Forward a Home Assistant WebRTC candidate to X-Sense."""
+        if session := self._webrtc_sessions.get(session_id):
+            await session.add_candidate(candidate)
+
+    @callback
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Close an X-Sense WebRTC session."""
+        if session := self._webrtc_sessions.pop(session_id, None):
+            self.hass.async_create_task(session.close())
+        super().close_webrtc_session(session_id)
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop any live view session when Home Assistant removes the entity."""
+        for session_id in list(self._webrtc_sessions):
+            self.close_webrtc_session(session_id)
         entity = self._current_entity()
         if entity is not None and entity.data.get("cameraLiveUrl"):
             with suppress(Exception):
                 await self.coordinator.xsense.stop_camera_live(entity)
         await super().async_will_remove_from_hass()
+
+
+def _url_scheme(url: str | None) -> str | None:
+    """Return the URL scheme without exposing the full stream URL."""
+    if not isinstance(url, str) or "://" not in url:
+        return None
+    return url.split("://", 1)[0].lower()
+
+
+def _stream_protocol(entity) -> str | None:
+    """Return the ADDX stream protocol from the camera device model."""
+    protocol = entity.data.get("streamProtocol")
+    if protocol is None:
+        return None
+    return str(protocol).lower()
+
+
+def _is_native_stream_camera(entity) -> bool:
+    """Return whether the camera has a Home Assistant native stream protocol."""
+    protocol = _stream_protocol(entity)
+    if protocol is None:
+        return False
+    return "rtsp" in protocol or "rtmp" in protocol
+
+
+def _is_webrtc_camera(entity) -> bool:
+    """Return whether the ADDX device model says this camera streams over WebRTC."""
+    protocol = _stream_protocol(entity)
+    if protocol is None:
+        return entity.data.get("supportWebrtc") is True
+    return (
+        protocol not in {"rtsp", "rtmp"}
+        and "rtsp" not in protocol
+        and "rtmp" not in protocol
+    )
+
+
+def _camera_live_resolution(entity) -> str:
+    """Return the live resolution string used by the ADDX player."""
+    value = entity.data.get("liveResolution") or entity.data.get("recResolution")
+    if isinstance(value, str) and "x" in value:
+        return value
+    return "auto"

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -11,6 +11,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "requirements": [
+    "aiortc>=1.14.0,<2",
     "boto3",
     "botocore",
     "pycognito",
@@ -19,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.3"
+  "version": "1.2.6.4"
 }

--- a/custom_components/xsense/select.py
+++ b/custom_components/xsense/select.py
@@ -99,9 +99,10 @@ SELECTS: tuple[XSenseSelectEntityDescription, ...] = (
         data_key="motionSensitivity",
         addx_key="motionSensitivity",
         options_key="motionSensitivityOptionList",
+        fixed_options=(1, 2, 3),
         name="Motion Sensitivity",
         icon="mdi:motion-sensor",
-        exists_fn=has_data("motionSensitivity", "motionSensitivityOptionList"),
+        exists_fn=has_data("motionSensitivity"),
     ),
     XSenseSelectEntityDescription(
         key="camera_video_seconds",
@@ -246,6 +247,10 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
         entity = self._current_entity()
         if entity is None:
             return []
+        if self.entity_description.key == "camera_motion_sensitivity":
+            options = entity.data.get("motionSensitivityOptionList")
+            if isinstance(options, list) and len(options) == 4:
+                return option_strings(options)
         if self.entity_description.fixed_options is not None:
             return option_strings(list(self.entity_description.fixed_options))
         return option_strings(entity.data.get(self.entity_description.options_key))

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -1,0 +1,483 @@
+"""X-Sense ADDX WebRTC signaling helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import aiohttp
+from aiortc import (
+    RTCBundlePolicy as AiortcRTCBundlePolicy,
+    RTCConfiguration as AiortcRTCConfiguration,
+    RTCIceCandidate,
+    RTCIceServer as AiortcRTCIceServer,
+    RTCPeerConnection,
+    RTCSessionDescription,
+)
+from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
+from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
+from homeassistant.components.camera.webrtc import (
+    WebRTCAnswer,
+    WebRTCError,
+    WebRTCSendMessage,
+)
+from webrtc_models import RTCIceCandidateInit
+
+from .const import LOGGER
+
+SIGNAL_MODE = "vicoo"
+SIGNAL_VIEWER_TYPE = "a4x_sdk"
+SIGNAL_DATA_CHANNEL = "data-channel-of-"
+_SIGNAL_NAME = "test-123"
+_DEFAULT_RESOLUTION = "auto"
+
+
+@dataclass(slots=True)
+class XSenseWebRTCTicket:
+    """ADDX WebRTC ticket data returned by the X-Sense camera API."""
+
+    serial_number: str
+    signal_server: str
+    group_id: str
+    role: str
+    client_id: str
+    trace_id: str
+    sign: str
+    time: int
+    expiration_time: int | None = None
+    signal_ping_interval: int | None = None
+    app_stop_live_timeout: int | None = None
+    signal_server_ip_address: str | None = None
+    ice_servers: list[dict[str, Any]] | None = None
+
+    @classmethod
+    def from_api(cls, serial_number: str, data: dict[str, Any]) -> "XSenseWebRTCTicket":
+        """Build a ticket from the Android app getWebrtcTicket response."""
+        return cls(
+            serial_number=serial_number,
+            signal_server=str(data["signalServer"]),
+            group_id=str(data["groupId"]),
+            role=str(data["role"]),
+            client_id=str(data["id"]),
+            trace_id=str(data["traceId"]),
+            sign=str(data["sign"]),
+            time=int(data["time"]),
+            expiration_time=_optional_int(data.get("expirationTime")),
+            signal_ping_interval=_optional_int(data.get("signalPingInterval")),
+            app_stop_live_timeout=_optional_int(data.get("appStopLiveTimeout")),
+            signal_server_ip_address=data.get("signalServerIpAddress"),
+            ice_servers=list(data.get("iceServer") or []),
+        )
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether the ticket has enough lifetime left to start playback."""
+        if self.expiration_time is None:
+            return True
+        return self.expiration_time > int(time.time() * 1000) + 60_000
+
+    @property
+    def session_id(self) -> str:
+        """Return the SDK-style peer connection session id."""
+        return f"Android-{self.client_id}-{int(time.time() * 1000)}"
+
+    def signal_url(self) -> str:
+        """Return the APK-compatible WebRTC signal URL."""
+        parsed = self._parsed_signal_server()
+        path = f"/{self.group_id}/{self.role}/{self.client_id}"
+        query = (
+            f"traceId={self.trace_id}&time={self.time}"
+            f"&sign={self.sign}&name={_SIGNAL_NAME}"
+        )
+        return urlunparse((parsed.scheme, parsed.netloc, path, "", query, ""))
+
+    def signal_connect_options(self) -> dict[str, Any]:
+        """Return APK-style WebSocket connect overrides for signal IP tickets."""
+        if not self.signal_server_ip_address:
+            return {}
+        parsed = urlparse(self.signal_url())
+        host = parsed.hostname
+        if not host:
+            return {}
+        netloc = self.signal_server_ip_address
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        url = urlunparse((parsed.scheme, netloc, parsed.path, "", parsed.query, ""))
+        return {
+            "url": url,
+            "headers": {"Host": parsed.netloc},
+            "server_hostname": host,
+        }
+
+    def _parsed_signal_server(self):
+        parsed = urlparse(self.signal_server)
+        if not parsed.scheme:
+            parsed = urlparse(f"wss://{self.signal_server}")
+        scheme = "wss" if parsed.scheme in {"http", "https"} else parsed.scheme
+        return parsed._replace(scheme=scheme)
+
+
+class _ProxyTrack(MediaStreamTrack):
+    """Media track that forwards frames from the X-Sense camera peer."""
+
+    def __init__(self, kind: str) -> None:
+        super().__init__()
+        self.kind = kind
+        self._source: asyncio.Future[MediaStreamTrack] = asyncio.get_running_loop().create_future()
+
+    def set_source(self, track: MediaStreamTrack) -> None:
+        """Set the source track once the camera peer receives it."""
+        if not self._source.done():
+            self._source.set_result(track)
+
+    async def recv(self):
+        """Return the next frame from the camera peer."""
+        if self.readyState != "live":
+            raise MediaStreamError
+        source = await self._source
+        return await source.recv()
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def make_sdp_offer_payload(
+    *,
+    offer_sdp: str,
+    ticket: XSenseWebRTCTicket,
+    recipient_client_id: str,
+    session_id: str,
+    resolution: str | None,
+) -> str:
+    """Return the APK-compatible SDP offer envelope."""
+    payload = _b64_json({"type": "offer", "sdp": offer_sdp})
+    envelope: dict[str, Any] = {
+        "messageType": "SDP_OFFER",
+        "messagePayload": payload,
+        "mode": SIGNAL_MODE,
+        "recipientClientId": recipient_client_id,
+        "senderClientId": ticket.client_id,
+        "sessionId": session_id,
+        "viewerType": SIGNAL_VIEWER_TYPE,
+    }
+    if resolution:
+        envelope["resolution"] = resolution
+    return json.dumps(envelope, separators=(",", ":"))
+
+
+def make_ice_candidate_payload(
+    *,
+    candidate: RTCIceCandidate | RTCIceCandidateInit,
+    ticket: XSenseWebRTCTicket,
+    recipient_client_id: str,
+    session_id: str,
+) -> str:
+    """Return the APK-compatible ICE candidate envelope."""
+    candidate_sdp = _candidate_to_sdp(candidate)
+    sdp_mid = getattr(candidate, "sdpMid", None) or getattr(candidate, "sdp_mid", None)
+    sdp_m_line_index = getattr(candidate, "sdpMLineIndex", None)
+    if sdp_m_line_index is None:
+        sdp_m_line_index = getattr(candidate, "sdp_m_line_index", None)
+    payload = _b64_json(
+        {
+            "sdpMid": sdp_mid,
+            "sdpMLineIndex": sdp_m_line_index,
+            "candidate": candidate_sdp,
+        }
+    )
+    envelope = {
+        "messageType": "ICE_CANDIDATE",
+        "messagePayload": payload,
+        "recipientClientId": recipient_client_id,
+        "senderClientId": ticket.client_id,
+        "sessionId": session_id,
+    }
+    return json.dumps(envelope, separators=(",", ":"))
+
+
+def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
+    """Return the APK-compatible data-channel startLive command."""
+    timestamp = int(time.time())
+    return {
+        "requestID": f"cmd_{timestamp}",
+        "connectionID": "7893feb",
+        "timeStamp": timestamp,
+        "action": "startLive",
+        "size": _map_video_size(resolution),
+        "resolution": resolution,
+    }
+
+
+def parse_signal_message(raw: str | bytes) -> tuple[str | None, Any]:
+    """Parse a signal-server message into the APK event callback shape."""
+    if isinstance(raw, bytes):
+        raw = raw.decode(errors="ignore")
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None, raw
+
+    event = data.get("messageType") or data.get("event") or data.get("type")
+    payload: Any = _signal_payload(data)
+    if isinstance(payload, str) and event in {"SDP_ANSWER", "ICE_CANDIDATE"}:
+        with suppress(Exception):
+            payload = json.loads(base64.b64decode(payload).decode())
+    if event in {"PEER_IN", "PEER_OUT"}:
+        payload = _signal_peer_payload(payload)
+    return event, payload
+
+
+def _signal_payload(data: dict[str, Any]) -> Any:
+    for key in ("messagePayload", "payload", "data", "message", "body"):
+        if key in data:
+            return data[key]
+    return data
+
+
+def _signal_peer_payload(payload: Any) -> Any:
+    if isinstance(payload, str):
+        with suppress(Exception):
+            payload = json.loads(payload)
+    if isinstance(payload, dict):
+        for key in ("clientId", "serialNumber", "deviceSn", "deviceSN", "sn"):
+            value = payload.get(key)
+            if value:
+                return str(value)
+    return payload
+
+
+class XSenseWebRTCSession:
+    """One Home Assistant WebRTC session bridged to X-Sense ADDX WebRTC."""
+
+    def __init__(
+        self,
+        *,
+        session: aiohttp.ClientSession,
+        ticket: XSenseWebRTCTicket,
+        offer_sdp: str,
+        resolution: str | None,
+        send_message: WebRTCSendMessage,
+        session_id: str | None = None,
+    ) -> None:
+        self._session = session
+        self._ticket = ticket
+        self._offer_sdp = offer_sdp
+        self._resolution = resolution or _DEFAULT_RESOLUTION
+        self._send_message = send_message
+        self._session_id = session_id or ticket.session_id
+        self._recipient_client_id = ticket.serial_number
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._ha_pc = RTCPeerConnection()
+        self._camera_pc = RTCPeerConnection(_camera_rtc_configuration(ticket))
+        self._video = _ProxyTrack("video")
+        self._audio = _ProxyTrack("audio")
+        self._data_channel = None
+
+    async def start(self) -> None:
+        """Connect both WebRTC peers and start the X-Sense camera stream."""
+        try:
+            self._setup_camera_peer()
+            self._ha_pc.addTrack(self._video)
+            self._ha_pc.addTrack(self._audio)
+            await self._ha_pc.setRemoteDescription(
+                RTCSessionDescription(sdp=self._offer_sdp, type="offer")
+            )
+            answer = await self._ha_pc.createAnswer()
+            await self._ha_pc.setLocalDescription(answer)
+            self._send_message(WebRTCAnswer(self._ha_pc.localDescription.sdp))
+
+            connect_options = self._ticket.signal_connect_options()
+            connect_url = connect_options.pop("url", self._ticket.signal_url())
+            self._ws = await self._session.ws_connect(
+                connect_url, heartbeat=30, **connect_options
+            )
+            self._reader_task = asyncio.create_task(self._read_loop())
+            await self._start_camera_peer()
+        except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
+            LOGGER.debug("Unable to start X-Sense WebRTC bridge", exc_info=err)
+            self._send_message(WebRTCError("xsense_webrtc_start_failed", str(err)))
+            await self.close()
+
+    async def add_candidate(self, candidate: RTCIceCandidateInit) -> None:
+        """Forward a browser ICE candidate to the HA-facing peer."""
+        await self._ha_pc.addIceCandidate(_candidate_init_to_aiortc(candidate))
+
+    async def close(self) -> None:
+        """Close the X-Sense signaling and WebRTC sessions."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        await self._camera_pc.close()
+        await self._ha_pc.close()
+
+    def _setup_camera_peer(self) -> None:
+        @self._camera_pc.on("icecandidate")
+        async def on_icecandidate(candidate):
+            if candidate is not None and self._ws is not None and not self._ws.closed:
+                await self._ws.send_str(
+                    make_ice_candidate_payload(
+                        candidate=candidate,
+                        ticket=self._ticket,
+                        recipient_client_id=self._recipient_client_id,
+                        session_id=self._session_id,
+                    )
+                )
+
+        @self._camera_pc.on("track")
+        def on_track(track):
+            if track.kind == "video":
+                self._video.set_source(track)
+            elif track.kind == "audio":
+                self._audio.set_source(track)
+
+        self._data_channel = self._camera_pc.createDataChannel(SIGNAL_DATA_CHANNEL)
+
+        @self._data_channel.on("open")
+        def on_open():
+            self._data_channel.send(
+                json.dumps(
+                    make_start_live_data_channel_message(self._resolution),
+                    separators=(",", ":"),
+                )
+            )
+
+    async def _start_camera_peer(self) -> None:
+        self._camera_pc.addTransceiver("video", direction="recvonly")
+        self._camera_pc.addTransceiver("audio", direction="recvonly")
+        offer = await self._camera_pc.createOffer()
+        await self._camera_pc.setLocalDescription(offer)
+        await self._send_offer()
+
+    async def _send_offer(self) -> None:
+        if self._ws is None or self._camera_pc.localDescription is None:
+            return
+        await self._ws.send_str(
+            make_sdp_offer_payload(
+                offer_sdp=self._camera_pc.localDescription.sdp,
+                ticket=self._ticket,
+                recipient_client_id=self._recipient_client_id,
+                session_id=self._session_id,
+                resolution=self._resolution,
+            )
+        )
+
+    async def _read_loop(self) -> None:
+        if self._ws is None:
+            return
+        async for message in self._ws:
+            if message.type not in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
+                continue
+            event, payload = parse_signal_message(message.data)
+            if event == "PEER_IN":
+                if isinstance(payload, str) and payload:
+                    self._recipient_client_id = payload
+                await self._send_offer()
+            elif event == "SDP_ANSWER":
+                answer = _answer_sdp(payload)
+                if answer:
+                    await self._camera_pc.setRemoteDescription(
+                        RTCSessionDescription(sdp=answer, type="answer")
+                    )
+            elif event == "ICE_CANDIDATE":
+                candidate = _candidate_payload_to_aiortc(payload)
+                if candidate:
+                    await self._camera_pc.addIceCandidate(candidate)
+            elif event == "PEER_OUT":
+                self._send_message(
+                    WebRTCError(
+                        "xsense_webrtc_peer_offline", "Camera peer went offline"
+                    )
+                )
+
+
+def _camera_rtc_configuration(ticket: XSenseWebRTCTicket) -> AiortcRTCConfiguration:
+    servers = []
+    for server in ticket.ice_servers or []:
+        url = server.get("url") if isinstance(server, dict) else None
+        if not url:
+            continue
+        servers.append(
+            AiortcRTCIceServer(
+                urls=url,
+                username=server.get("username"),
+                credential=server.get("credential"),
+            )
+        )
+    return AiortcRTCConfiguration(
+        iceServers=servers, bundlePolicy=AiortcRTCBundlePolicy.MAX_BUNDLE
+    )
+
+
+def _answer_sdp(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        nested = payload.get("sdp")
+        if isinstance(nested, str):
+            return nested
+        encoded = payload.get("messagePayload")
+        if isinstance(encoded, str):
+            with suppress(Exception):
+                decoded = json.loads(base64.b64decode(encoded).decode())
+                return decoded.get("sdp")
+    return None
+
+
+def _candidate_payload_to_aiortc(payload: Any) -> RTCIceCandidate | None:
+    if not isinstance(payload, dict):
+        return None
+    candidate = payload.get("candidate")
+    if not isinstance(candidate, str):
+        return None
+    parsed = candidate_from_sdp(candidate)
+    parsed.sdpMid = payload.get("sdpMid")
+    parsed.sdpMLineIndex = payload.get("sdpMLineIndex")
+    return parsed
+
+
+def _candidate_init_to_aiortc(candidate: RTCIceCandidateInit) -> RTCIceCandidate:
+    parsed = candidate_from_sdp(candidate.candidate)
+    parsed.sdpMid = candidate.sdp_mid
+    parsed.sdpMLineIndex = candidate.sdp_m_line_index
+    return parsed
+
+
+def _candidate_to_sdp(candidate: RTCIceCandidate | RTCIceCandidateInit) -> str:
+    if isinstance(candidate, RTCIceCandidateInit):
+        return candidate.candidate
+    return candidate_to_sdp(candidate)
+
+
+def _b64_json(data: dict[str, Any]) -> str:
+    raw = json.dumps(data, separators=(",", ":")).encode()
+    return base64.b64encode(raw).decode()
+
+
+def _map_video_size(resolution: str) -> str:
+    if resolution in {"640x360", "640x480", "960x720"}:
+        return "1280x720"
+    if resolution in {"1280x720", "1280x960"}:
+        return "1280x720"
+    if resolution in {
+        "1920x1080",
+        "2048x1440",
+        "2048x1536",
+        "2304x1296",
+        "2560x1440",
+        "3840x2160",
+        "7680x4320",
+    }:
+        return "1920x1080"
+    return "1280x720"

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -31,6 +31,7 @@ def load_api_module(module_name: str):
 
 
 async_xsense = load_api_module("async_xsense")
+base = importlib.import_module("custom_components.xsense.api.base")
 entity = load_api_module("entity")
 device_module = load_api_module("device")
 entity_map = load_api_module("entity_map")
@@ -157,6 +158,82 @@ def test_xsense_mqtt_nonzero_disconnect_still_warns(caplog):
     assert client.connected is False
     assert results == [False]
     assert "Disconnected from MQTT server (7)" in caplog.text
+
+
+class FakeAWSSRP:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def get_auth_params(self):
+        return {"USERNAME": self.kwargs["username"]}
+
+    def process_challenge(self, challenge_parameters, auth_params):
+        return {"PASSWORD_CLAIM": "claim"}
+
+
+class FakeCognitoClient:
+    def __init__(self, *, fail=False):
+        self.fail = fail
+
+    def initiate_auth(self, **kwargs):
+        if self.fail:
+            raise base.BotoCoreError(error_msg="Could not connect to Cognito")
+        return {"ChallengeParameters": {"USERNAME": "user-id"}}
+
+    def respond_to_auth_challenge(self, **kwargs):
+        return {
+            "AuthenticationResult": {
+                "AccessToken": "access",
+                "IdToken": "id",
+                "RefreshToken": "refresh",
+                "ExpiresIn": 3600,
+            }
+        }
+
+
+class FakeBotoSession:
+    def __init__(self, *, fail=False):
+        self.fail = fail
+        self.client_calls = []
+
+    def client(self, service_name, **kwargs):
+        self.client_calls.append((service_name, kwargs))
+        return FakeCognitoClient(fail=self.fail)
+
+
+def _login_client():
+    client = base.XSenseBase()
+    client.region = "us-east-1"
+    client.userpool = "pool"
+    client.clientid = "client-id"
+    client.clientsecret = None
+    return client
+
+
+def test_sync_login_uses_bounded_cognito_network_config(monkeypatch):
+    session = FakeBotoSession()
+    monkeypatch.setattr(base.boto3, "Session", lambda: session)
+    monkeypatch.setattr(base, "AWSSRP", FakeAWSSRP)
+
+    client = _login_client()
+    client.sync_login("user@example.com", "password")
+
+    service_name, kwargs = session.client_calls[0]
+    config = kwargs["config"]
+    assert service_name == "cognito-idp"
+    assert kwargs["region_name"] == "us-east-1"
+    assert config.connect_timeout == 15
+    assert config.read_timeout == 15
+    assert config.retries is None
+    assert client.access_token == "access"
+
+
+def test_sync_login_maps_cognito_network_errors_to_api_failure(monkeypatch):
+    monkeypatch.setattr(base.boto3, "Session", lambda: FakeBotoSession(fail=True))
+    monkeypatch.setattr(base, "AWSSRP", FakeAWSSRP)
+
+    with pytest.raises(exceptions.APIFailure, match="Cognito connection failed"):
+        _login_client().sync_login("user@example.com", "password")
 
 
 @pytest.mark.asyncio
@@ -702,290 +779,84 @@ class FakeXSenseDevice:
         self.entity_type = entity_type
 
 
-@pytest.mark.asyncio
-async def test_second_gen_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XS0B-MR")
+async def _capture_action(client, target, action):
     calls = []
 
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
+    async def do_thing(station_arg, page, data):
+        calls.append((station_arg, page, data))
         return {"ok": True}
 
     client.do_thing = do_thing
-
-    await client.action(device, "test")
-
+    await client.action(target, action)
     assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "app2ndSelfTest"
+    station_arg, page, data = calls[0]
+    return station_arg, page, data["state"]["desired"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "device_type",
+        "entity_type",
+        "device_data",
+        "station_type",
+        "expected_page",
+        "expected_shadow",
+        "expected_user_param",
+        "expected_time_len",
+        "expected_station_shadow",
+    ),
+    [
+        ("XS0B-MR", entity_map.EntityType.SMOKE, {}, None, "2nd_selftest_device-sn", "app2ndSelfTest", "source=1", 13, None),
+        ("XS01-WX", entity_map.EntityType.SMOKE, {}, "XS01-WX", "appselftest_device-sn", "appSelfTest", None, None, None),
+        ("XS01-WX", entity_map.EntityType.SMOKE, {}, None, "2nd_selftest_device-sn", "appSelfTest", None, 13, None),
+        ("XS01-M", entity_map.EntityType.SMOKE, {"smokeEdition": "9"}, None, "2nd_selftest_device-sn", "app2ndSelfTest", "source=1", 13, None),
+        ("XS01-M", entity_map.EntityType.SMOKE, {"smokeEdition": "8"}, None, "2nd_selftest_device-sn", "appSelfTest", None, 13, None),
+        ("XP0J-iA", entity_map.EntityType.COMBI, {}, None, "2nd_selftest_device-sn", "appSelfTest", "source=1", 13, "XP0J-iA-station-sn"),
+        ("SD11-MR", entity_map.EntityType.SMOKE, {}, None, "2nd_selftest_device-sn", "app2ndSelfTest", "source=1", 13, None),
+        ("SWS0A", entity_map.EntityType.WATER, {}, None, "2nd_selftest_device-sn", "waterSelfTest", "source=1", 13, None),
+        ("SDS0A", entity_map.EntityType.DOOR, {}, None, "2nd_selftest_device-sn", "app2ndSelfTest", "source=1", 13, None),
+        ("SAL51", entity_map.EntityType.LISTENER, {}, None, "2nd_selftest_device-sn", "listenerSelfTest", None, 13, None),
+    ],
+)
+async def test_self_test_uses_apk_payload_shape(
+    device_type,
+    entity_type,
+    device_data,
+    station_type,
+    expected_page,
+    expected_shadow,
+    expected_user_param,
+    expected_time_len,
+    expected_station_shadow,
+):
+    client = async_xsense.AsyncXSense()
+    client.userid = "user-id"
+    device = FakeXSenseDevice(device_type, entity_type)
+    device.data = device_data
+    if station_type:
+        device.station = FakeXSenseStation(station_type)
+
+    station_arg, page, desired = await _capture_action(client, device, "test")
+
+    if expected_station_shadow is None:
+        assert station_arg is device.station
+    assert page == expected_page
+    assert desired["shadow"] == expected_shadow
     assert desired["stationSN"] == "station-sn"
     assert desired["deviceSN"] == "device-sn"
     assert desired["userId"] == "user-id"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_xs01_wx_standalone_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XS01-WX")
-    device.station = FakeXSenseStation("XS01-WX")
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "appselftest_device-sn"
-    assert desired == {
-        "shadow": "appSelfTest",
-        "stationSN": "station-sn",
-        "deviceSN": "device-sn",
-        "userId": "user-id",
-    }
-
-
-@pytest.mark.asyncio
-async def test_xs01_wx_sbs50_linked_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XS01-WX")
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "appSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_smoke_rf_v9_self_test_uses_apk_device_test_v2_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XS01-M")
-    device.data = {"smokeEdition": "9"}
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "app2ndSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_smoke_rf_older_self_test_keeps_apk_smoke_test_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XS01-M")
-    device.data = {"smokeEdition": "8"}
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "appSelfTest"
-    assert "userParam" not in desired
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_wifi_device_test_v2_targets_wifi_thing_like_apk():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("XP0J-iA", entity_map.EntityType.COMBI)
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station.shadow_name == "XP0J-iA-station-sn"
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "appSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_sd11_mr_self_test_uses_device_test_v2_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("SD11-MR")
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "app2ndSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_sws0a_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("SWS0A", entity_map.EntityType.WATER)
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "waterSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_sbs50_accessory_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("SDS0A", entity_map.EntityType.DOOR)
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "app2ndSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["userParam"] == "source=1"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
-
-
-@pytest.mark.asyncio
-async def test_listener_self_test_uses_apk_payload_shape():
-    client = async_xsense.AsyncXSense()
-    client.userid = "user-id"
-    device = FakeXSenseDevice("SAL51", entity_map.EntityType.LISTENER)
-    calls = []
-
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.action(device, "test")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
-    assert page == "2nd_selftest_device-sn"
-    assert desired["shadow"] == "listenerSelfTest"
-    assert desired["stationSN"] == "station-sn"
-    assert desired["deviceSN"] == "device-sn"
-    assert desired["userId"] == "user-id"
-    assert desired["time"].isdigit()
-    assert len(desired["time"]) == 13
+    if expected_station_shadow is not None:
+        assert station_arg.shadow_name == expected_station_shadow
+    if expected_user_param is None:
+        assert "userParam" not in desired
+    else:
+        assert desired["userParam"] == expected_user_param
+    if expected_time_len is None:
+        assert "time" not in desired
+    else:
+        assert desired["time"].isdigit()
+        assert len(desired["time"]) == expected_time_len
 
 
 @pytest.mark.asyncio
@@ -1004,20 +875,10 @@ async def test_xs01_wx_mute_targets_apk_thing_name(
     device = FakeXSenseDevice("XS01-WX")
     device.station.sn = station_sn
     device.data = {"smokeEdition": smoke_edition}
-    calls = []
 
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
+    station_arg, page, desired = await _capture_action(client, device, "mute")
 
-    client.do_thing = do_thing
-
-    await client.action(device, "mute")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station.shadow_name == expected_thing
+    assert station_arg.shadow_name == expected_thing
     assert page == expected_topic
     assert desired["shadow"] == "appMute"
     assert desired["stationSN"] == station_sn
@@ -1053,20 +914,10 @@ async def test_wifi_device_mute_uses_apk_factory_payload_shape(
     client = async_xsense.AsyncXSense()
     client.userid = "user-id"
     device = FakeXSenseStation(device_type)
-    calls = []
 
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
+    station_arg, page, desired = await _capture_action(client, device, "mute")
 
-    client.do_thing = do_thing
-
-    await client.action(device, "mute")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station.shadow_name == expected_thing
+    assert station_arg.shadow_name == expected_thing
     assert page == expected_topic
     assert desired["shadow"] == expected_shadow
     assert desired["stationSN"] == "station-sn"
@@ -1096,20 +947,10 @@ async def test_sbs50_child_mute_uses_apk_payload_shape(
     client = async_xsense.AsyncXSense()
     client.userid = "user-id"
     device = FakeXSenseDevice(device_type)
-    calls = []
 
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
+    station_arg, page, desired = await _capture_action(client, device, "mute")
 
-    client.do_thing = do_thing
-
-    await client.action(device, "mute")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station is device.station
+    assert station_arg is device.station
     assert page == "2nd_appmute"
     assert desired["shadow"] == expected_shadow
     assert desired["stationSN"] == "station-sn"
@@ -1125,20 +966,10 @@ async def test_xs03_iwx_mute_uses_apk_station_serial_thing_name():
     client = async_xsense.AsyncXSense()
     client.userid = "user-id"
     device = FakeXSenseDevice("XS03-iWX")
-    calls = []
 
-    async def do_thing(station, page, data):
-        calls.append((station, page, data))
-        return {"ok": True}
+    station_arg, page, desired = await _capture_action(client, device, "mute")
 
-    client.do_thing = do_thing
-
-    await client.action(device, "mute")
-
-    assert len(calls) == 1
-    station, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station.shadow_name == "station-sn"
+    assert station_arg.shadow_name == "station-sn"
     assert page == "appmute"
     assert desired["shadow"] == "appMute"
     assert desired["stationSN"] == "station-sn"
@@ -1290,10 +1121,7 @@ async def test_do_thing_raises_on_shadow_update_failure():
         )
 
 
-@pytest.mark.asyncio
-async def test_sbs50_station_voice_volume_uses_station_config_shadow():
-    client = async_xsense.AsyncXSense()
-    station = FakeXSenseStation("SBS50")
+async def _capture_volume_update(client, target, volume_key, volume):
     calls = []
 
     async def do_thing(station_arg, page, data):
@@ -1301,77 +1129,155 @@ async def test_sbs50_station_voice_volume_uses_station_config_shadow():
         return {"ok": True}
 
     client.do_thing = do_thing
-
-    await client.update_shadow_volume(station, "voiceVol", 35)
-
+    await client.update_shadow_volume(target, volume_key, volume)
     assert len(calls) == 1
     station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is station
-    assert page == "2nd_cfg_station-sn"
-    assert desired == {
-        "shadow": "infoBase",
-        "stationSN": "station-sn",
-        "voiceVol": "35",
-    }
+    return station_arg, page, data["state"]["desired"]
 
 
 @pytest.mark.asyncio
-async def test_sbs50_child_alarm_volume_uses_device_config_shadow():
+@pytest.mark.parametrize(
+    ("station_type", "station_data", "volume_key", "volume", "expected_page", "expected_desired"),
+    [
+        (
+            "SBS50",
+            {},
+            "voiceVol",
+            35,
+            "2nd_cfg_station-sn",
+            {"shadow": "infoBase", "stationSN": "station-sn", "voiceVol": "35"},
+        ),
+        (
+            "SBS10",
+            {"voiceVol": 45, "alarmTone": "3"},
+            "alarmVol",
+            55,
+            "info_station-sn",
+            {
+                "shadow": "infoBase",
+                "stationSN": "station-sn",
+                "alarmVol": "55",
+                "voiceVol": "45",
+                "alarmTone": "3",
+            },
+        ),
+    ],
+)
+async def test_station_volume_uses_apk_station_payload_shape(
+    station_type, station_data, volume_key, volume, expected_page, expected_desired
+):
     client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("XS0B-MR")
-    device.data = {"alarmTone": "2"}
-    calls = []
+    station_obj = FakeXSenseStation(station_type)
+    station_obj.data = station_data
 
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
+    station_arg, page, desired = await _capture_volume_update(
+        client, station_obj, volume_key, volume
+    )
 
-    client.do_thing = do_thing
+    assert station_arg is station_obj
+    assert page == expected_page
+    assert desired == expected_desired
 
-    await client.update_shadow_volume(device, "alarmVol", 65)
 
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("device_type", "entity_type", "device_data", "volume_key", "volume", "expected_desired"),
+    [
+        (
+            "XS0B-MR",
+            entity_map.EntityType.SMOKE,
+            {"alarmTone": "2"},
+            "alarmVol",
+            65,
+            {
+                "shadow": "infoDev",
+                "stationSN": "station-sn",
+                "alarmVol": "65",
+                "deviceSN": "device-sn",
+                "alarmTone": "2",
+            },
+        ),
+        (
+            "SDS0A",
+            entity_map.EntityType.DOOR,
+            {"chirpTone": "3"},
+            "chirpVol",
+            40,
+            {
+                "shadow": "infoDev",
+                "chirpVol": "40",
+                "deviceSN": "device-sn",
+                "chirpTone": "3",
+            },
+        ),
+        (
+            "SDS0A",
+            entity_map.EntityType.DOOR,
+            {"remindTone": "2"},
+            "remindVol",
+            30,
+            {
+                "shadow": "infoDev",
+                "remindVol": "30",
+                "deviceSN": "device-sn",
+                "remindTone": "2",
+            },
+        ),
+        (
+            "CB0Z-3S",
+            entity_map.EntityType.LIGHT,
+            {"alarmTone": "1"},
+            "alarmVol",
+            70,
+            {
+                "shadow": "infoDev",
+                "alarmVol": "70",
+                "deviceSN": "device-sn",
+                "alarmTone": "1",
+            },
+        ),
+        (
+            "XC0C-MR",
+            entity_map.EntityType.CO,
+            {"alarmTone": "3"},
+            "alarmVol",
+            80,
+            {
+                "shadow": "infoDev",
+                "alarmVol": "80",
+                "deviceSN": "device-sn",
+                "alarmTone": "3",
+            },
+        ),
+        (
+            "STH0B",
+            entity_map.EntityType.TEMPERATURE,
+            {"alarmTone": "2"},
+            "alarmVol",
+            60,
+            {
+                "shadow": "infoDev",
+                "alarmVol": "60",
+                "deviceSN": "device-sn",
+                "alarmTone": "2",
+            },
+        ),
+    ],
+)
+async def test_device_volume_uses_apk_device_payload_shape(
+    device_type, entity_type, device_data, volume_key, volume, expected_desired
+):
+    client = async_xsense.AsyncXSense()
+    device = FakeXSenseDevice(device_type, entity_type)
+    device.data = device_data
+
+    station_arg, page, desired = await _capture_volume_update(
+        client, device, volume_key, volume
+    )
+
     assert station_arg is device.station
     assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "stationSN": "station-sn",
-        "alarmVol": "65",
-        "deviceSN": "device-sn",
-        "alarmTone": "2",
-    }
-
-
-@pytest.mark.asyncio
-async def test_sbs10_station_alarm_volume_keeps_companion_voice_value():
-    client = async_xsense.AsyncXSense()
-    station = FakeXSenseStation("SBS10")
-    station.data = {"voiceVol": 45, "alarmTone": "3"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(station, "alarmVol", 55)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is station
-    assert page == "info_station-sn"
-    assert desired == {
-        "shadow": "infoBase",
-        "stationSN": "station-sn",
-        "alarmVol": "55",
-        "voiceVol": "45",
-        "alarmTone": "3",
-    }
+    assert desired == expected_desired
 
 
 @pytest.mark.asyncio
@@ -1402,119 +1308,6 @@ async def test_light_power_uses_lamp_power_payload_shape():
     assert desired["userParam"] == "source=1"
     assert desired["time"].isdigit()
     assert len(desired["time"]) == 14
-
-
-@pytest.mark.asyncio
-async def test_sbs50_child_chirp_volume_uses_device_info_payload_without_station_sn():
-    client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("SDS0A")
-    device.data = {"chirpTone": "3"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(device, "chirpVol", 40)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is device.station
-    assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "chirpVol": "40",
-        "deviceSN": "device-sn",
-        "chirpTone": "3",
-    }
-
-
-@pytest.mark.asyncio
-async def test_sbs50_child_reminder_volume_preserves_reminder_tone():
-    client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("SDS0A")
-    device.data = {"remindTone": "2"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(device, "remindVol", 30)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is device.station
-    assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "remindVol": "30",
-        "deviceSN": "device-sn",
-        "remindTone": "2",
-    }
-
-
-@pytest.mark.asyncio
-async def test_light_alarm_volume_uses_light_info_payload_without_station_sn():
-    client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("CB0Z-3S", entity_map.EntityType.LIGHT)
-    device.data = {"alarmTone": "1"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(device, "alarmVol", 70)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is device.station
-    assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "alarmVol": "70",
-        "deviceSN": "device-sn",
-        "alarmTone": "1",
-    }
-
-
-
-@pytest.mark.asyncio
-async def test_co_alarm_volume_uses_co_info_payload_without_station_sn():
-    client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("XC0C-MR", entity_map.EntityType.CO)
-    device.data = {"alarmTone": "3"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(device, "alarmVol", 80)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is device.station
-    assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "alarmVol": "80",
-        "deviceSN": "device-sn",
-        "alarmTone": "3",
-    }
 
 
 @pytest.mark.asyncio
@@ -1560,34 +1353,6 @@ async def test_group_light_power_uses_apk_group_power_payload_shape():
     assert desired["timeOut"] == "180"
     assert desired["userId"] == "user-id"
     assert desired["userParam"] == "source=1"
-
-
-@pytest.mark.asyncio
-async def test_temperature_alarm_volume_uses_temp_info_payload_without_station_sn():
-    client = async_xsense.AsyncXSense()
-    device = FakeXSenseDevice("STH0B", entity_map.EntityType.TEMPERATURE)
-    device.data = {"alarmTone": "2"}
-    calls = []
-
-    async def do_thing(station_arg, page, data):
-        calls.append((station_arg, page, data))
-        return {"ok": True}
-
-    client.do_thing = do_thing
-
-    await client.update_shadow_volume(device, "alarmVol", 60)
-
-    assert len(calls) == 1
-    station_arg, page, data = calls[0]
-    desired = data["state"]["desired"]
-    assert station_arg is device.station
-    assert page == "2nd_cfg_device-sn"
-    assert desired == {
-        "shadow": "infoDev",
-        "alarmVol": "60",
-        "deviceSN": "device-sn",
-        "alarmTone": "2",
-    }
 
 
 def test_house_set_stations_maps_apk_camera_list():
@@ -1800,7 +1565,7 @@ async def test_update_camera_data_creates_camera_from_addx_without_home_stub():
         ({"liveResolution": "VIDEO_SIZE_1920x1080"}, "1920x1080"),
         ({"liveResolution": "HD"}, "1920x1080"),
         ({"supportedRecordingResolutions": ["P1296", "P1080"]}, "2304x1296"),
-        ({"supportedRecordingResolutions": []}, ""),
+        ({"supportedRecordingResolutions": []}, "auto"),
     ],
 )
 async def test_start_camera_live_uses_apk_live_resolution_fallback(
@@ -1830,6 +1595,84 @@ async def test_start_camera_live_uses_apk_live_resolution_fallback(
             {"serialNumber": "cam-sn", "liveResolution": expected},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_loads_apk_form_options():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
+    client.houses = {"house-id": test_house}
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "cam-sn",
+                        "deviceName": "Front Camera",
+                        "houseId": "house-id",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                        "deviceModel": {"streamProtocol": "webrtc"},
+                    }
+                ]
+            }
+        if endpoint == "/device/getuserconfig":
+            return {"motionSensitivity": 1, "videoSeconds": -1}
+        if endpoint == "/user/getFormOptions":
+            return {
+                "deviceFormOptions": {
+                    "videoSeconds": [{"enabled": True, "value": -1}],
+                    "cooldown_in_s": [{"enabled": True, "value": 10}],
+                }
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    camera = test_house.get_station_by_sn("cam-sn")
+    assert camera.data["videoSecondsValues"] == [-1]
+    assert camera.data["cooldownOptions"] == [10]
+    assert "cameraWebrtcTicket" not in camera.data
+    assert ("/user/getFormOptions", {"serialNumber": "cam-sn"}) in calls
+    assert ("/device/getWebrtcTicket", {"serialNumber": "cam-sn"}) not in calls
+
+
+@pytest.mark.asyncio
+async def test_get_camera_webrtc_ticket_fetches_on_demand_and_reuses_cache():
+    client = async_xsense.AsyncXSense()
+    camera = entity.Entity()
+    camera.sn = "cam-sn"
+    camera.type = "SSC0A"
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        return {
+            "signalServer": "https://signal.example",
+            "groupId": "group",
+            "role": "viewer",
+            "id": "client123",
+            "traceId": "trace",
+            "sign": "sig",
+            "time": 123456,
+            "expirationTime": 4102444800000,
+            "iceServer": [],
+        }
+
+    client.addx_call = addx_call
+
+    first = await client.get_camera_webrtc_ticket(camera)
+    second = await client.get_camera_webrtc_ticket(camera)
+
+    assert first == second
+    assert calls == [("/device/getWebrtcTicket", {"serialNumber": "cam-sn", "verifyDormancyStatus": True})]
+
 
 def test_addx_body_requires_ipc_country():
     client = async_xsense.AsyncXSense()
@@ -2050,7 +1893,20 @@ async def test_register_ipc_requires_house_region_instead_of_defaulting_to_us():
 async def test_update_camera_data_handles_empty_addx_camera_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
-    test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "stale-cam-id",
+                    "ipcSn": "stale-cam-sn",
+                    "ipcName": "Stale Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
     client.houses = {"house-id": test_house}
     calls = []
 
@@ -2239,6 +2095,7 @@ def test_camera_config_write_value_uses_apk_field_types():
     assert async_xsense._camera_config_payload_value("needMotion", False) == 0
     assert async_xsense._camera_config_payload_value("deviceCallToggleOn", 1) is True
 
+
 def test_camera_config_data_normalizes_boolean_fields():
     data = async_xsense._camera_config_data(
         {
@@ -2270,10 +2127,26 @@ def test_camera_config_data_normalizes_boolean_fields():
 
 
 def test_camera_data_requires_apk_sd_card_support_status():
-    assert async_xsense._camera_data({"sdCard": {"formatStatus": 0}})["supportSdCard"] is True
-    assert async_xsense._camera_data({"sdCard": {"formatStatus": 1}})["supportSdCard"] is False
-    assert async_xsense._camera_data({"sdCard": {"formatStatus": 23}})["supportSdCard"] is False
+    assert (
+        async_xsense._camera_data({"sdCard": {"formatStatus": 0}})[
+            "supportSdCard"
+        ]
+        is True
+    )
+    assert (
+        async_xsense._camera_data({"sdCard": {"formatStatus": 1}})[
+            "supportSdCard"
+        ]
+        is False
+    )
+    assert (
+        async_xsense._camera_data({"sdCard": {"formatStatus": 23}})[
+            "supportSdCard"
+        ]
+        is False
+    )
     assert async_xsense._camera_data({})["supportSdCard"] is False
+
 
 def test_camera_data_requires_apk_sleep_support_code():
     data = async_xsense._camera_data(

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -1,0 +1,131 @@
+import base64
+import json
+
+from webrtc_models import RTCIceCandidateInit
+
+from custom_components.xsense import webrtc_signal
+from custom_components.xsense.webrtc_signal import (
+    SIGNAL_DATA_CHANNEL,
+    XSenseWebRTCTicket,
+    make_ice_candidate_payload,
+    make_sdp_offer_payload,
+    make_start_live_data_channel_message,
+    parse_signal_message,
+)
+
+
+def ticket(**overrides):
+    data = {
+        "signalServer": "https://signal.example",
+        "groupId": "group",
+        "role": "viewer",
+        "id": "client123",
+        "traceId": "trace",
+        "sign": "sig",
+        "time": 123456,
+        "expirationTime": 4_102_444_800_000,
+        "iceServer": [{"url": "turn:turn.example", "username": "user", "credential": "secret"}],
+    }
+    data.update(overrides)
+    return XSenseWebRTCTicket.from_api("SSC0A123", data)
+
+
+def test_ticket_connect_details_match_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100.123)
+
+    signal_ticket = ticket(signalServer="https://signal.example:443", signalServerIpAddress="203.0.113.10")
+
+    assert signal_ticket.session_id == "Android-client123-100123"
+    assert signal_ticket.signal_url() == (
+        "wss://signal.example:443/group/viewer/client123"
+        "?traceId=trace&time=123456&sign=sig&name=test-123"
+    )
+    assert signal_ticket.signal_connect_options() == {
+        "url": (
+            "wss://203.0.113.10:443/group/viewer/client123"
+            "?traceId=trace&time=123456&sign=sig&name=test-123"
+        ),
+        "headers": {"Host": "signal.example:443"},
+        "server_hostname": "signal.example",
+    }
+
+
+def test_webrtc_offer_candidate_and_start_live_payloads_match_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+
+    offer = json.loads(
+        make_sdp_offer_payload(
+            offer_sdp="v=0\r\n",
+            ticket=ticket(),
+            recipient_client_id="SSC0A123",
+            session_id="Android-client123-100000",
+            resolution="1280x720",
+        )
+    )
+    candidate = json.loads(
+        make_ice_candidate_payload(
+            candidate=RTCIceCandidateInit(
+                "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+                sdp_mid="0",
+                sdp_m_line_index=0,
+            ),
+            ticket=ticket(),
+            recipient_client_id="SSC0A123",
+            session_id="Android-client123-100000",
+        )
+    )
+
+    assert SIGNAL_DATA_CHANNEL == "data-channel-of-"
+    assert offer | {"messagePayload": "<decoded>"} == {
+        "messageType": "SDP_OFFER",
+        "messagePayload": "<decoded>",
+        "mode": "vicoo",
+        "recipientClientId": "SSC0A123",
+        "senderClientId": "client123",
+        "sessionId": "Android-client123-100000",
+        "viewerType": "a4x_sdk",
+        "resolution": "1280x720",
+    }
+    assert json.loads(base64.b64decode(offer["messagePayload"])) == {"type": "offer", "sdp": "v=0\r\n"}
+    assert candidate | {"messagePayload": "<decoded>"} == {
+        "messageType": "ICE_CANDIDATE",
+        "messagePayload": "<decoded>",
+        "recipientClientId": "SSC0A123",
+        "senderClientId": "client123",
+        "sessionId": "Android-client123-100000",
+    }
+    assert json.loads(base64.b64decode(candidate["messagePayload"])) == {
+        "sdpMid": "0",
+        "sdpMLineIndex": 0,
+        "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+    }
+    assert make_start_live_data_channel_message("2560x1440") == {
+        "requestID": "cmd_100",
+        "connectionID": "7893feb",
+        "timeStamp": 100,
+        "action": "startLive",
+        "size": "1920x1080",
+        "resolution": "2560x1440",
+    }
+    assert make_start_live_data_channel_message("auto")["size"] == "1280x720"
+    assert (
+        webrtc_signal._camera_rtc_configuration(ticket()).bundlePolicy.value
+        == "max-bundle"
+    )
+
+
+def test_parse_signal_message_decodes_answer_payload():
+    encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
+
+    assert parse_signal_message(
+        json.dumps({"messageType": "SDP_ANSWER", "messagePayload": encoded})
+    ) == ("SDP_ANSWER", {"sdp": "answer"})
+
+
+def test_parse_signal_message_accepts_apk_peer_event_wrappers():
+    assert parse_signal_message(
+        json.dumps({"event": "PEER_IN", "data": {"clientId": "SSC0A123"}})
+    ) == ("PEER_IN", "SSC0A123")
+    assert parse_signal_message(
+        json.dumps({"type": "PEER_OUT", "message": json.dumps({"deviceSN": "SSC0B456"})})
+    ) == ("PEER_OUT", "SSC0B456")


### PR DESCRIPTION
## Summary
- add the ADDX/X-Sense WebRTC signaling bridge used by the Android app camera player
- align camera ticket, live-resolution, form-option, and stale-camera handling with the APK paths
- bound Cognito login network handling to the AWS Android SDK-style timeout behavior
- bump manifest and add release notes for v.1.2.6.4

## Validation
- installed on live Home Assistant and restarted successfully
- X-Sense platforms loaded cleanly after restart
- git diff --check
- pytest tests -q (170 passed)
