### PR TITLE
fix: harden camera WebRTC session cleanup

### DIFF
--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -178,7 +178,8 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             send_message=send_message,
         )
         self._webrtc_sessions[session_id] = session
-        await session.start()
+        if not await session.start():
+            self._webrtc_sessions.pop(session_id, None)
 
     async def async_on_webrtc_candidate(self, session_id, candidate) -> None:
         """Forward a Home Assistant WebRTC candidate to X-Sense."""

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.5"
+  "version": "1.2.6.6"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -32,7 +32,7 @@ with warnings.catch_warnings():
         RTCSessionDescription,
     )
     from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
-    from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
+    from aiortc.sdp import candidate_from_sdp
 from homeassistant.components.camera.webrtc import (
     WebRTCAnswer,
     WebRTCError,
@@ -45,9 +45,12 @@ from .const import LOGGER
 
 def _preload_dns_rdata_classes() -> None:
     """Warm dnspython lazy imports used by aioice mDNS outside the event loop."""
-    for rdclass, rdtype in ((32769, 1), (255, 1), (1, 1), (1, 28)):
-        with suppress(Exception):
-            dns.rdata.get_rdata_class(rdclass, rdtype)
+    mdns_classes = (1, 255, 32769)
+    mdns_types = (1, 12, 16, 28, 33, 47)
+    for rdclass in mdns_classes:
+        for rdtype in mdns_types:
+            with suppress(Exception):
+                dns.rdata.get_rdata_class(rdclass, rdtype)
 
 
 _preload_dns_rdata_classes()
@@ -151,7 +154,9 @@ class _ProxyTrack(MediaStreamTrack):
     def __init__(self, kind: str) -> None:
         super().__init__()
         self.kind = kind
-        self._source: asyncio.Future[MediaStreamTrack] = asyncio.get_running_loop().create_future()
+        self._source: asyncio.Future[MediaStreamTrack] = (
+            asyncio.get_running_loop().create_future()
+        )
 
     def set_source(self, track: MediaStreamTrack) -> None:
         """Set the source track once the camera peer receives it."""
@@ -199,46 +204,26 @@ def make_sdp_offer_payload(
     return json.dumps(envelope, separators=(",", ":"))
 
 
-def make_ice_candidate_payload(
-    *,
-    candidate: RTCIceCandidate | RTCIceCandidateInit,
-    ticket: XSenseWebRTCTicket,
-    recipient_client_id: str,
-    session_id: str,
-) -> str:
-    """Return the APK-compatible ICE candidate envelope."""
-    candidate_sdp = _candidate_to_sdp(candidate)
-    sdp_mid = getattr(candidate, "sdpMid", None) or getattr(candidate, "sdp_mid", None)
-    sdp_m_line_index = getattr(candidate, "sdpMLineIndex", None)
-    if sdp_m_line_index is None:
-        sdp_m_line_index = getattr(candidate, "sdp_m_line_index", None)
-    payload = _b64_json(
-        {
-            "sdpMid": sdp_mid,
-            "sdpMLineIndex": sdp_m_line_index,
-            "candidate": candidate_sdp,
-        }
-    )
-    envelope = {
-        "messageType": "ICE_CANDIDATE",
-        "messagePayload": payload,
-        "recipientClientId": recipient_client_id,
-        "senderClientId": ticket.client_id,
-        "sessionId": session_id,
-    }
-    return json.dumps(envelope, separators=(",", ":"))
-
 
 def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
     """Return the APK-compatible data-channel startLive command."""
-    timestamp = int(time.time())
+    message = make_data_channel_command("startLive")
+    message.update(
+        {
+            "size": _map_video_size(resolution),
+            "resolution": resolution,
+        }
+    )
+    return message
+
+
+def make_data_channel_command(action: str) -> dict[str, Any]:
+    """Return the APK-compatible base data-channel command."""
     return {
         "requestID": f"{int(time.time() * 1000)}-{random.randint(0, 999)}",
         "connectionID": "7893feb",
-        "timeStamp": timestamp,
-        "action": "startLive",
-        "size": _map_video_size(resolution),
-        "resolution": resolution,
+        "timeStamp": int(time.time()),
+        "action": action,
     }
 
 
@@ -309,11 +294,12 @@ class XSenseWebRTCSession:
         self._video = _ProxyTrack("video")
         self._audio = _ProxyTrack("audio")
         self._data_channel = None
+        self._pending_ha_candidates: list[RTCIceCandidate] = []
         self._pending_camera_candidates: list[RTCIceCandidate] = []
         self._camera_peer_ready = False
         self._camera_offer_sent = False
 
-    async def start(self) -> None:
+    async def start(self) -> bool:
         """Connect both WebRTC peers and start the X-Sense camera stream."""
         try:
             self._setup_camera_peer()
@@ -322,6 +308,7 @@ class XSenseWebRTCSession:
             await self._ha_pc.setRemoteDescription(
                 RTCSessionDescription(sdp=self._offer_sdp, type="offer")
             )
+            await self._flush_pending_ha_candidates()
             answer = await self._ha_pc.createAnswer()
             await self._ha_pc.setLocalDescription(answer)
             self._send_message(WebRTCAnswer(self._ha_pc.localDescription.sdp))
@@ -333,17 +320,24 @@ class XSenseWebRTCSession:
             )
             self._reader_task = asyncio.create_task(self._read_loop())
             await self._start_camera_peer()
+            return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
             LOGGER.debug("Unable to start X-Sense WebRTC bridge", exc_info=err)
             self._send_message(WebRTCError("xsense_webrtc_start_failed", str(err)))
             await self.close()
+            return False
 
     async def add_candidate(self, candidate: RTCIceCandidateInit) -> None:
-        """Forward a browser ICE candidate to the HA-facing peer."""
-        await self._ha_pc.addIceCandidate(_candidate_init_to_aiortc(candidate))
+        """Forward a browser ICE candidate after the HA offer has been applied."""
+        parsed = _candidate_init_to_aiortc(candidate)
+        if self._ha_pc.remoteDescription is None:
+            self._pending_ha_candidates.append(parsed)
+            return
+        await self._ha_pc.addIceCandidate(parsed)
 
     async def close(self) -> None:
         """Close the X-Sense signaling and WebRTC sessions."""
+        self._send_stop_live()
         if self._reader_task:
             self._reader_task.cancel()
         if self._ws and not self._ws.closed:
@@ -351,24 +345,19 @@ class XSenseWebRTCSession:
         await self._camera_pc.close()
         await self._ha_pc.close()
 
-    def _setup_camera_peer(self) -> None:
-        @self._camera_pc.on("icecandidate")
-        async def on_icecandidate(candidate):
-            if (
-                candidate is not None
-                and self._ws is not None
-                and not self._ws.closed
-                and not _is_localhost_candidate(candidate)
-            ):
-                await self._ws.send_str(
-                    make_ice_candidate_payload(
-                        candidate=candidate,
-                        ticket=self._ticket,
-                        recipient_client_id=self._recipient_client_id,
-                        session_id=self._session_id,
-                    )
+    def _send_stop_live(self) -> None:
+        """Send the APK stopLive data-channel command before closing."""
+        if getattr(self._data_channel, "readyState", None) != "open":
+            return
+        with suppress(Exception):
+            self._data_channel.send(
+                json.dumps(
+                    make_data_channel_command("stopLive"),
+                    separators=(",", ":"),
                 )
+            )
 
+    def _setup_camera_peer(self) -> None:
         @self._camera_pc.on("track")
         def on_track(track):
             if track.kind == "video":
@@ -447,10 +436,17 @@ class XSenseWebRTCSession:
                         )
                     )
 
+    async def _flush_pending_ha_candidates(self) -> None:
+        """Apply queued browser ICE candidates after the HA offer is set."""
+        while self._pending_ha_candidates:
+            await self._ha_pc.addIceCandidate(self._pending_ha_candidates.pop(0))
+
     async def _flush_pending_camera_candidates(self) -> None:
         """Apply queued camera ICE candidates after the APK-style SDP answer gate."""
         while self._pending_camera_candidates:
-            await self._camera_pc.addIceCandidate(self._pending_camera_candidates.pop(0))
+            await self._camera_pc.addIceCandidate(
+                self._pending_camera_candidates.pop(0)
+            )
 
 
 def _camera_rtc_configuration(ticket: XSenseWebRTCTicket) -> AiortcRTCConfiguration:
@@ -501,11 +497,6 @@ def _is_owned_peer_message(payload: Any, serial_number: str) -> bool:
     return isinstance(payload, str) and payload == serial_number
 
 
-def _is_localhost_candidate(candidate: RTCIceCandidate | RTCIceCandidateInit) -> bool:
-    """Return whether the candidate is filtered by the Android app."""
-    candidate_sdp = _candidate_to_sdp(candidate)
-    return "127.0.0.1" in candidate_sdp or "::1" in candidate_sdp
-
 
 def _candidate_payload_to_aiortc(payload: Any) -> RTCIceCandidate | None:
     if not isinstance(payload, dict):
@@ -524,12 +515,6 @@ def _candidate_init_to_aiortc(candidate: RTCIceCandidateInit) -> RTCIceCandidate
     parsed.sdpMid = candidate.sdp_mid
     parsed.sdpMLineIndex = candidate.sdp_m_line_index
     return parsed
-
-
-def _candidate_to_sdp(candidate: RTCIceCandidate | RTCIceCandidateInit) -> str:
-    if isinstance(candidate, RTCIceCandidateInit):
-        return candidate.candidate
-    return candidate_to_sdp(candidate)
 
 
 def _b64_json(data: dict[str, Any]) -> str:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -292,3 +292,62 @@ def test_camera_entity_webrtc_protocol_default_matches_apk():
     assert camera._is_webrtc_camera(entity("SSC0A", {"streamProtocol": "webrtc"}))
     assert not camera._is_webrtc_camera(entity("SSC0A", {"streamProtocol": "rtsp"}))
     assert not camera._is_webrtc_camera(entity("SSC0A", {"streamProtocol": "RTMP"}))
+
+
+async def test_failed_webrtc_start_is_removed_from_active_sessions(monkeypatch):
+    from custom_components.xsense import camera as camera_module
+    from custom_components.xsense.camera import CAMERA_DESCRIPTION, XSenseCameraEntity
+
+    camera_entity = entity("SSC0A", {"streamProtocol": "webrtc", "supportWebrtc": True})
+    camera_entity.entity_id = "camera-test"
+    camera_entity.sn = "SSC0ATEST"
+    camera_entity.name = "Camera"
+    camera_entity.online = True
+
+    async def get_camera_webrtc_ticket(entity):
+        return {"signalServer": "signal"}
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = SimpleNamespace(
+                get_camera_webrtc_ticket=get_camera_webrtc_ticket
+            )
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            pass
+
+        async def start(self):
+            return False
+
+    fake_module = SimpleNamespace(
+        XSenseWebRTCTicket=SimpleNamespace(
+            from_api=lambda serial_number, data: SimpleNamespace()
+        ),
+        XSenseWebRTCSession=FakeSession,
+    )
+
+    class FakeHass:
+        async def async_add_import_executor_job(self, func, module):
+            return fake_module
+
+    monkeypatch.setattr(
+        camera_module, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+
+    camera = XSenseCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+    camera.hass = FakeHass()
+
+    await camera.async_handle_async_webrtc_offer(
+        "v=0\r\n", "session-1", lambda message: None
+    )
+
+    assert camera._webrtc_sessions == {}
+    assert not camera.is_streaming

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -7,7 +7,6 @@ from custom_components.xsense import webrtc_signal
 from custom_components.xsense.webrtc_signal import (
     SIGNAL_DATA_CHANNEL,
     XSenseWebRTCTicket,
-    make_ice_candidate_payload,
     make_sdp_offer_payload,
     make_start_live_data_channel_message,
     parse_signal_message,
@@ -24,7 +23,9 @@ def ticket(**overrides):
         "sign": "sig",
         "time": 123456,
         "expirationTime": 4_102_444_800_000,
-        "iceServer": [{"url": "turn:turn.example", "username": "user", "credential": "secret"}],
+        "iceServer": [
+            {"url": "turn:turn.example", "username": "user", "credential": "secret"}
+        ],
     }
     data.update(overrides)
     return XSenseWebRTCTicket.from_api("SSC0A123", data)
@@ -33,7 +34,9 @@ def ticket(**overrides):
 def test_ticket_connect_details_match_apk(monkeypatch):
     monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100.123)
 
-    signal_ticket = ticket(signalServer="https://signal.example:443", signalServerIpAddress="203.0.113.10")
+    signal_ticket = ticket(
+        signalServer="https://signal.example:443", signalServerIpAddress="203.0.113.10"
+    )
 
     assert signal_ticket.session_id == "Android-client123-100123"
     assert signal_ticket.signal_url() == (
@@ -63,19 +66,6 @@ def test_webrtc_offer_candidate_and_start_live_payloads_match_apk(monkeypatch):
             resolution="1280x720",
         )
     )
-    candidate = json.loads(
-        make_ice_candidate_payload(
-            candidate=RTCIceCandidateInit(
-                "candidate:1 1 udp 1 192.0.2.1 123 typ host",
-                sdp_mid="0",
-                sdp_m_line_index=0,
-            ),
-            ticket=ticket(),
-            recipient_client_id="SSC0A123",
-            session_id="Android-client123-100000",
-        )
-    )
-
     assert SIGNAL_DATA_CHANNEL == "data-channel-of-"
     assert offer | {"messagePayload": "<decoded>"} == {
         "messageType": "SDP_OFFER",
@@ -87,18 +77,9 @@ def test_webrtc_offer_candidate_and_start_live_payloads_match_apk(monkeypatch):
         "viewerType": "a4x_sdk",
         "resolution": "1280x720",
     }
-    assert json.loads(base64.b64decode(offer["messagePayload"])) == {"type": "offer", "sdp": "v=0\r\n"}
-    assert candidate | {"messagePayload": "<decoded>"} == {
-        "messageType": "ICE_CANDIDATE",
-        "messagePayload": "<decoded>",
-        "recipientClientId": "SSC0A123",
-        "senderClientId": "client123",
-        "sessionId": "Android-client123-100000",
-    }
-    assert json.loads(base64.b64decode(candidate["messagePayload"])) == {
-        "sdpMid": "0",
-        "sdpMLineIndex": 0,
-        "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+    assert json.loads(base64.b64decode(offer["messagePayload"])) == {
+        "type": "offer",
+        "sdp": "v=0\r\n",
     }
     assert make_start_live_data_channel_message("2560x1440") == {
         "requestID": "100000-321",
@@ -168,29 +149,101 @@ def test_parse_signal_message_accepts_apk_peer_event_wrappers():
     assert webrtc_signal._is_owned_peer_message("SSC0A123", "SSC0A123")
     assert not webrtc_signal._is_owned_peer_message("SSC0B456", "SSC0A123")
     assert parse_signal_message(
-        json.dumps({"type": "PEER_OUT", "message": json.dumps({"deviceSN": "SSC0B456"})})
+        json.dumps(
+            {"type": "PEER_OUT", "message": json.dumps({"deviceSN": "SSC0B456"})}
+        )
     ) == ("PEER_OUT", "SSC0B456")
 
 
-def test_localhost_ice_candidates_are_filtered_like_apk():
-    assert webrtc_signal._is_localhost_candidate(
-        RTCIceCandidateInit(
-            "candidate:1 1 udp 1 127.0.0.1 123 typ host",
-            sdp_mid="0",
-            sdp_m_line_index=0,
-        )
+
+def test_stop_live_data_channel_command_matches_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    class FakeDataChannel:
+        readyState = "open"
+
+        def __init__(self):
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(message)
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._data_channel = FakeDataChannel()
+
+    session._send_stop_live()
+
+    assert [json.loads(message) for message in session._data_channel.messages] == [
+        {
+            "requestID": "100000-321",
+            "connectionID": "7893feb",
+            "timeStamp": 100,
+            "action": "stopLive",
+        }
+    ]
+
+
+def test_stop_live_is_not_sent_when_data_channel_is_not_open():
+    class FakeDataChannel:
+        readyState = "connecting"
+
+        def __init__(self):
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(message)
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._data_channel = FakeDataChannel()
+
+    session._send_stop_live()
+
+    assert session._data_channel.messages == []
+
+
+def test_dns_preload_covers_mdns_nsec_records(monkeypatch):
+    calls = []
+
+    def record_call(rdclass, rdtype):
+        calls.append((rdclass, rdtype))
+
+    monkeypatch.setattr(webrtc_signal.dns.rdata, "get_rdata_class", record_call)
+
+    webrtc_signal._preload_dns_rdata_classes()
+
+    assert (32769, 47) in calls
+    assert (255, 47) in calls
+
+
+async def test_browser_ice_candidates_wait_for_ha_remote_description():
+    class FakePeer:
+        def __init__(self):
+            self.remoteDescription = None
+            self.candidates = []
+
+        async def addIceCandidate(self, candidate):
+            if self.remoteDescription is None:
+                raise AssertionError("candidate added before remote description")
+            self.candidates.append(candidate)
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._ha_pc = FakePeer()
+    session._pending_ha_candidates = []
+
+    candidate = RTCIceCandidateInit(
+        "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+        sdp_mid="0",
+        sdp_m_line_index=0,
     )
-    assert webrtc_signal._is_localhost_candidate(
-        RTCIceCandidateInit(
-            "candidate:1 1 udp 1 ::1 123 typ host",
-            sdp_mid="0",
-            sdp_m_line_index=0,
-        )
-    )
-    assert not webrtc_signal._is_localhost_candidate(
-        RTCIceCandidateInit(
-            "candidate:1 1 udp 1 192.0.2.1 123 typ host",
-            sdp_mid="0",
-            sdp_m_line_index=0,
-        )
-    )
+
+    await session.add_candidate(candidate)
+
+    assert session._pending_ha_candidates
+    assert session._ha_pc.candidates == []
+
+    session._ha_pc.remoteDescription = object()
+    await session._flush_pending_ha_candidates()
+
+    assert session._pending_ha_candidates == []
+    assert len(session._ha_pc.candidates) == 1


### PR DESCRIPTION
## Summary
- Queue Home Assistant/browser ICE candidates until the HA offer is applied, matching the WebRTC ordering required by aiortc.
- Send the APK-style stopLive data-channel command before closing an X-Sense camera session.
- Preload additional dnspython mDNS record classes used by aioice and remove dead outgoing trickle-ICE code that aiortc does not emit.
- Clean up failed WebRTC session startup so failed attempts do not leave cameras marked as streaming.

## Tests
- /root/codex-work/ha-xsense-component_test/.venv/bin/python -m pytest -q
- git diff --check
- Installed on Steve Home Assistant and restarted successfully before release.
