### PR TITLE
fix: defer camera WebRTC media imports

### DIFF
--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -24,10 +24,6 @@ from .api.async_xsense import is_camera_entity
 from .const import DOMAIN, LOGGER
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
-from .webrtc_signal import (
-    XSenseWebRTCSession,
-    XSenseWebRTCTicket,
-)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -70,7 +66,7 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         """Set up the camera entity."""
         Camera.__init__(self)
         self.entity_description = entity_description
-        self._webrtc_sessions: dict[str, XSenseWebRTCSession] = {}
+        self._webrtc_sessions: dict[str, object] = {}
         super().__init__(coordinator, entity)
 
     @property
@@ -159,6 +155,11 @@ class XSenseCameraEntity(XSenseEntity, Camera):
                 )
             )
             return
+
+        # Import the WebRTC bridge only when Home Assistant actually starts a
+        # camera WebRTC session. This keeps optional media-stack imports out of
+        # normal camera discovery and mirrors the app on-demand live-view path.
+        from .webrtc_signal import XSenseWebRTCSession, XSenseWebRTCTicket
 
         session = XSenseWebRTCSession(
             session=async_get_clientsession(self.hass),

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -6,22 +6,31 @@ import asyncio
 import base64
 import json
 import time
+import warnings
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import aiohttp
-from aiortc import (
-    RTCBundlePolicy as AiortcRTCBundlePolicy,
-    RTCConfiguration as AiortcRTCConfiguration,
-    RTCIceCandidate,
-    RTCIceServer as AiortcRTCIceServer,
-    RTCPeerConnection,
-    RTCSessionDescription,
-)
-from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
-from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message="As the c extension couldn't be imported, `google-crc32c` is using a pure python implementation.*",
+        category=RuntimeWarning,
+        module="google_crc32c",
+    )
+    from aiortc import (
+        RTCBundlePolicy as AiortcRTCBundlePolicy,
+        RTCConfiguration as AiortcRTCConfiguration,
+        RTCIceCandidate,
+        RTCIceServer as AiortcRTCIceServer,
+        RTCPeerConnection,
+        RTCSessionDescription,
+    )
+    from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
+    from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
 from homeassistant.components.camera.webrtc import (
     WebRTCAnswer,
     WebRTCError,

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -206,3 +206,12 @@ def test_alarm_status_is_unknown_until_reported():
     alarm.data["alarmStatus"] = "1"
 
     assert binary_sensor.alarm_status(alarm) is True
+
+
+def test_camera_platform_import_does_not_load_webrtc_bridge():
+    sys.modules.pop("custom_components.xsense.camera", None)
+    sys.modules.pop("custom_components.xsense.webrtc_signal", None)
+
+    from custom_components.xsense import camera  # noqa: F401
+
+    assert "custom_components.xsense.webrtc_signal" not in sys.modules


### PR DESCRIPTION
Fixes the camera platform loading the WebRTC media stack during normal entity setup.

- Defers the X-Sense WebRTC bridge import until Home Assistant starts a WebRTC camera session
- Keeps the optional google-crc32c pure-Python warning from surfacing as an X-Sense platform warning
