### PR TITLE
Fix camera WebRTC startup and config defaults

### DIFF
--- a/.github/release-notes/v.1.2.6.11.md
+++ b/.github/release-notes/v.1.2.6.11.md
@@ -1,0 +1,13 @@
+## X-Sense Home Security v.1.2.6.11
+
+### 🔧 Fixes
+- Fixed the camera WebRTC start path so online cameras send the SDP offer when the X-Sense signal socket opens, while offline/unknown cameras still wait for PEER_IN like the Android app.
+- Kept `PEER_IN` handling as the offline camera resume path instead of blocking cameras already reported online.
+- Matched the APK startLive timing by waiting for both the data channel and camera peer connection before sending the live command.
+- Tightened WebRTC close cleanup after failed stream attempts to reduce leftover aioice retry/session errors.
+- Normalized camera motion sensitivity and recording duration defaults the same way the Android app does, avoiding unknown `0` values for those controls.
+
+### ✅ Validation
+- Full test suite passed: 220 tests.
+- Python compile check passed.
+- APK-alignment pass completed for WebRTC offer timing, recipient handling, data-channel `startLive`, stream cleanup, and camera config defaults.

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -1115,7 +1115,7 @@ def _camera_user_config_payload(camera: Entity, updates: Dict) -> Dict:
 
 def _add_camera_config_companions(camera: Entity, payload: Dict) -> None:
     """Add companion config fields the APK sends with selected toggles."""
-    if "needMotion" in payload and camera.data.get("motionSensitivity") is None:
+    if "needMotion" in payload and camera.data.get("motionSensitivity") in (None, 0):
         payload["motionSensitivity"] = 1
     if "needVideo" in payload and camera.data.get("videoSeconds") == 0:
         payload["videoSeconds"] = -1
@@ -1212,7 +1212,9 @@ def _camera_config_data(data: Dict) -> Dict:
         "mechanicalDingDongDuration": data.get("mechanicalDingDongDuration"),
         "mechanicalDingDongSwitch": _addx_bool(data.get("mechanicalDingDongSwitch")),
         "mirrorFlip": _addx_bool(data.get("mirrorFlip")),
-        "motionSensitivity": data.get("motionSensitivity"),
+        "motionSensitivity": _camera_motion_sensitivity_value(
+            data.get("motionSensitivity")
+        ),
         "motionSensitivityOptionList": data.get("motionSensitivityOptionList"),
         "motionTrack": _addx_bool(data.get("motionTrack")),
         "motionTrackMode": data.get("motionTrackMode"),
@@ -1225,12 +1227,22 @@ def _camera_config_data(data: Dict) -> Dict:
         "recLamp": _addx_bool(data.get("recLamp")),
         "timeZone": data.get("timeZone"),
         "timeZoneArea": data.get("timeZoneArea"),
-        "videoSeconds": data.get("videoSeconds"),
+        "videoSeconds": _camera_video_seconds_value(data.get("videoSeconds")),
         "videoSecondsValues": data.get("videoSecondsValues"),
         "voiceVol": data.get("voiceVolume"),
         "voiceVolumeSwitch": _addx_bool(data.get("voiceVolumeSwitch")),
         "whiteLightScintillation": _addx_bool(data.get("whiteLightScintillation")),
     }
+
+
+def _camera_motion_sensitivity_value(value):
+    """Return the APK default for unset camera motion sensitivity."""
+    return 1 if value in (None, 0) else value
+
+
+def _camera_video_seconds_value(value):
+    """Return the APK default for unset camera recording duration."""
+    return -1 if value in (None, 0) else value
 
 
 def _camera_audio_data(data: Dict) -> Dict:

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -189,6 +189,7 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             resolution=_camera_live_resolution(entity),
             send_message=send_message,
             on_close=remove_session,
+            camera_online=_camera_online(entity),
         )
         self._webrtc_sessions[session_id] = session
         if not await session.start():
@@ -225,6 +226,14 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             with suppress(Exception):
                 await self.coordinator.xsense.stop_camera_live(entity)
         await super().async_will_remove_from_hass()
+
+
+def _camera_online(entity) -> bool:
+    """Return whether ADDX currently reports the camera online."""
+    online = entity.data.get("online")
+    if isinstance(online, bool):
+        return online
+    return online == 1
 
 
 def _stream_protocol(entity) -> str | None:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.10"
+  "version": "1.2.6.11"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -316,6 +316,7 @@ class XSenseWebRTCSession:
         send_message: WebRTCSendMessage,
         session_id: str | None = None,
         on_close: Callable[[], None] | None = None,
+        camera_online: bool = False,
     ) -> None:
         self._session = session
         self._ticket = ticket
@@ -325,6 +326,7 @@ class XSenseWebRTCSession:
         self._on_close = on_close
         self._session_id = session_id or ticket.session_id
         self._recipient_client_id = ticket.serial_number
+        self._camera_online = camera_online
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._ha_pc = RTCPeerConnection()
@@ -366,21 +368,23 @@ class XSenseWebRTCSession:
                 connect_url, heartbeat=30, **connect_options
             )
             self._reader_task = asyncio.create_task(self._read_loop())
-            self._peer_in_timeout_task = asyncio.create_task(
-                self._fail_after_timeout(
-                    _PEER_IN_TIMEOUT,
-                    "xsense_webrtc_peer_in_timeout",
-                    "Camera did not join the WebRTC session",
-                )
-            )
             self._play_timeout_task = asyncio.create_task(
                 self._fail_after_timeout(
                     _PLAY_TIMEOUT,
                     "xsense_webrtc_play_timeout",
-                    "Camera live view did not start",
+                    "Camera did not start the WebRTC stream",
                 )
             )
-            await self._start_camera_peer()
+            if self._camera_online:
+                await self._start_camera_peer()
+            else:
+                self._peer_in_timeout_task = asyncio.create_task(
+                    self._fail_after_timeout(
+                        _PEER_IN_TIMEOUT,
+                        "xsense_webrtc_peer_in_timeout",
+                        "Camera did not join the WebRTC session",
+                    )
+                )
             return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
             LOGGER.debug("Unable to start X-Sense WebRTC bridge", exc_info=err)
@@ -459,6 +463,7 @@ class XSenseWebRTCSession:
                 await receiver.stop()
         with suppress(Exception):
             await peer_connection.close()
+        await asyncio.sleep(0)
 
     def _create_task(
         self, coro: Coroutine[Any, Any, Any]
@@ -526,6 +531,9 @@ class XSenseWebRTCSession:
         @self._camera_pc.on("connectionstatechange")
         def on_connectionstatechange():
             state = self._camera_pc.connectionState
+            if state == "connected":
+                self._send_start_live_if_ready()
+                return
             if state in {"failed", "closed"} and not self._closed:
                 self._send_message(
                     WebRTCError(
@@ -536,10 +544,12 @@ class XSenseWebRTCSession:
                 self._create_task(self.close())
 
     def _send_start_live_if_ready(self) -> None:
-        """Send startLive when the APK would: after the data channel opens."""
+        """Send startLive when the APK would: data channel ready and peer connected."""
         if self._start_live_sent or getattr(
             self._data_channel, "readyState", None
         ) != "open":
+            return
+        if self._camera_pc.connectionState != "connected":
             return
         try:
             self._data_channel.send(
@@ -576,7 +586,6 @@ class XSenseWebRTCSession:
             or self._ws is None
             or getattr(self._ws, "closed", False)
             or self._camera_offer_sdp is None
-            or not self._camera_peer_ready
             or self._camera_offer_sent
         ):
             return
@@ -644,7 +653,10 @@ class XSenseWebRTCSession:
                 task = getattr(self, "_peer_in_timeout_task", None)
                 if task:
                     task.cancel()
-                await self._send_offer()
+                if self._camera_offer_sdp is None:
+                    await self._start_camera_peer()
+                else:
+                    await self._send_offer()
         elif event == "SDP_ANSWER":
             answer = _owned_answer_sdp(payload, self._ticket)
             if answer:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -2056,7 +2056,7 @@ async def test_update_camera_data_loads_apk_form_options():
                 ]
             }
         if endpoint == "/device/getuserconfig":
-            return {"motionSensitivity": 1, "videoSeconds": -1}
+            return {"motionSensitivity": 0, "videoSeconds": 0}
         if endpoint == "/user/getFormOptions":
             return {
                 "deviceFormOptions": {
@@ -2071,6 +2071,8 @@ async def test_update_camera_data_loads_apk_form_options():
     await client.update_camera_data()
 
     camera = test_house.get_station_by_sn("cam-sn")
+    assert camera.data["motionSensitivity"] == 1
+    assert camera.data["videoSeconds"] == -1
     assert camera.data["videoSecondsValues"] == [-1]
     assert camera.data["cooldownOptions"] == [10]
     assert "cameraWebrtcTicket" not in camera.data
@@ -2522,7 +2524,7 @@ def test_camera_user_config_payload_adds_apk_toggle_companions():
     camera.set_data(
         {
             "alarmSeconds": 20,
-            "motionSensitivity": None,
+            "motionSensitivity": 0,
             "nightThresholdLevel": 3,
             "supportRocker": False,
             "videoSeconds": 0,

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -214,7 +214,7 @@ a=candidate:1 1 udp 1 192.0.2.1 123 typ host
     session._closed = False
     session._camera_offer_sdp = FakeDescription.sdp
     session._camera_local_description_task = None
-    session._camera_peer_ready = True
+    session._camera_peer_ready = False
     session._camera_offer_sent = False
     session._ticket = ticket()
     session._recipient_client_id = "SSC0A123"
@@ -380,7 +380,7 @@ def test_camera_webrtc_resolution_uses_apk_normalization():
     assert _camera_live_resolution(SimpleNamespace(data={})) == "auto"
 
 
-def test_start_live_waits_only_for_data_channel_open(monkeypatch):
+def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
     monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
     monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
 
@@ -392,13 +392,21 @@ def test_start_live_waits_only_for_data_channel_open(monkeypatch):
         def send(self, message):
             self.messages.append(message)
 
+    class FakePeerConnection:
+        def __init__(self):
+            self.connectionState = "connecting"
+
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
     session._resolution = "2560x1440"
+    session._camera_pc = FakePeerConnection()
     session._data_channel = FakeDataChannel()
     session._start_live_sent = False
     session._create_task = lambda coro: (coro.close(), None)[1]
 
     session._send_start_live_if_ready()
+    assert session._data_channel.messages == []
+
+    session._camera_pc.connectionState = "connected"
     assert session._data_channel.messages == []
 
     session._data_channel.readyState = "open"
@@ -549,7 +557,7 @@ async def test_closed_session_ignores_late_signal_events():
     assert session._camera_peer_ready is False
 
 
-async def test_camera_offer_is_sent_before_waiting_for_local_ice_gathering():
+async def test_camera_offer_is_sent_before_peer_in_and_local_ice_gathering():
     class FakeWs:
         closed = False
 
@@ -570,7 +578,7 @@ async def test_camera_offer_is_sent_before_waiting_for_local_ice_gathering():
     session._camera_offer_sdp = "v=0\r\n"
     session._camera_local_description_task = asyncio.create_task(never_finishes())
     session._camera_pc = object()
-    session._camera_peer_ready = True
+    session._camera_peer_ready = False
     session._camera_offer_sent = False
     session._ticket = ticket()
     session._recipient_client_id = "SSC0A123"
@@ -602,7 +610,6 @@ async def test_webrtc_close_does_not_cancel_current_timeout_task():
     session._closed = False
     session._close_lock = asyncio.Lock()
     session._reader_task = None
-    session._peer_in_timeout_task = None
     session._play_timeout_task = asyncio.current_task()
     session._first_frame_timeout_task = None
     session._camera_local_description_task = None
@@ -665,7 +672,6 @@ async def test_webrtc_close_stops_peer_transports_before_closing():
     session._closed = False
     session._close_lock = asyncio.Lock()
     session._reader_task = None
-    session._peer_in_timeout_task = None
     session._play_timeout_task = None
     session._first_frame_timeout_task = None
     session._camera_local_description_task = None
@@ -747,3 +753,50 @@ async def test_first_video_frame_cancels_first_frame_timeout():
     await asyncio.sleep(0)
     assert session._first_frame_timeout_task.cancelled()
     assert session._play_timeout_task.cancelled()
+
+
+async def test_offline_camera_waits_for_peer_in_before_offer_like_apk():
+    class FakeWs:
+        closed = False
+
+        def __init__(self):
+            self.messages = []
+
+        async def send_str(self, message):
+            self.messages.append(json.loads(message))
+
+    class FakePeer:
+        localDescription = None
+
+        def addTransceiver(self, *args, **kwargs):
+            return None
+
+        async def createOffer(self):
+            class Offer:
+                sdp = "v=0\r\n"
+
+            return Offer()
+
+        async def setLocalDescription(self, offer):
+            self.localDescription = offer
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._ws = FakeWs()
+    session._camera_pc = FakePeer()
+    session._camera_offer_sdp = None
+    session._camera_local_description_task = None
+    session._camera_peer_ready = False
+    session._camera_offer_sent = False
+    session._ticket = ticket()
+    session._recipient_client_id = "SSC0A123"
+    session._session_id = "Android-client123-100000"
+    session._resolution = "1280x720"
+    session._peer_in_timeout_task = None
+
+    assert session._ws.messages == []
+
+    await session._handle_signal_event("PEER_IN", "SSC0A123")
+
+    assert [message["messageType"] for message in session._ws.messages] == ["SDP_OFFER"]
+    assert session._camera_offer_sent is True


### PR DESCRIPTION
## Summary
- start online camera WebRTC offers immediately after the signal socket opens, while preserving PEER_IN as the offline resume path
- wait for both the data channel and peer connection before sending startLive
- normalize camera motion sensitivity and recording duration defaults to match the Android app

## Validation
- pytest -q
- python3 -m compileall -q custom_components tests
- git diff --check
- installed on HA and confirmed X-Sense smoke detector recovered after coordinator poll with no recent X-Sense log errors