### PR TITLE
Fix camera WebRTC signaling diagnostics

### DIFF
--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -907,12 +907,10 @@ def _url_scheme(url: str | None) -> str | None:
 
 
 def _camera_live_url(data: Dict) -> str | None:
-    """Return the live URL transformed the same way as the APK RTMP player."""
+    """Return the live URL from the APK LiveResponse data model."""
     live_url = data.get("liveUrl") or data.get("url")
     if not isinstance(live_url, str) or not live_url:
         return None
-    if live_url.startswith("rtmp://"):
-        return live_url.replace("rtmp://", "rtmps://", 1)
     return live_url
 
 
@@ -992,7 +990,6 @@ def _camera_type(data: Dict) -> str | None:
         if model:
             return model
     return None
-
 
 
 def _camera_data(data: Dict) -> Dict:

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api.async_xsense import camera_live_resolution, is_camera_entity
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import XSenseEntity
 
@@ -151,7 +151,15 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             )
             return
 
+        LOGGER.debug(
+            "X-Sense camera WebRTC offer received: %s",
+            _camera_debug_context(entity, session_id),
+        )
         ticket_data = await self.coordinator.xsense.get_camera_webrtc_ticket(entity)
+        LOGGER.debug(
+            "X-Sense camera WebRTC ticket response: %s",
+            _ticket_data_debug_context(ticket_data),
+        )
         if not isinstance(ticket_data, dict):
             send_message(
                 WebRTCError(
@@ -168,8 +176,25 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             import_module, __package__ + ".webrtc_signal"
         )
 
-        ticket = webrtc_signal.XSenseWebRTCTicket.from_api(entity.sn, ticket_data)
+        try:
+            ticket = webrtc_signal.XSenseWebRTCTicket.from_api(entity.sn, ticket_data)
+        except (KeyError, TypeError, ValueError) as err:
+            LOGGER.debug(
+                "X-Sense camera WebRTC ticket parse failed: %s",
+                _camera_debug_context(entity, session_id, error=type(err).__name__),
+            )
+            send_message(
+                WebRTCError(
+                    "xsense_webrtc_ticket_failed",
+                    "Unable to parse X-Sense WebRTC ticket",
+                )
+            )
+            return
         if not ticket.is_valid:
+            LOGGER.debug(
+                "X-Sense camera WebRTC ticket expired or incomplete: %s",
+                _camera_debug_context(entity, session_id),
+            )
             send_message(
                 WebRTCError(
                     "xsense_webrtc_ticket_expired",
@@ -190,6 +215,10 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             send_message=send_message,
             on_close=remove_session,
             camera_online=_camera_online(entity),
+        )
+        LOGGER.debug(
+            "X-Sense camera WebRTC bridge created: %s",
+            _camera_debug_context(entity, session_id),
         )
         self._webrtc_sessions[session_id] = session
         if not await session.start():
@@ -256,13 +285,45 @@ def _is_webrtc_camera(entity) -> bool:
     protocol = _stream_protocol(entity)
     if protocol is None:
         return True
-    return (
-        protocol not in {"rtsp", "rtmp"}
-        and "rtsp" not in protocol
-        and "rtmp" not in protocol
-    )
+    return "rtsp" not in protocol and "rtmp" not in protocol
 
 
 def _camera_live_resolution(entity) -> str:
     """Return the live resolution string used by the ADDX player."""
     return camera_live_resolution(entity)
+
+
+def _short_id(value):
+    """Return a short diagnostic id without logging full serial-like values."""
+    if value in (None, ""):
+        return None
+    text = str(value)
+    return text if len(text) <= 6 else f"...{text[-6:]}"
+
+
+def _camera_debug_context(entity, session_id, **extra):
+    """Return debug-only camera context without SDP, tokens, or full serials."""
+    context = {
+        "camera": _short_id(getattr(entity, "sn", None)),
+        "session": _short_id(session_id),
+        "model": entity.data.get("cameraModel") or entity.data.get("modelNo"),
+        "protocol": entity.data.get("streamProtocol"),
+        "online": getattr(entity, "online", None),
+        "data_online": entity.data.get("online"),
+        "resolution": _camera_live_resolution(entity),
+    }
+    context.update(extra)
+    return context
+
+
+def _ticket_data_debug_context(ticket_data):
+    """Return safe ticket metadata for debug logs."""
+    if not isinstance(ticket_data, dict):
+        return {"type": type(ticket_data).__name__}
+    return {
+        "keys": sorted(key for key in ticket_data if key not in {"sign"}),
+        "has_sign": bool(ticket_data.get("sign")),
+        "has_signal_ip": bool(ticket_data.get("signalServerIpAddress")),
+        "ice_servers": len(ticket_data.get("iceServer") or []),
+        "has_expiration": ticket_data.get("expirationTime") not in (None, ""),
+    }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -64,7 +64,6 @@ _SIGNAL_NAME = "test-123"
 _DEFAULT_RESOLUTION = "auto"
 _PEER_IN_TIMEOUT = 20
 _PLAY_TIMEOUT = 40
-_FIRST_FRAME_TIMEOUT = 10
 
 
 @dataclass(slots=True)
@@ -178,6 +177,12 @@ class _ProxyTrack(MediaStreamTrack):
             self._on_frame()
         return frame
 
+    def stop(self) -> None:
+        """Stop the proxy and wake any receiver waiting for the camera track."""
+        if not self._source.done():
+            self._source.set_exception(MediaStreamError())
+        super().stop()
+
 
 def _optional_int(value: Any) -> int | None:
     if value is None or value == "":
@@ -186,6 +191,44 @@ def _optional_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _short_id(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    text = str(value)
+    return text if len(text) <= 6 else f"...{text[-6:]}"
+
+
+def _safe_host(value: str | None) -> str | None:
+    if not value:
+        return None
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return parsed.hostname or parsed.path or None
+
+
+def _ticket_debug_context(ticket: XSenseWebRTCTicket) -> dict[str, Any]:
+    return {
+        "camera": _short_id(ticket.serial_number),
+        "client": _short_id(ticket.client_id),
+        "role": ticket.role,
+        "signal_host": _safe_host(ticket.signal_server),
+        "signal_ip_override": bool(ticket.signal_server_ip_address),
+        "ice_servers": len(ticket.ice_servers or []),
+        "ticket_expires_in_s": (
+            round((ticket.expiration_time - int(time.time() * 1000)) / 1000)
+            if ticket.expiration_time is not None
+            else None
+        ),
+    }
+
+
+def _payload_debug(payload: Any) -> str:
+    if isinstance(payload, dict):
+        return f"dict_keys={sorted(payload.keys())}"
+    if isinstance(payload, str):
+        return f"str:{_short_id(payload)}"
+    return type(payload).__name__
 
 
 def make_sdp_offer_payload(
@@ -337,20 +380,41 @@ class XSenseWebRTCSession:
         self._pending_ha_candidates: list[RTCIceCandidate] = []
         self._pending_camera_candidates: list[RTCIceCandidate] = []
         self._camera_peer_ready = False
+        self._data_channel_connected = False
         self._camera_offer_sent = False
         self._camera_offer_sdp: str | None = None
         self._camera_local_description_task: asyncio.Task[None] | None = None
         self._peer_in_timeout_task: asyncio.Task[None] | None = None
         self._play_timeout_task: asyncio.Task[None] | None = None
-        self._first_frame_timeout_task: asyncio.Task[None] | None = None
         self._start_live_sent = False
         self._first_frame_received = False
         self._closed = False
         self._close_lock = asyncio.Lock()
 
+    def _debug_context(self, **extra: Any) -> dict[str, Any]:
+        ticket = getattr(self, "_ticket", None)
+        context = _ticket_debug_context(ticket) if ticket is not None else {}
+        camera_pc = getattr(self, "_camera_pc", None)
+        ha_pc = getattr(self, "_ha_pc", None)
+        data_channel = getattr(self, "_data_channel", None)
+        context.update(
+            {
+                "session": _short_id(getattr(self, "_session_id", None)),
+                "recipient": _short_id(getattr(self, "_recipient_client_id", None)),
+                "resolution": getattr(self, "_resolution", None),
+                "camera_online": getattr(self, "_camera_online", None),
+                "camera_pc": getattr(camera_pc, "connectionState", None),
+                "ha_pc": getattr(ha_pc, "connectionState", None),
+                "data_channel": getattr(data_channel, "readyState", None),
+            }
+        )
+        context.update(extra)
+        return context
+
     async def start(self) -> bool:
         """Connect both WebRTC peers and start the X-Sense camera stream."""
         try:
+            LOGGER.debug("X-Sense WebRTC session starting: %s", self._debug_context())
             self._setup_camera_peer()
             self._ha_pc.addTrack(self._video)
             self._ha_pc.addTrack(self._audio)
@@ -360,13 +424,23 @@ class XSenseWebRTCSession:
             await self._flush_pending_ha_candidates()
             answer = await self._ha_pc.createAnswer()
             await self._ha_pc.setLocalDescription(answer)
-            self._send_message(WebRTCAnswer(self._ha_pc.localDescription.sdp))
+            if not self._send_ha_message(
+                WebRTCAnswer(self._ha_pc.localDescription.sdp)
+            ):
+                await self.close()
+                return False
 
+            LOGGER.debug("X-Sense WebRTC HA answer ready: %s", self._debug_context())
             connect_options = self._ticket.signal_connect_options()
             connect_url = connect_options.pop("url", self._ticket.signal_url())
+            LOGGER.debug(
+                "X-Sense WebRTC signal connecting: %s",
+                self._debug_context(connect_host=_safe_host(connect_url)),
+            )
             self._ws = await self._session.ws_connect(
                 connect_url, heartbeat=30, **connect_options
             )
+            LOGGER.debug("X-Sense WebRTC signal connected: %s", self._debug_context())
             self._reader_task = asyncio.create_task(self._read_loop())
             self._play_timeout_task = asyncio.create_task(
                 self._fail_after_timeout(
@@ -376,8 +450,16 @@ class XSenseWebRTCSession:
                 )
             )
             if self._camera_online:
+                LOGGER.debug(
+                    "X-Sense WebRTC camera online, starting peer: %s",
+                    self._debug_context(),
+                )
                 await self._start_camera_peer()
             else:
+                LOGGER.debug(
+                    "X-Sense WebRTC waiting for PEER_IN: %s",
+                    self._debug_context(),
+                )
                 self._peer_in_timeout_task = asyncio.create_task(
                     self._fail_after_timeout(
                         _PEER_IN_TIMEOUT,
@@ -387,8 +469,12 @@ class XSenseWebRTCSession:
                 )
             return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
+            LOGGER.debug(
+                "X-Sense WebRTC start failed context: %s",
+                self._debug_context(error=type(err).__name__, message=str(err)),
+            )
             LOGGER.debug("Unable to start X-Sense WebRTC bridge", exc_info=err)
-            self._send_message(WebRTCError("xsense_webrtc_start_failed", str(err)))
+            self._send_ha_message(WebRTCError("xsense_webrtc_start_failed", str(err)))
             await self.close()
             return False
 
@@ -399,14 +485,22 @@ class XSenseWebRTCSession:
         parsed = _candidate_init_to_aiortc(candidate)
         if self._ha_pc.remoteDescription is None:
             self._pending_ha_candidates.append(parsed)
+            LOGGER.debug(
+                "X-Sense WebRTC queued HA ICE candidate: %s",
+                self._debug_context(
+                    pending_ha_candidates=len(self._pending_ha_candidates)
+                ),
+            )
             return
         await self._ha_pc.addIceCandidate(parsed)
+        LOGGER.debug("X-Sense WebRTC applied HA ICE candidate: %s", self._debug_context())
 
     async def close(self) -> None:
         """Close the X-Sense signaling and WebRTC sessions."""
         async with self._close_lock:
             if self._closed:
                 return
+            LOGGER.debug("X-Sense WebRTC session closing: %s", self._debug_context())
             self._closed = True
             self._send_stop_live()
             if self._reader_task:
@@ -415,7 +509,6 @@ class XSenseWebRTCSession:
                     await self._reader_task
             await self._cancel_task(getattr(self, "_peer_in_timeout_task", None))
             await self._cancel_task(getattr(self, "_play_timeout_task", None))
-            await self._cancel_task(getattr(self, "_first_frame_timeout_task", None))
             if self._camera_local_description_task:
                 self._camera_local_description_task.cancel()
                 with suppress(asyncio.CancelledError, Exception):
@@ -465,9 +558,7 @@ class XSenseWebRTCSession:
             await peer_connection.close()
         await asyncio.sleep(0)
 
-    def _create_task(
-        self, coro: Coroutine[Any, Any, Any]
-    ) -> asyncio.Task[Any] | None:
+    def _create_task(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any] | None:
         try:
             return asyncio.create_task(coro)
         except Exception:
@@ -481,6 +572,20 @@ class XSenseWebRTCSession:
         with suppress(asyncio.CancelledError, Exception):
             await task
 
+    def _send_ha_message(self, message: WebRTCAnswer | WebRTCError) -> bool:
+        """Send a Home Assistant WebRTC message if the browser socket is open."""
+        if self._closed:
+            return False
+        try:
+            self._send_message(message)
+        except (ConnectionError, RuntimeError, aiohttp.ClientConnectionError) as err:
+            LOGGER.debug(
+                "Home Assistant WebRTC client closed while sending X-Sense reply",
+                exc_info=err,
+            )
+            return False
+        return True
+
     async def _fail_after_timeout(self, delay: int, code: str, message: str) -> None:
         try:
             await asyncio.sleep(delay)
@@ -488,16 +593,18 @@ class XSenseWebRTCSession:
             raise
         if self._closed:
             return
-        self._send_message(WebRTCError(code, message))
+        LOGGER.debug(
+            "X-Sense WebRTC timeout: %s",
+            self._debug_context(code=code, timeout_s=delay),
+        )
+        self._send_ha_message(WebRTCError(code, message))
         await self.close()
 
     def _mark_first_frame_received(self) -> None:
         if self._first_frame_received:
             return
         self._first_frame_received = True
-        first_frame_task = getattr(self, "_first_frame_timeout_task", None)
-        if first_frame_task:
-            first_frame_task.cancel()
+        LOGGER.debug("X-Sense WebRTC first frame received: %s", self._debug_context())
         play_task = getattr(self, "_play_timeout_task", None)
         if play_task:
             play_task.cancel()
@@ -524,18 +631,22 @@ class XSenseWebRTCSession:
 
         self._data_channel = self._camera_pc.createDataChannel(SIGNAL_DATA_CHANNEL)
 
-        @self._data_channel.on("open")
-        def on_open():
-            self._send_start_live_if_ready()
+        @self._data_channel.on("message")
+        def on_message(message):
+            self._handle_data_channel_message(message)
 
         @self._camera_pc.on("connectionstatechange")
         def on_connectionstatechange():
             state = self._camera_pc.connectionState
+            LOGGER.debug(
+                "X-Sense WebRTC camera peer state changed: %s",
+                self._debug_context(new_state=state),
+            )
             if state == "connected":
                 self._send_start_live_if_ready()
                 return
             if state in {"failed", "closed"} and not self._closed:
-                self._send_message(
+                self._send_ha_message(
                     WebRTCError(
                         "xsense_webrtc_peer_failed",
                         f"Camera peer connection {state}",
@@ -543,11 +654,30 @@ class XSenseWebRTCSession:
                 )
                 self._create_task(self.close())
 
+    def _handle_data_channel_message(self, message: str | bytes) -> None:
+        """Handle camera data-channel messages in the APK callback shape."""
+        if isinstance(message, bytes):
+            message = message.decode(errors="ignore")
+        try:
+            payload = json.loads(message)
+            LOGGER.debug(
+                "X-Sense WebRTC data-channel message: %s",
+                self._debug_context(action=payload.get("action")),
+            )
+        except (TypeError, json.JSONDecodeError):
+            return
+        if payload.get("action") == "dataChannelConnected":
+            self._data_channel_connected = True
+            self._send_start_live_if_ready()
+
     def _send_start_live_if_ready(self) -> None:
-        """Send startLive when the APK would: data channel ready and peer connected."""
-        if self._start_live_sent or getattr(
-            self._data_channel, "readyState", None
-        ) != "open":
+        """Send startLive when the APK would: after dataChannelConnected."""
+        if not self._data_channel_connected:
+            return
+        if (
+            self._start_live_sent
+            or getattr(self._data_channel, "readyState", None) != "open"
+        ):
             return
         if self._camera_pc.connectionState != "connected":
             return
@@ -562,15 +692,13 @@ class XSenseWebRTCSession:
             LOGGER.debug("Unable to send X-Sense startLive command", exc_info=err)
             return
         self._start_live_sent = True
-        self._first_frame_timeout_task = self._create_task(
-            self._fail_after_timeout(
-                _FIRST_FRAME_TIMEOUT,
-                "xsense_webrtc_first_frame_timeout",
-                "Camera did not send a video frame",
-            )
+        LOGGER.debug(
+            "X-Sense WebRTC sent startLive: %s",
+            self._debug_context(size=_map_video_size(self._resolution)),
         )
 
     async def _start_camera_peer(self) -> None:
+        LOGGER.debug("X-Sense WebRTC creating camera offer: %s", self._debug_context())
         self._camera_pc.addTransceiver("video", direction="recvonly")
         self._camera_pc.addTransceiver("audio", direction="recvonly")
         offer = await self._camera_pc.createOffer()
@@ -589,6 +717,7 @@ class XSenseWebRTCSession:
             or self._camera_offer_sent
         ):
             return
+        LOGGER.debug("X-Sense WebRTC sending SDP offer: %s", self._debug_context())
         await self._ws.send_str(
             make_sdp_offer_payload(
                 offer_sdp=self._camera_offer_sdp,
@@ -612,7 +741,12 @@ class XSenseWebRTCSession:
             or self._camera_pc.localDescription is None
         ):
             return
-        for candidate in _local_sdp_candidates(self._camera_pc.localDescription.sdp):
+        candidates = _local_sdp_candidates(self._camera_pc.localDescription.sdp)
+        LOGGER.debug(
+            "X-Sense WebRTC sending local ICE candidates: %s",
+            self._debug_context(candidate_count=len(candidates)),
+        )
+        for candidate in candidates:
             if self._closed or self._ws is None or getattr(self._ws, "closed", False):
                 return
             await self._ws.send_str(
@@ -633,9 +767,16 @@ class XSenseWebRTCSession:
             async for message in self._ws:
                 if self._closed:
                     return
-                if message.type not in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
+                if message.type not in (
+                    aiohttp.WSMsgType.TEXT,
+                    aiohttp.WSMsgType.BINARY,
+                ):
                     continue
                 event, payload = parse_signal_message(message.data)
+                LOGGER.debug(
+                    "X-Sense WebRTC signal event received: %s",
+                    self._debug_context(event=event, payload=_payload_debug(payload)),
+                )
                 await self._handle_signal_event(event, payload)
         except asyncio.CancelledError:
             raise
@@ -648,6 +789,10 @@ class XSenseWebRTCSession:
             return
         if event == "PEER_IN":
             if _is_owned_peer_message(payload, self._ticket.serial_number):
+                LOGGER.debug(
+                    "X-Sense WebRTC peer event matched camera: %s",
+                    self._debug_context(event=event),
+                )
                 self._recipient_client_id = str(payload)
                 self._camera_peer_ready = True
                 task = getattr(self, "_peer_in_timeout_task", None)
@@ -660,20 +805,41 @@ class XSenseWebRTCSession:
         elif event == "SDP_ANSWER":
             answer = _owned_answer_sdp(payload, self._ticket)
             if answer:
+                LOGGER.debug(
+                    "X-Sense WebRTC applying SDP answer: %s",
+                    self._debug_context(),
+                )
                 await self._camera_pc.setRemoteDescription(
                     RTCSessionDescription(sdp=answer, type="answer")
                 )
                 await self._flush_pending_camera_candidates()
+            else:
+                LOGGER.debug(
+                    "X-Sense WebRTC ignored invalid or foreign SDP answer: %s",
+                    self._debug_context(payload=_payload_debug(payload)),
+                )
         elif event == "ICE_CANDIDATE":
             candidate = _candidate_payload_to_aiortc(payload)
             if candidate:
                 if self._camera_pc.remoteDescription is None:
                     self._pending_camera_candidates.append(candidate)
+                    LOGGER.debug(
+                        "X-Sense WebRTC queued camera ICE candidate: %s",
+                        self._debug_context(
+                            pending_camera_candidates=len(
+                                self._pending_camera_candidates
+                            )
+                        ),
+                    )
                 else:
                     await self._camera_pc.addIceCandidate(candidate)
+                    LOGGER.debug(
+                        "X-Sense WebRTC applied camera ICE candidate: %s",
+                        self._debug_context(),
+                    )
         elif event == "PEER_OUT":
             if _is_owned_peer_message(payload, self._ticket.serial_number):
-                self._send_message(
+                self._send_ha_message(
                     WebRTCError(
                         "xsense_webrtc_peer_offline", "Camera peer went offline"
                     )
@@ -711,27 +877,29 @@ def _camera_rtc_configuration(ticket: XSenseWebRTCTicket) -> AiortcRTCConfigurat
 
 
 def _answer_sdp(payload: Any) -> str | None:
-    if isinstance(payload, dict):
-        nested = payload.get("sdp")
-        if isinstance(nested, str):
-            return nested
-        encoded = payload.get("messagePayload")
-        if isinstance(encoded, str):
-            with suppress(Exception):
-                decoded = json.loads(base64.b64decode(encoded).decode())
-                return decoded.get("sdp")
+    if not isinstance(payload, dict):
+        return None
+    encoded = payload.get("messagePayload")
+    if not isinstance(encoded, str):
+        return None
+    with suppress(Exception):
+        decoded = json.loads(base64.b64decode(encoded).decode())
+        sdp = decoded.get("sdp")
+        if isinstance(sdp, str):
+            return sdp
     return None
 
 
 def _owned_answer_sdp(payload: Any, ticket: XSenseWebRTCTicket) -> str | None:
     """Return the SDP answer only when it belongs to this APK-style session."""
-    if isinstance(payload, dict):
-        sender = payload.get("senderClientId")
-        recipient = payload.get("recipientClientId")
-        if sender and sender != ticket.serial_number:
-            return None
-        if recipient and recipient != ticket.client_id:
-            return None
+    if not isinstance(payload, dict):
+        return None
+    sender = payload.get("senderClientId")
+    recipient = payload.get("recipientClientId")
+    if sender and sender != ticket.serial_number:
+        return None
+    if recipient and recipient != ticket.client_id:
+        return None
     return _answer_sdp(payload)
 
 
@@ -781,7 +949,7 @@ def _local_sdp_candidates(sdp: str) -> list[dict[str, Any]]:
 def _is_apk_supported_local_candidate(candidate: str) -> bool:
     """Return whether the APK would signal this local ICE candidate."""
     parts = candidate.split()
-    if len(parts) < 3 or parts[2].lower() != "udp":
+    if len(parts) >= 3 and parts[2].lower() == "tcp":
         return False
     return "127.0.0.1" not in candidate and "::1" not in candidate
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -194,7 +194,9 @@ def _subscription_test_client():
 
 
 @pytest.mark.asyncio
-async def test_xsense_mqtt_omits_subscription_id_when_ha_signature_lacks_it(monkeypatch):
+async def test_xsense_mqtt_omits_subscription_id_when_ha_signature_lacks_it(
+    monkeypatch,
+):
     created = []
 
     class FakeSubscription:
@@ -931,7 +933,6 @@ async def test_get_station_state_does_not_guess_second_info_for_unknown_types():
 
     assert calls == ["info_station-sn"]
     assert station.data == {}
-
 
 
 @pytest.mark.asyncio
@@ -2108,6 +2109,18 @@ async def test_start_camera_live_uses_apk_live_resolution(camera_data, expected)
     ]
 
 
+def test_camera_live_url_uses_apk_response_fields_without_scheme_rewrite():
+    assert (
+        async_xsense._camera_live_url({"liveUrl": "rtmp://example/live"})
+        == "rtmp://example/live"
+    )
+    assert (
+        async_xsense._camera_live_url({"url": "rtsp://example/live"})
+        == "rtsp://example/live"
+    )
+    assert async_xsense._camera_live_url({"liveUrl": ""}) is None
+
+
 @pytest.mark.asyncio
 async def test_update_camera_data_loads_apk_form_options():
     client = async_xsense.AsyncXSense()
@@ -2153,7 +2166,7 @@ async def test_update_camera_data_loads_apk_form_options():
     assert camera.data["cooldownOptions"] == [10]
     assert "cameraWebrtcTicket" not in camera.data
     assert ("/user/getFormOptions", {"serialNumber": "cam-sn"}) in calls
-    assert ("/device/getWebrtcTicket", {"serialNumber": "cam-sn"}) not in calls
+    assert ("/device/getWebrtcTicket", {"serialNumber": "cam-sn", "verifyDormancyStatus": True}) not in calls
 
 
 @pytest.mark.asyncio
@@ -2560,7 +2573,6 @@ def test_camera_data_normalizes_apk_integer_support_flags():
         }
     )
 
-
     for key in (
         "supportAntiFlicker",
         "supportAlarm",
@@ -2591,15 +2603,24 @@ def test_camera_data_normalizes_apk_integer_support_flags():
 
 
 def test_camera_data_uses_explicit_apk_webrtc_support_flag():
-    assert async_xsense._camera_data({"deviceSupport": {"supportWebrtc": 1}})[
-        "supportWebrtc"
-    ] is True
-    assert async_xsense._camera_data({"deviceSupport": {"supportWebrtc": 0}})[
-        "supportWebrtc"
-    ] is False
-    assert async_xsense._camera_data({"deviceModel": {"streamProtocol": "webrtc"}})[
-        "supportWebrtc"
-    ] is None
+    assert (
+        async_xsense._camera_data({"deviceSupport": {"supportWebrtc": 1}})[
+            "supportWebrtc"
+        ]
+        is True
+    )
+    assert (
+        async_xsense._camera_data({"deviceSupport": {"supportWebrtc": 0}})[
+            "supportWebrtc"
+        ]
+        is False
+    )
+    assert (
+        async_xsense._camera_data({"deviceModel": {"streamProtocol": "webrtc"}})[
+            "supportWebrtc"
+        ]
+        is None
+    )
 
 
 def test_camera_user_config_payload_sends_only_changed_cloud_fields_like_apk():

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -174,7 +174,7 @@ def test_webrtc_ice_candidate_payload_matches_apk():
     }
 
 
-def test_local_sdp_candidates_extracts_apk_payloads_and_skips_loopback():
+def test_local_sdp_candidates_match_apk_loopback_and_tcp_filters():
     sdp = """v=0
 m=video 9 UDP/TLS/RTP/SAVPF 96
 a=mid:0
@@ -183,7 +183,7 @@ a=candidate:2 1 udp 1 127.0.0.1 456 typ host
 a=candidate:5 1 tcp 1 192.0.2.1 457 typ host tcptype passive
 m=audio 9 UDP/TLS/RTP/SAVPF 111
 a=mid:1
-a=candidate:3 1 udp 1 2001:db8::1 789 typ host
+a=candidate:3 1 udp 1 2001:db8::2 789 typ host
 a=candidate:4 1 udp 1 ::1 790 typ host
 """
 
@@ -192,6 +192,11 @@ a=candidate:4 1 udp 1 ::1 790 typ host
             "sdpMid": "0",
             "sdpMLineIndex": 0,
             "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+        },
+        {
+            "sdpMid": "1",
+            "sdpMLineIndex": 1,
+            "candidate": "candidate:3 1 udp 1 2001:db8::2 789 typ host",
         },
     ]
 
@@ -245,6 +250,32 @@ a=candidate:1 1 udp 1 192.0.2.1 123 typ host
     assert session._camera_offer_sent is True
 
 
+async def test_proxy_track_stop_wakes_pending_receiver():
+    track = webrtc_signal._ProxyTrack("video")
+
+    receive_task = webrtc_signal.asyncio.create_task(track.recv())
+    await webrtc_signal.asyncio.sleep(0)
+
+    track.stop()
+
+    with suppress(webrtc_signal.MediaStreamError):
+        await receive_task
+    assert receive_task.done()
+
+
+def test_send_ha_message_ignores_closed_browser_socket():
+    def send_message(message):
+        raise ConnectionResetError("browser websocket closed")
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._send_message = send_message
+
+    message = webrtc_signal.WebRTCError("closed", "closed")
+
+    assert session._send_ha_message(message) is False
+
+
 def test_parse_signal_message_preserves_answer_envelope_for_apk_validation():
     encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
     raw = json.dumps(
@@ -262,6 +293,25 @@ def test_parse_signal_message_preserves_answer_envelope_for_apk_validation():
     assert payload["senderClientId"] == "SSC0A123"
     assert payload["recipientClientId"] == "client123"
     assert webrtc_signal._owned_answer_sdp(payload, ticket()) == "answer"
+
+
+def test_apk_sdp_answer_validation_allows_missing_optional_ids():
+    encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
+
+    assert (
+        webrtc_signal._owned_answer_sdp(
+            {"messagePayload": encoded, "senderClientId": "SSC0A123"},
+            ticket(),
+        )
+        == "answer"
+    )
+    assert (
+        webrtc_signal._owned_answer_sdp(
+            {"messagePayload": encoded, "recipientClientId": "client123"},
+            ticket(),
+        )
+        == "answer"
+    )
 
 
 def test_apk_sdp_answer_validation_rejects_other_camera_or_viewer():
@@ -409,7 +459,15 @@ def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
     session._camera_pc = FakePeerConnection()
     session._data_channel = FakeDataChannel()
     session._start_live_sent = False
-    session._create_task = lambda coro: (coro.close(), None)[1]
+    session._data_channel_connected = False
+    created_tasks = []
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    session._create_task = create_task
 
     session._send_start_live_if_ready()
     assert session._data_channel.messages == []
@@ -419,6 +477,9 @@ def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
 
     session._data_channel.readyState = "open"
     session._send_start_live_if_ready()
+    assert session._data_channel.messages == []
+
+    session._handle_data_channel_message(json.dumps({"action": "dataChannelConnected"}))
     session._send_start_live_if_ready()
 
     assert [json.loads(message) for message in session._data_channel.messages] == [
@@ -431,6 +492,7 @@ def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
             "resolution": "2560x1440",
         }
     ]
+    assert created_tasks == []
 
 
 async def test_browser_ice_candidates_wait_for_ha_remote_description():
@@ -619,7 +681,6 @@ async def test_webrtc_close_does_not_cancel_current_timeout_task():
     session._close_lock = asyncio.Lock()
     session._reader_task = None
     session._play_timeout_task = asyncio.current_task()
-    session._first_frame_timeout_task = None
     session._camera_local_description_task = None
     session._ws = None
     session._data_channel = None
@@ -681,7 +742,6 @@ async def test_webrtc_close_stops_peer_transports_before_closing():
     session._close_lock = asyncio.Lock()
     session._reader_task = None
     session._play_timeout_task = None
-    session._first_frame_timeout_task = None
     session._camera_local_description_task = None
     session._ws = None
     session._data_channel = None
@@ -741,7 +801,7 @@ async def test_webrtc_timeout_reports_error_and_closes_session():
     assert closed == [True]
 
 
-async def test_first_video_frame_cancels_first_frame_timeout():
+async def test_first_video_frame_cancels_play_timeout():
     import asyncio
 
     class FakeSource:
@@ -750,7 +810,6 @@ async def test_first_video_frame_cancels_first_frame_timeout():
 
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
     session._first_frame_received = False
-    session._first_frame_timeout_task = asyncio.create_task(asyncio.sleep(60))
     session._play_timeout_task = asyncio.create_task(asyncio.sleep(60))
     track = webrtc_signal._ProxyTrack("video", session._mark_first_frame_received)
     track.set_source(FakeSource())
@@ -759,7 +818,6 @@ async def test_first_video_frame_cancels_first_frame_timeout():
 
     assert session._first_frame_received is True
     await asyncio.sleep(0)
-    assert session._first_frame_timeout_task.cancelled()
     assert session._play_timeout_task.cancelled()
 
 


### PR DESCRIPTION
## Summary
- align camera WebRTC start flow with the APK data-channel handshake
- keep ADDX live URLs exactly as returned by the API
- add debug-only camera/WebRTC breadcrumbs without logging SDP, ICE strings, tokens, signs, or full serials

## Validation
- pytest: 236 passed, 1 warning
- installed on Steve Home Assistant and restarted Core after moving the backup out of custom_components
- post-restart X-Sense setup/import log scan clean
