### PR TITLE
Fix HA compatibility, SBS10 state parsing, and WebRTC cleanup

### DIFF
--- a/.github/release-notes/v.1.2.6.10.md
+++ b/.github/release-notes/v.1.2.6.10.md
@@ -1,0 +1,17 @@
+## 🔧 v.1.2.6.10
+
+A focused compatibility and reliability hotfix for Home Assistant 2026.5/2026.6, SBS10 child devices, and WebRTC camera cleanup.
+
+### 🛠️ Fixed
+
+- 🧩 Handled both Home Assistant MQTT subscription constructor shapes so older and newer supported HA builds can load the integration.
+- 📡 Parsed SBS10 child-device `mainpage` reports when X-Sense sends the APK-style device list instead of a `devs` map.
+- 🧪 Matched SBS10 smoke RF self-test commands to the APK target/shadow path for `XS01-M` and `XS03-iWX` devices.
+- 🚨 Limited the SBS50 alarm control panel to security-device setups instead of smoke-only stations.
+- 🎥 Tightened WebRTC camera cleanup to stop tracks, transports, senders, and receivers before closing peer connections.
+
+### 🔎 Validation
+
+- ✅ Full test suite passed.
+- ✅ Python compile check passed.
+- ✅ APK-alignment pass completed for MQTT subscriptions, SBS10 device reports, smoke RF self-test, SBS50 alarm panel exposure, and WebRTC close behavior.

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import XSenseDataUpdateCoordinator
+from .api.entity_map import EntityType, entities as entity_definitions
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ async def async_setup_entry(
     entities = []
     for house in coordinator.xsense.houses.values():
         for station in house.stations.values():
-            if station.type == "SBS50":
+            if station_supports_alarm_panel(station):
                 LOGGER.debug(
                     "Creating alarm control panel for station %s (%s)",
                     station.sn,
@@ -50,7 +51,30 @@ async def async_setup_entry(
     if entities:
         async_add_entities(entities)
     else:
-        LOGGER.debug("No SBS50 base station found; alarm control panel skipped")
+        LOGGER.debug(
+            "No SBS50 security alarm base station found; alarm control panel skipped"
+        )
+
+
+ALARM_PANEL_DEVICE_TYPES = {
+    EntityType.DOOR,
+    EntityType.KEYPAD,
+    EntityType.MOTION,
+    EntityType.REMOTE,
+}
+
+
+def station_supports_alarm_panel(station) -> bool:
+    """Return whether the app exposes SBS50 security alarm modes for this station."""
+    if station.type != "SBS50":
+        return False
+
+    for device in station.devices.values():
+        definition = entity_definitions.get(device.type)
+        if definition and definition.get("type") in ALARM_PANEL_DEVICE_TYPES:
+            return True
+
+    return False
 
 
 class XSenseAlarmControlPanel(

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -273,8 +273,12 @@ class XSenseBase:
             )
 
     def parse_get_state(self, station: Station, data: Dict):
-        station_data = data.copy()
-        children = station_data.pop("devs", {}) or {}
+        if isinstance(data, list):
+            station_data = {}
+            children = data
+        else:
+            station_data = data.copy()
+            children = station_data.pop("devs", {}) or {}
 
         if _apply_group_light_state(station, station_data, children):
             return
@@ -283,13 +287,12 @@ class XSenseBase:
         if station_data:
             station.set_data(station_data)
 
-        station.has_alarm = _is_active_state(data.get("activate")) or (
+        station.has_alarm = _is_active_state(station_data.get("activate")) or (
             has_alarm_status and _is_active_state(station.data.get("alarmStatus"))
         )
-        if isinstance(children, dict):
-            for child_key, child_state in children.items():
-                if dev := _state_child_device(station, child_key, child_state):
-                    dev.set_data(child_state)
+        for child_key, child_state in _child_state_items(children):
+            if dev := _state_child_device(station, child_key, child_state):
+                dev.set_data(child_state)
 
     def _parse_get_house_state(self, house: House, data: Dict):
         for sn, i in data.items():
@@ -310,6 +313,16 @@ def _state_child_device(station: Station, child_key, child_state):
         if dev := station.get_device_by_sn(value):
             return dev
     return None
+
+
+def _child_state_items(children):
+    """Yield child device shadow records in the list/dict forms used by the app."""
+    if isinstance(children, dict):
+        yield from children.items()
+    elif isinstance(children, list):
+        for child_state in children:
+            if isinstance(child_state, dict):
+                yield None, child_state
 
 
 def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:

--- a/custom_components/xsense/api/entity_map.py
+++ b/custom_components/xsense/api/entity_map.py
@@ -69,11 +69,20 @@ def _smoke_rf_test_shadow(entity) -> str:
 
 
 def _smoke_rf_test_extra(entity) -> Dict:
-    return {"userParam": "source=1"} if _is_smoke_v9(entity) else {}
+    return {"userParam": "source=1"}
+
+
+def _smoke_rf_test_target(entity):
+    station = getattr(entity, "station", entity)
+    if _is_smoke_v9(entity) or getattr(station, "type", None) == "SBS50":
+        return station
+    return _ThingTarget(station, f"{entity.type}{station.sn}")
 
 
 def SmokeRFTestAction():
-    return TestAction(_smoke_rf_test_shadow, extra=_smoke_rf_test_extra)
+    return TestAction(
+        _smoke_rf_test_shadow, extra=_smoke_rf_test_extra, target=_smoke_rf_test_target
+    )
 
 
 class _ThingTarget:

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
 from dataclasses import dataclass
 from importlib import import_module
@@ -22,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api.async_xsense import camera_live_resolution, is_camera_entity
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
 
@@ -68,6 +69,7 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         Camera.__init__(self)
         self.entity_description = entity_description
         self._webrtc_sessions: dict[str, object] = {}
+        self._webrtc_close_tasks: set[asyncio.Task] = set()
         super().__init__(coordinator, entity)
 
     @callback
@@ -125,13 +127,9 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         entity = self._current_entity()
         if entity is None:
             return None
-        source = await self.coordinator.xsense.start_camera_live(entity)
-        if _url_scheme(source) == "webrtc":
-            LOGGER.info(
-                "X-Sense camera %s returned an ADDX WebRTC stream that Home Assistant's native stream worker cannot open",
-                entity.entity_id,
-            )
+        if _is_webrtc_camera(entity):
             return None
+        source = await self.coordinator.xsense.start_camera_live(entity)
         return source
 
     @callback
@@ -180,16 +178,22 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             )
             return
 
+        def remove_session() -> None:
+            if self._webrtc_sessions.get(session_id) is session:
+                self._webrtc_sessions.pop(session_id, None)
+
         session = webrtc_signal.XSenseWebRTCSession(
             session=async_get_clientsession(self.hass),
             ticket=ticket,
             offer_sdp=offer_sdp,
             resolution=_camera_live_resolution(entity),
             send_message=send_message,
+            on_close=remove_session,
         )
         self._webrtc_sessions[session_id] = session
         if not await session.start():
-            self._webrtc_sessions.pop(session_id, None)
+            await session.close()
+            remove_session()
 
     async def async_on_webrtc_candidate(self, session_id, candidate) -> None:
         """Forward a Home Assistant WebRTC candidate to X-Sense."""
@@ -200,25 +204,27 @@ class XSenseCameraEntity(XSenseEntity, Camera):
     def close_webrtc_session(self, session_id: str) -> None:
         """Close an X-Sense WebRTC session."""
         if session := self._webrtc_sessions.pop(session_id, None):
-            self.hass.async_create_task(session.close())
+            task = self.hass.async_create_task(session.close())
+            self._webrtc_close_tasks.add(task)
+            task.add_done_callback(self._webrtc_close_tasks.discard)
         super().close_webrtc_session(session_id)
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop any live view session when Home Assistant removes the entity."""
-        for session_id in list(self._webrtc_sessions):
-            self.close_webrtc_session(session_id)
+        sessions = list(self._webrtc_sessions.values())
+        self._webrtc_sessions.clear()
+        for session in sessions:
+            await session.close()
+        close_tasks = list(self._webrtc_close_tasks)
+        self._webrtc_close_tasks.clear()
+        for task in close_tasks:
+            with suppress(asyncio.CancelledError, Exception):
+                await task
         entity = self._current_entity()
         if entity is not None and entity.data.get("cameraLiveUrl"):
             with suppress(Exception):
                 await self.coordinator.xsense.stop_camera_live(entity)
         await super().async_will_remove_from_hass()
-
-
-def _url_scheme(url: str | None) -> str | None:
-    """Return the URL scheme without exposing the full stream URL."""
-    if not isinstance(url, str) or "://" not in url:
-        return None
-    return url.split("://", 1)[0].lower()
 
 
 def _stream_protocol(entity) -> str | None:

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -303,8 +303,11 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         station_data = _mqtt_reported_data(data)
 
-        station_sn = station_data.get("stationSN") or station_data.get("_stationSN")
-        device_sn = station_data.get("deviceSN") or station_data.get("_deviceSN")
+        station_sn = None
+        device_sn = None
+        if isinstance(station_data, dict):
+            station_sn = station_data.get("stationSN") or station_data.get("_stationSN")
+            device_sn = station_data.get("deviceSN") or station_data.get("_deviceSN")
 
         station = self._get_station_by_id(station_sn)
         if station is None:
@@ -326,6 +329,11 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if event_type := data.get("eventType"):
                 station._set_online(event_type == "connected")
                 self.async_update_listeners()
+            return
+
+        if isinstance(station_data, list):
+            self.xsense.parse_get_state(station, station_data)
+            self.async_update_listeners()
             return
 
         is_safemode_topic = "/shadow/name/2nd_safemode/update" in topic
@@ -446,11 +454,13 @@ def _apply_safe_mode(station, safe_mode: str) -> None:
     station._data["safeMode"] = safe_mode
 
 
-def _mqtt_reported_data(data: dict[str, Any]) -> dict[str, Any]:
+def _mqtt_reported_data(data: dict[str, Any]) -> dict[str, Any] | list[Any]:
     """Return device data from either shadow reports or X-Sense event payloads."""
     reported = data.get("state", {}).get("reported")
     if isinstance(reported, dict):
         return reported.copy()
+    if isinstance(reported, list):
+        return list(reported)
 
     event_data = data.get("eventData")
     if isinstance(event_data, dict):

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.9"
+  "version": "1.2.6.10"
 }

--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, Callable, Coroutine, Iterable
 import contextlib
 from functools import lru_cache, partial
 from itertools import chain
+import inspect
 import logging
 from typing import Any
 
@@ -45,6 +46,14 @@ MAX_PACKETS_TO_READ = 500
 
 type SocketType = mqtt.WebsocketWrapper | Any
 type PublishPayloadType = str | bytes | int | float | None
+
+
+def _subscription_accepts_id() -> bool:
+    """Return whether this Home Assistant version wants subscription_id."""
+    try:
+        return "subscription_id" in inspect.signature(Subscription).parameters
+    except (TypeError, ValueError):
+        return False
 
 
 class XSenseMQTT:
@@ -492,6 +501,9 @@ class XSenseMQTT:
         matcher = None if is_simple_match else _matcher_for_topic(topic)
 
         self._subscription_id += 1
+        subscription_kwargs = {}
+        if _subscription_accepts_id():
+            subscription_kwargs["subscription_id"] = self._subscription_id
         subscription = Subscription(
             topic,
             is_simple_match,
@@ -499,7 +511,7 @@ class XSenseMQTT:
             job,
             qos,
             encoding,
-            self._subscription_id,
+            **subscription_kwargs,
         )
 
         self._async_track_subscription(subscription)

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -315,12 +315,14 @@ class XSenseWebRTCSession:
         resolution: str | None,
         send_message: WebRTCSendMessage,
         session_id: str | None = None,
+        on_close: Callable[[], None] | None = None,
     ) -> None:
         self._session = session
         self._ticket = ticket
         self._offer_sdp = offer_sdp
         self._resolution = resolution or _DEFAULT_RESOLUTION
         self._send_message = send_message
+        self._on_close = on_close
         self._session_id = session_id or ticket.session_id
         self._recipient_client_id = ticket.serial_number
         self._ws: aiohttp.ClientWebSocketResponse | None = None
@@ -421,11 +423,42 @@ class XSenseWebRTCSession:
                 with suppress(Exception):
                     self._data_channel.close()
             with suppress(Exception):
-                await self._camera_pc.close()
+                self._video.stop()
             with suppress(Exception):
-                await self._ha_pc.close()
+                self._audio.stop()
+            await self._stop_peer_connection(self._camera_pc)
+            await self._stop_peer_connection(self._ha_pc)
             self._pending_ha_candidates.clear()
             self._pending_camera_candidates.clear()
+            on_close = getattr(self, "_on_close", None)
+            if on_close:
+                with suppress(Exception):
+                    on_close()
+
+    async def _stop_peer_connection(self, peer_connection: RTCPeerConnection) -> None:
+        """Stop media transports before closing, matching the APK stop path."""
+        get_transceivers = getattr(peer_connection, "getTransceivers", lambda: [])
+        get_senders = getattr(peer_connection, "getSenders", lambda: [])
+        get_receivers = getattr(peer_connection, "getReceivers", lambda: [])
+        for transceiver in list(get_transceivers()):
+            with suppress(Exception):
+                await transceiver.stop()
+            sender = getattr(transceiver, "sender", None)
+            if sender is not None:
+                with suppress(Exception):
+                    await sender.stop()
+            receiver = getattr(transceiver, "receiver", None)
+            if receiver is not None:
+                with suppress(Exception):
+                    await receiver.stop()
+        for sender in list(get_senders()):
+            with suppress(Exception):
+                await sender.stop()
+        for receiver in list(get_receivers()):
+            with suppress(Exception):
+                await receiver.stop()
+        with suppress(Exception):
+            await peer_connection.close()
 
     def _create_task(
         self, coro: Coroutine[Any, Any, Any]

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -194,6 +194,40 @@ def _subscription_test_client():
 
 
 @pytest.mark.asyncio
+async def test_xsense_mqtt_omits_subscription_id_when_ha_signature_lacks_it(monkeypatch):
+    created = []
+
+    class FakeSubscription:
+        def __init__(
+            self,
+            topic,
+            is_simple_match,
+            complex_matcher,
+            job,
+            qos=0,
+            encoding="utf-8",
+        ):
+            self.topic = topic
+            self.is_simple_match = is_simple_match
+            self.complex_matcher = complex_matcher
+            self.job = job
+            self.qos = qos
+            self.encoding = encoding
+            created.append(topic)
+
+    monkeypatch.setattr(xsense_mqtt, "Subscription", FakeSubscription)
+    client = _subscription_test_client()
+
+    async def callback(msg):
+        return None
+
+    await client.async_subscribe("x/sense/one", callback, 0)
+
+    assert created == ["x/sense/one"]
+    assert client._subscription_id == 1
+
+
+@pytest.mark.asyncio
 async def test_xsense_mqtt_uses_incrementing_subscription_ids(monkeypatch):
     created = []
 
@@ -647,6 +681,91 @@ def test_parse_get_state_updates_child_when_apk_key_is_device_serial():
     assert station_obj.devices["device-id"].online is False
 
 
+def test_parse_get_state_accepts_apk_reported_device_list():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS10",
+    )
+    station_obj.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "device-id",
+                    "deviceName": "Smoke",
+                    "deviceSn": "child-sn",
+                    "deviceType": "XS03-iWX",
+                }
+            ]
+        }
+    )
+
+    client.parse_get_state(
+        station_obj,
+        [
+            {
+                "deviceSn": "child-sn",
+                "deviceType": "XS03-iWX",
+                "alarmStatus": "0",
+                "muteStatus": "1",
+                "onLine": "1",
+            }
+        ],
+    )
+
+    child = station_obj.devices["device-id"]
+    assert child.online is True
+    assert child.data["alarmStatus"] is False
+    assert child.data["muteStatus"] is True
+
+
+def test_parse_get_state_updates_sbs10_child_from_apk_device_list():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS10",
+    )
+    station_obj.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "device-id",
+                    "deviceName": "Smoke",
+                    "deviceSn": "child-sn",
+                    "deviceType": "XS03-iWX",
+                }
+            ]
+        }
+    )
+
+    client.parse_get_state(
+        station_obj,
+        {
+            "stationSN": "station-sn",
+            "devs": [
+                {
+                    "deviceSn": "child-sn",
+                    "deviceType": "XS03-iWX",
+                    "alarmStatus": "0",
+                    "muteStatus": "1",
+                    "onLine": "1",
+                }
+            ],
+        },
+    )
+
+    child = station_obj.devices["device-id"]
+    assert child.online is True
+    assert child.data["alarmStatus"] is False
+    assert child.data["muteStatus"] is True
+
+
 def test_parse_get_state_does_not_use_stale_alarm_status_when_missing():
     client = async_xsense.AsyncXSense()
     station_obj = station.Station(
@@ -984,12 +1103,23 @@ async def _capture_action(client, target, action):
             "XS01-M",
             entity_map.EntityType.SMOKE,
             {"smokeEdition": "8"},
-            None,
+            "SBS10",
             "2nd_selftest_device-sn",
             "appSelfTest",
-            None,
+            "source=1",
             13,
-            None,
+            "XS01-Mstation-sn",
+        ),
+        (
+            "XS03-iWX",
+            entity_map.EntityType.SMOKE,
+            {},
+            "SBS10",
+            "2nd_selftest_device-sn",
+            "appSelfTest",
+            "source=1",
+            13,
+            "XS03-iWXstation-sn",
         ),
         (
             "XP0J-iA",

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -322,10 +322,13 @@ async def test_failed_webrtc_start_is_removed_from_active_sessions(monkeypatch):
 
     class FakeSession:
         def __init__(self, **kwargs):
-            pass
+            self.closed = False
 
         async def start(self):
             return False
+
+        async def close(self):
+            self.closed = True
 
     fake_module = SimpleNamespace(
         XSenseWebRTCTicket=SimpleNamespace(
@@ -351,3 +354,32 @@ async def test_failed_webrtc_start_is_removed_from_active_sessions(monkeypatch):
 
     assert camera._webrtc_sessions == {}
     assert not camera.is_streaming
+
+
+async def test_webrtc_camera_stream_source_does_not_start_native_live_url():
+    from custom_components.xsense.camera import CAMERA_DESCRIPTION, XSenseCameraEntity
+
+    camera_entity = entity("SSC0A", {"streamProtocol": "webrtc", "supportWebrtc": True})
+    camera_entity.entity_id = "camera-test"
+    camera_entity.sn = "SSC0ATEST"
+    camera_entity.name = "Camera"
+    camera_entity.online = True
+
+    class XSense:
+        async def start_camera_live(self, entity):
+            raise AssertionError("WebRTC cameras use getWebrtcTicket, not newstartlive")
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = XSense()
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    camera = XSenseCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+
+    assert await camera.stream_source() is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -99,6 +99,42 @@ class PresenceHouse:
         return None
 
 
+def test_mqtt_reported_device_list_is_routed_to_apk_state_parser():
+    from types import SimpleNamespace
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Station:
+        sn = "station-sn"
+        shadow_name = "SBS10station-sn"
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    station = Station()
+    parsed = []
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(
+        houses={"house-id": PresenceHouse(station)},
+        parse_get_state=lambda station_arg, data: parsed.append((station_arg, data)),
+    )
+    coordinator.async_update_listeners = lambda: None
+
+    coordinator.async_event_received(
+        "$aws/things/SBS10station-sn/shadow/name/mainpage/update",
+        (
+            '{"state":{"reported":[{"deviceSn":"child-sn",'
+            '"deviceType":"XS03-iWX","onLine":"1"}]}}'
+        ).encode(),
+    )
+
+    assert parsed == [
+        (
+            station,
+            [{"deviceSn": "child-sn", "deviceType": "XS03-iWX", "onLine": "1"}],
+        )
+    ]
+
+
 def test_mqtt_child_devs_payload_is_routed_to_apk_state_parser():
     from types import SimpleNamespace
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1,4 +1,7 @@
-from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
+from custom_components.xsense.alarm_control_panel import (
+    XSenseAlarmControlPanel,
+    station_supports_alarm_panel,
+)
 from custom_components.xsense.api.station import Station
 from custom_components.xsense.binary_sensor import (
     XSenseBinarySensorEntity,
@@ -212,3 +215,40 @@ def test_connected_sensor_does_not_assume_unknown_online_state():
 
     assert connected.available
     assert connected.is_on is None
+
+
+def test_alarm_control_panel_requires_security_device_family():
+    smoke_station = _xs01_wx_from_real_shadow()
+    smoke_station.type = "SBS50"
+    smoke_station.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "smoke-id",
+                    "deviceName": "Smoke",
+                    "deviceSn": "smoke-sn",
+                    "deviceType": "XP0A-MR",
+                    "roomName": "Kitchen",
+                }
+            ]
+        }
+    )
+
+    security_station = _xs01_wx_from_real_shadow()
+    security_station.type = "SBS50"
+    security_station.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "door-id",
+                    "deviceName": "Door",
+                    "deviceSn": "door-sn",
+                    "deviceType": "SDS0A",
+                    "roomName": "Kitchen",
+                }
+            ]
+        }
+    )
+
+    assert not station_supports_alarm_panel(smoke_station)
+    assert station_supports_alarm_panel(security_station)

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -621,6 +621,90 @@ async def test_webrtc_close_does_not_cancel_current_timeout_task():
     assert not asyncio.current_task().cancelled()
 
 
+
+async def test_webrtc_close_stops_peer_transports_before_closing():
+    import asyncio
+
+    calls = []
+
+    class StopPart:
+        def __init__(self, name):
+            self.name = name
+
+        async def stop(self):
+            calls.append(self.name)
+
+    class FakeTransceiver:
+        def __init__(self):
+            self.sender = StopPart("transceiver-sender")
+            self.receiver = StopPart("transceiver-receiver")
+
+        async def stop(self):
+            calls.append("transceiver")
+
+    class FakePeerConnection:
+        def __init__(self, name):
+            self.name = name
+            self.transceiver = FakeTransceiver()
+            self.sender = StopPart(f"{name}-sender")
+            self.receiver = StopPart(f"{name}-receiver")
+
+        def getTransceivers(self):
+            return [self.transceiver]
+
+        def getSenders(self):
+            return [self.sender]
+
+        def getReceivers(self):
+            return [self.receiver]
+
+        async def close(self):
+            calls.append(f"{self.name}-close")
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._close_lock = asyncio.Lock()
+    session._reader_task = None
+    session._peer_in_timeout_task = None
+    session._play_timeout_task = None
+    session._first_frame_timeout_task = None
+    session._camera_local_description_task = None
+    session._ws = None
+    session._data_channel = None
+    class TrackPart:
+        def __init__(self, name):
+            self.name = name
+
+        def stop(self):
+            calls.append(self.name)
+
+    session._video = TrackPart("video")
+    session._audio = TrackPart("audio")
+    session._camera_pc = FakePeerConnection("camera")
+    session._ha_pc = FakePeerConnection("ha")
+    session._pending_ha_candidates = []
+    session._pending_camera_candidates = []
+    session._on_close = None
+
+    await session.close()
+
+    assert calls == [
+        "video",
+        "audio",
+        "transceiver",
+        "transceiver-sender",
+        "transceiver-receiver",
+        "camera-sender",
+        "camera-receiver",
+        "camera-close",
+        "transceiver",
+        "transceiver-sender",
+        "transceiver-receiver",
+        "ha-sender",
+        "ha-receiver",
+        "ha-close",
+    ]
+
 async def test_webrtc_timeout_reports_error_and_closes_session():
     import asyncio
 


### PR DESCRIPTION
## Summary
- Fix Home Assistant MQTT subscription compatibility across constructor signatures.
- Parse SBS10 APK-style child-device `mainpage` list reports and route them through the state parser.
- Align SBS10 smoke RF self-test target/shadow payloads for XS01-M and XS03-iWX.
- Hide the SBS50 alarm control panel unless the station has security-family child devices.
- Improve WebRTC camera close cleanup by stopping media transports before closing peer connections.
- Prepare v.1.2.6.10 release notes and manifest version.

## Validation
- Installed on Steve HA running Home Assistant 2026.6.1.
- Confirmed X-Sense manifest version 1.2.6.10 on HA.
- Confirmed smoke alarm connected and key entities available in HA.
- Checked HA error buffer for X-Sense errors after restart.
- `/root/.venvs/ha-xsense-test/bin/python -m pytest -q`
- `/root/.venvs/ha-xsense-test/bin/python -m compileall -q custom_components tests`
- `git diff --check`

