### PR TITLE
fix: align camera WebRTC signaling with app

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.6"
+  "version": "1.2.6.7"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -45,8 +45,8 @@ from .const import LOGGER
 
 def _preload_dns_rdata_classes() -> None:
     """Warm dnspython lazy imports used by aioice mDNS outside the event loop."""
-    mdns_classes = (1, 255, 32769)
-    mdns_types = (1, 12, 16, 28, 33, 47)
+    mdns_classes = (1, 255, 512, 1232, 1280, 1400, 1440, 1500, 4096, 32769)
+    mdns_types = (1, 12, 16, 28, 33, 41, 47)
     for rdclass in mdns_classes:
         for rdtype in mdns_types:
             with suppress(Exception):
@@ -189,7 +189,9 @@ def make_sdp_offer_payload(
     resolution: str | None,
 ) -> str:
     """Return the APK-compatible SDP offer envelope."""
-    payload = _b64_json({"type": "offer", "sdp": offer_sdp})
+    payload = _b64_json(
+        {"type": "offer", "sdp": _sdp_without_local_candidates(offer_sdp)}
+    )
     envelope: dict[str, Any] = {
         "messageType": "SDP_OFFER",
         "messagePayload": payload,
@@ -203,6 +205,32 @@ def make_sdp_offer_payload(
         envelope["resolution"] = resolution
     return json.dumps(envelope, separators=(",", ":"))
 
+
+def make_ice_candidate_payload(
+    *,
+    candidate: str,
+    sdp_mid: str | None,
+    sdp_m_line_index: int,
+    ticket: XSenseWebRTCTicket,
+    recipient_client_id: str,
+    session_id: str,
+) -> str:
+    """Return the APK-compatible ICE_CANDIDATE signal envelope."""
+    payload = _b64_json(
+        {
+            "sdpMid": sdp_mid,
+            "sdpMLineIndex": sdp_m_line_index,
+            "candidate": candidate,
+        }
+    )
+    envelope: dict[str, Any] = {
+        "messageType": "ICE_CANDIDATE",
+        "messagePayload": payload,
+        "recipientClientId": recipient_client_id,
+        "senderClientId": ticket.client_id,
+        "sessionId": session_id,
+    }
+    return json.dumps(envelope, separators=(",", ":"))
 
 
 def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
@@ -298,6 +326,8 @@ class XSenseWebRTCSession:
         self._pending_camera_candidates: list[RTCIceCandidate] = []
         self._camera_peer_ready = False
         self._camera_offer_sent = False
+        self._camera_peer_connected = False
+        self._start_live_sent = False
 
     async def start(self) -> bool:
         """Connect both WebRTC peers and start the X-Sense camera stream."""
@@ -369,12 +399,28 @@ class XSenseWebRTCSession:
 
         @self._data_channel.on("open")
         def on_open():
-            self._data_channel.send(
-                json.dumps(
-                    make_start_live_data_channel_message(self._resolution),
-                    separators=(",", ":"),
-                )
+            self._send_start_live_if_ready()
+
+        @self._camera_pc.on("connectionstatechange")
+        def on_connectionstatechange():
+            self._camera_peer_connected = self._camera_pc.connectionState == "connected"
+            self._send_start_live_if_ready()
+
+    def _send_start_live_if_ready(self) -> None:
+        """Send startLive when the APK would: data channel open and peer connected."""
+        if (
+            self._start_live_sent
+            or not self._camera_peer_connected
+            or getattr(self._data_channel, "readyState", None) != "open"
+        ):
+            return
+        self._data_channel.send(
+            json.dumps(
+                make_start_live_data_channel_message(self._resolution),
+                separators=(",", ":"),
             )
+        )
+        self._start_live_sent = True
 
     async def _start_camera_peer(self) -> None:
         self._camera_pc.addTransceiver("video", direction="recvonly")
@@ -400,7 +446,24 @@ class XSenseWebRTCSession:
                 resolution=self._resolution,
             )
         )
+        await self._send_local_ice_candidates()
         self._camera_offer_sent = True
+
+    async def _send_local_ice_candidates(self) -> None:
+        """Send gathered local ICE candidates over the X-Sense signal server."""
+        if self._ws is None or self._camera_pc.localDescription is None:
+            return
+        for candidate in _local_sdp_candidates(self._camera_pc.localDescription.sdp):
+            await self._ws.send_str(
+                make_ice_candidate_payload(
+                    candidate=candidate["candidate"],
+                    sdp_mid=candidate["sdpMid"],
+                    sdp_m_line_index=candidate["sdpMLineIndex"],
+                    ticket=self._ticket,
+                    recipient_client_id=self._recipient_client_id,
+                    session_id=self._session_id,
+                )
+            )
 
     async def _read_loop(self) -> None:
         if self._ws is None:
@@ -496,6 +559,43 @@ def _is_owned_peer_message(payload: Any, serial_number: str) -> bool:
     """Return whether a PEER_IN/PEER_OUT payload belongs to this camera."""
     return isinstance(payload, str) and payload == serial_number
 
+
+def _sdp_without_local_candidates(sdp: str) -> str:
+    """Return the createOffer-style SDP before local ICE candidates are appended."""
+    lines = [
+        line
+        for line in sdp.splitlines()
+        if not line.startswith("a=candidate:")
+        and not line.startswith("a=end-of-candidates")
+    ]
+    ending = "\r\n" if "\r\n" in sdp else "\n"
+    return ending.join(lines) + (ending if sdp.endswith(("\r\n", "\n")) else "")
+
+
+def _local_sdp_candidates(sdp: str) -> list[dict[str, Any]]:
+    """Return APK-style candidate payloads from a gathered local SDP."""
+    candidates: list[dict[str, Any]] = []
+    current_mid: str | None = None
+    current_index = -1
+    for raw_line in sdp.splitlines():
+        line = raw_line.strip()
+        if line.startswith("m="):
+            current_index += 1
+            current_mid = None
+        elif line.startswith("a=mid:"):
+            current_mid = line.removeprefix("a=mid:")
+        elif line.startswith("a=candidate:"):
+            candidate = line.removeprefix("a=")
+            if "127.0.0.1" in candidate or "::1" in candidate:
+                continue
+            candidates.append(
+                {
+                    "sdpMid": current_mid,
+                    "sdpMLineIndex": current_index,
+                    "candidate": candidate,
+                }
+            )
+    return candidates
 
 
 def _candidate_payload_to_aiortc(payload: Any) -> RTCIceCandidate | None:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -7,6 +7,7 @@ from custom_components.xsense import webrtc_signal
 from custom_components.xsense.webrtc_signal import (
     SIGNAL_DATA_CHANNEL,
     XSenseWebRTCTicket,
+    make_ice_candidate_payload,
     make_sdp_offer_payload,
     make_start_live_data_channel_message,
     parse_signal_message,
@@ -94,6 +95,123 @@ def test_webrtc_offer_candidate_and_start_live_payloads_match_apk(monkeypatch):
         webrtc_signal._camera_rtc_configuration(ticket()).bundlePolicy.value
         == "max-bundle"
     )
+
+
+def test_sdp_offer_payload_strips_local_candidates_like_apk_create_offer():
+    sdp = (
+        "v=0\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n"
+        "a=mid:0\r\n"
+        "a=candidate:1 1 udp 1 192.0.2.1 123 typ host\r\n"
+        "a=end-of-candidates\r\n"
+    )
+
+    offer = json.loads(
+        make_sdp_offer_payload(
+            offer_sdp=sdp,
+            ticket=ticket(),
+            recipient_client_id="SSC0A123",
+            session_id="Android-client123-100000",
+            resolution="1280x720",
+        )
+    )
+
+    decoded = json.loads(base64.b64decode(offer["messagePayload"]))
+    assert decoded["type"] == "offer"
+    assert "a=candidate:" not in decoded["sdp"]
+    assert "a=end-of-candidates" not in decoded["sdp"]
+    assert decoded["sdp"].endswith("\r\n")
+
+
+def test_webrtc_ice_candidate_payload_matches_apk():
+    payload = json.loads(
+        make_ice_candidate_payload(
+            candidate="candidate:1 1 udp 1 192.0.2.1 123 typ host",
+            sdp_mid="0",
+            sdp_m_line_index=0,
+            ticket=ticket(),
+            recipient_client_id="SSC0A123",
+            session_id="Android-client123-100000",
+        )
+    )
+
+    assert payload | {"messagePayload": "<decoded>"} == {
+        "messageType": "ICE_CANDIDATE",
+        "messagePayload": "<decoded>",
+        "recipientClientId": "SSC0A123",
+        "senderClientId": "client123",
+        "sessionId": "Android-client123-100000",
+    }
+    assert json.loads(base64.b64decode(payload["messagePayload"])) == {
+        "sdpMid": "0",
+        "sdpMLineIndex": 0,
+        "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+    }
+
+
+def test_local_sdp_candidates_extracts_apk_payloads_and_skips_loopback():
+    sdp = """v=0
+m=video 9 UDP/TLS/RTP/SAVPF 96
+a=mid:0
+a=candidate:1 1 udp 1 192.0.2.1 123 typ host
+a=candidate:2 1 udp 1 127.0.0.1 456 typ host
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:1
+a=candidate:3 1 udp 1 2001:db8::1 789 typ host
+a=candidate:4 1 udp 1 ::1 790 typ host
+"""
+
+    assert webrtc_signal._local_sdp_candidates(sdp) == [
+        {
+            "sdpMid": "0",
+            "sdpMLineIndex": 0,
+            "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+        },
+    ]
+
+
+async def test_send_offer_sends_apk_offer_then_local_ice_candidates():
+    class FakeWs:
+        def __init__(self):
+            self.messages = []
+
+        async def send_str(self, message):
+            self.messages.append(json.loads(message))
+
+    class FakeDescription:
+        sdp = """v=0
+m=video 9 UDP/TLS/RTP/SAVPF 96
+a=mid:0
+a=candidate:1 1 udp 1 192.0.2.1 123 typ host
+"""
+
+    class FakePeer:
+        localDescription = FakeDescription()
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._ws = FakeWs()
+    session._camera_pc = FakePeer()
+    session._camera_peer_ready = True
+    session._camera_offer_sent = False
+    session._ticket = ticket()
+    session._recipient_client_id = "SSC0A123"
+    session._session_id = "Android-client123-100000"
+    session._resolution = "1280x720"
+
+    await session._send_offer()
+
+    assert [message["messageType"] for message in session._ws.messages] == [
+        "SDP_OFFER",
+        "ICE_CANDIDATE",
+    ]
+    assert session._ws.messages[1] | {"messagePayload": "<decoded>"} == {
+        "messageType": "ICE_CANDIDATE",
+        "messagePayload": "<decoded>",
+        "recipientClientId": "SSC0A123",
+        "senderClientId": "client123",
+        "sessionId": "Android-client123-100000",
+    }
+    assert session._camera_offer_sent is True
 
 
 def test_parse_signal_message_preserves_answer_envelope_for_apk_validation():
@@ -214,6 +332,48 @@ def test_dns_preload_covers_mdns_nsec_records(monkeypatch):
 
     assert (32769, 47) in calls
     assert (255, 47) in calls
+    assert (1440, 41) in calls
+
+
+def test_start_live_waits_for_data_channel_and_connected_camera_peer(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    class FakeDataChannel:
+        def __init__(self):
+            self.readyState = "connecting"
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(message)
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._resolution = "2560x1440"
+    session._data_channel = FakeDataChannel()
+    session._camera_peer_connected = False
+    session._start_live_sent = False
+
+    session._send_start_live_if_ready()
+    assert session._data_channel.messages == []
+
+    session._data_channel.readyState = "open"
+    session._send_start_live_if_ready()
+    assert session._data_channel.messages == []
+
+    session._camera_peer_connected = True
+    session._send_start_live_if_ready()
+    session._send_start_live_if_ready()
+
+    assert [json.loads(message) for message in session._data_channel.messages] == [
+        {
+            "requestID": "100000-321",
+            "connectionID": "7893feb",
+            "timeStamp": 100,
+            "action": "startLive",
+            "size": "1920x1080",
+            "resolution": "2560x1440",
+        }
+    ]
 
 
 async def test_browser_ice_candidates_wait_for_ha_remote_description():


### PR DESCRIPTION
Aligns camera WebRTC signaling more closely with the X-Sense Android app: candidate-free SDP offers, separate ICE candidate messages, connected-peer startLive timing, and DNS preload coverage for the recent camera startup warning. Validation: 32 focused camera and WebRTC tests passed, full suite 192 passed, and the 1.2.6.7 candidate was installed on Steve Home Assistant before release.