### PR TITLE
Fix APK shadow routing and WebRTC cleanup

### DIFF
--- a/.github/release-notes/v.1.2.6.9.md
+++ b/.github/release-notes/v.1.2.6.9.md
@@ -1,0 +1,17 @@
+## 🔧 v.1.2.6.9
+
+A focused reliability hotfix for child-device shadow updates and WebRTC camera cleanup.
+
+### 🛠️ Fixed
+
+- 📡 Routed MQTT `devs` child payloads through the same APK-style state parser used by full shadow reads.
+- 🧭 Matched child-device updates by the serial fields used in X-Sense shadow payloads instead of only the raw map key.
+- 🎥 Fixed WebRTC camera cleanup when a live-view timeout closes the session, preventing the timeout task from cancelling itself.
+- ⏱️ Added coverage to keep the old broad integration login timeout from coming back.
+
+### 🔎 Validation
+
+- ✅ Installed and restarted on Steve Home Assistant before release.
+- ✅ X-Sense loaded and the smoke alarm entities came back online.
+- ✅ Full test suite passed.
+- ✅ APK-alignment pass completed for child shadow routing, camera WebRTC signaling, and active entity exposure.

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -287,9 +287,9 @@ class XSenseBase:
             has_alarm_status and _is_active_state(station.data.get("alarmStatus"))
         )
         if isinstance(children, dict):
-            for sn, i in children.items():
-                if dev := station.get_device_by_sn(sn):
-                    dev.set_data(i)
+            for child_key, child_state in children.items():
+                if dev := _state_child_device(station, child_key, child_state):
+                    dev.set_data(child_state)
 
     def _parse_get_house_state(self, house: House, data: Dict):
         for sn, i in data.items():
@@ -302,6 +302,39 @@ class XSenseBase:
                 a for a in entity_def.get("actions", []) if a.get("action") == action
             )
         return False
+
+
+def _state_child_device(station: Station, child_key, child_state):
+    """Return the child device targeted by an APK shadow payload."""
+    for value in _child_state_identifiers(child_key, child_state):
+        if dev := station.get_device_by_sn(value):
+            return dev
+    return None
+
+
+def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:
+    """Return device serial identifiers used by X-Sense child shadows."""
+    values = [child_key]
+    if isinstance(child_state, dict):
+        values.extend(
+            child_state.get(key)
+            for key in (
+                "deviceSN",
+                "deviceSn",
+                "_deviceSN",
+                "_deviceSn",
+            )
+        )
+    seen = set()
+    result = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return tuple(result)
 
 
 def _apply_group_light_state(station: Station, station_data: Dict, children) -> bool:

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -355,13 +355,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ):
             dev.set_data(station_data)
         else:
-            if isinstance(children, list):
+            if isinstance(children, (dict, list)):
                 station_data["devs"] = children
             self.xsense.parse_get_state(station, station_data)
-        if isinstance(children, dict):
-            for k, v in children.items():
-                if dev := station.get_device_by_sn(k):
-                    dev.set_data(v)
 
         self.async_update_listeners()
 

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.8"
+  "version": "1.2.6.9"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -437,10 +437,11 @@ class XSenseWebRTCSession:
             return None
 
     async def _cancel_task(self, task: asyncio.Task[Any] | None) -> None:
-        if task and not task.done():
-            task.cancel()
-            with suppress(asyncio.CancelledError, Exception):
-                await task
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError, Exception):
+            await task
 
     async def _fail_after_timeout(self, delay: int, code: str, message: str) -> None:
         try:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -590,6 +590,63 @@ def test_station_alarm_data_preserves_explicit_falsy_values():
     assert station_obj.alarm_data["forceArm"] is False
 
 
+def test_parse_get_state_updates_child_from_apk_device_serial_field():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS10",
+    )
+    station_obj.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "device-id",
+                    "deviceName": "Door",
+                    "deviceSn": "child-sn",
+                    "deviceType": "SDS0A",
+                }
+            ]
+        }
+    )
+
+    client.parse_get_state(
+        station_obj,
+        {"devs": {"state-key": {"_deviceSN": "child-sn", "onLine": "1"}}},
+    )
+
+    assert station_obj.devices["device-id"].online is True
+
+
+def test_parse_get_state_updates_child_when_apk_key_is_device_serial():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS50",
+    )
+    station_obj.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "device-id",
+                    "deviceName": "Sensor",
+                    "deviceSn": "child-sn",
+                    "deviceType": "XS03-iWX",
+                }
+            ]
+        }
+    )
+
+    client.parse_get_state(station_obj, {"devs": {"child-sn": {"onLine": "0"}}})
+
+    assert station_obj.devices["device-id"].online is False
+
+
 def test_parse_get_state_does_not_use_stale_alarm_status_when_missing():
     client = async_xsense.AsyncXSense()
     station_obj = station.Station(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,6 +3,17 @@ import pytest
 from custom_components.xsense.coordinator import _is_self_test_topic
 
 
+def test_connect_path_does_not_reintroduce_integration_login_timeout():
+    import inspect
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    source = inspect.getsource(XSenseDataUpdateCoordinator._connect)
+
+    assert "wait_for" not in source
+    assert "LOGIN_TIMEOUT" not in source
+    assert "Timed out connecting" not in source
+
+
 def test_self_test_topic_detection_matches_apk_markers():
     assert _is_self_test_topic(
         "$aws/things/SBS50sn/shadow/name/selftestup/update"
@@ -86,6 +97,45 @@ class PresenceHouse:
 
     def get_station_by_sn(self, _identifier):
         return None
+
+
+def test_mqtt_child_devs_payload_is_routed_to_apk_state_parser():
+    from types import SimpleNamespace
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Station:
+        sn = "station-sn"
+        shadow_name = "SBS10station-sn"
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    station = Station()
+    parsed = []
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(
+        houses={"house-id": PresenceHouse(station)},
+        parse_get_state=lambda station_arg, data: parsed.append((station_arg, data)),
+    )
+    coordinator.async_update_listeners = lambda: None
+
+    coordinator.async_event_received(
+        "$aws/things/SBS10station-sn/shadow/name/mainpage/update",
+        (
+            '{"state":{"reported":{"stationSN":"station-sn",'
+            '"devs":{"shadow-key":{"_deviceSN":"child-sn","onLine":"1"}}}}}'
+        ).encode(),
+    )
+
+    assert parsed == [
+        (
+            station,
+            {
+                "stationSN": "station-sn",
+                "devs": {"shadow-key": {"_deviceSN": "child-sn", "onLine": "1"}},
+            },
+        )
+    ]
 
 
 def test_presence_topic_updates_station_online_like_apk():

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -588,6 +588,39 @@ async def test_camera_offer_is_sent_before_waiting_for_local_ice_gathering():
         await task
 
 
+async def test_webrtc_close_does_not_cancel_current_timeout_task():
+    import asyncio
+
+    class FakePeerConnection:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._close_lock = asyncio.Lock()
+    session._reader_task = None
+    session._peer_in_timeout_task = None
+    session._play_timeout_task = asyncio.current_task()
+    session._first_frame_timeout_task = None
+    session._camera_local_description_task = None
+    session._ws = None
+    session._data_channel = None
+    session._camera_pc = FakePeerConnection()
+    session._ha_pc = FakePeerConnection()
+    session._pending_ha_candidates = []
+    session._pending_camera_candidates = []
+
+    await session.close()
+
+    assert session._closed is True
+    assert session._camera_pc.closed is True
+    assert session._ha_pc.closed is True
+    assert not asyncio.current_task().cancelled()
+
+
 async def test_webrtc_timeout_reports_error_and_closes_session():
     import asyncio
 


### PR DESCRIPTION
## Summary

This hotfix keeps the integration aligned with the Android app behavior for child-device shadow updates and camera WebRTC cleanup.

## Changes

- Route MQTT `devs` child payloads through the same APK-style state parser used by full shadow reads.
- Match child-device shadow updates by X-Sense serial fields such as `deviceSN` and `_deviceSN`, instead of only the raw map key.
- Avoid cancelling/awaiting the currently running WebRTC timeout task while closing a camera session.
- Bump the integration to `1.2.6.9` and add focused release notes.

## Validation

- Installed and restarted on Steve's Home Assistant before release prep.
- X-Sense config entry loaded after restart.
- Smoke alarm entities came back online after restart.
- `python -m pytest -q` passed: 211 tests.
- `python -m compileall -q custom_components tests` passed.
- `git diff --check` passed.
