### PR TITLE
Fix camera availability during ADDX refresh

### DIFF
--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -421,28 +421,13 @@ class AsyncXSense(XSenseBase):
     async def update_camera_data(self):
         """Merge camera metadata and config from the Android app ADDX API."""
         data = await self.addx_call("/device/listuserdevices")
-        known_camera_serials = {
-            _normalized_camera_serial(station.sn)
-            for house in self.houses.values()
-            for station in house.stations.values()
-            if is_camera_entity(station)
-        }
         devices = [
             device
             for device in (data or {}).get("list") or []
-            if (serial := _normalized_camera_serial(device.get("serialNumber")))
-            and (_camera_type(device) in CAMERA_TYPES or serial in known_camera_serials)
+            if _normalized_camera_serial(device.get("serialNumber"))
         ]
-        camera_serials = {
-            _normalized_camera_serial(device.get("serialNumber")) for device in devices
-        }
-        for house in self.houses.values():
-            for station_id, station in list(house.stations.items()):
-                if (
-                    is_camera_entity(station)
-                    and _normalized_camera_serial(station.sn) not in camera_serials
-                ):
-                    del house.stations[station_id]
+        if not devices:
+            return
 
         cameras = []
         for device in devices:
@@ -514,6 +499,19 @@ class AsyncXSense(XSenseBase):
         if normalized_serial is None:
             return None
 
+        for house in self.houses.values():
+            for station in house.stations.values():
+                if (
+                    is_camera_entity(station)
+                    and _normalized_camera_serial(station.sn) == normalized_serial
+                ):
+                    camera_type = _camera_type(data)
+                    if camera_type:
+                        station.type = camera_type
+                    if data.get("deviceName"):
+                        station.name = data["deviceName"]
+                    return station
+
         device_house_id = data.get("houseId")
         if device_house_id in (None, ""):
             target_houses = list(self.houses.values())
@@ -523,18 +521,10 @@ class AsyncXSense(XSenseBase):
                 for house in self.houses.values()
                 if str(device_house_id) == str(house.house_id)
             ]
-        if not target_houses:
-            return None
+            if not target_houses and len(self.houses) == 1:
+                target_houses = list(self.houses.values())
 
-        for house in target_houses:
-            for station in house.stations.values():
-                if (
-                    is_camera_entity(station)
-                    and _normalized_camera_serial(station.sn) == normalized_serial
-                ):
-                    return station
-
-        if device_house_id in (None, "") and len(target_houses) != 1:
+        if len(target_houses) != 1:
             return None
 
         house = target_houses[0]

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.14"
+  "version": "1.2.6.15"
 }

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1898,7 +1898,7 @@ async def test_update_camera_data_does_not_assume_missing_camera_online_state():
 
 
 @pytest.mark.asyncio
-async def test_update_camera_data_does_not_create_unknown_model_from_general_device_list():
+async def test_update_camera_data_accepts_addx_camera_list_as_authority():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
     test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
@@ -1909,10 +1909,43 @@ async def test_update_camera_data_does_not_create_unknown_model_from_general_dev
             return {
                 "list": [
                     {
-                        "serialNumber": "future-device-sn",
-                        "deviceName": "Future Device",
+                        "serialNumber": "future-camera-sn",
+                        "deviceName": "Future Camera",
                         "houseId": "house-id",
                         "modelNo": "SSC99",
+                        "online": 1,
+                        "deviceModel": {"streamProtocol": "webrtc"},
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    camera = test_house.get_station_by_sn("future-camera-sn")
+    assert camera is not None
+    assert camera.entity_type == async_xsense.EntityType.CAMERA
+    assert camera.type == "SSC99"
+    assert camera.online is True
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_accepts_addx_camera_without_model_metadata():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
+    client.houses = {"house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-sn",
+                        "deviceName": "Garage Camera",
+                        "houseId": "house-id",
                         "online": 1,
                     }
                 ]
@@ -1923,7 +1956,93 @@ async def test_update_camera_data_does_not_create_unknown_model_from_general_dev
 
     await client.update_camera_data()
 
-    assert test_house.get_station_by_sn("future-device-sn") is None
+    camera = test_house.get_station_by_sn("camera-sn")
+    assert camera is not None
+    assert camera.entity_type == async_xsense.EntityType.CAMERA
+    assert camera.name == "Garage Camera"
+    assert camera.type is None
+    assert camera.online is True
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_updates_existing_camera_when_addx_house_id_differs():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "xsense-house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "cam-id",
+                    "ipcSn": "cam-sn",
+                    "ipcName": "Garage Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"xsense-house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "cam-sn",
+                        "deviceName": "Garage Camera",
+                        "houseId": "addx-location-id",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                        "batteryLevel": 4,
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    camera = test_house.get_station_by_sn("cam-sn")
+    assert camera is not None
+    assert camera.entity_id == "cam-id"
+    assert camera.name == "Garage Camera"
+    assert camera.type == "SSC0A"
+    assert camera.online is True
+    assert camera.data["batteryLevel"] == 4
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_places_addx_camera_with_mismatched_house_in_single_house_account():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "xsense-house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations({"stationSort": [], "stations": [], "cameras": []})
+    client.houses = {"xsense-house-id": test_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-sn",
+                        "deviceName": "Garage Camera",
+                        "houseId": "addx-location-id",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    camera = test_house.get_station_by_sn("camera-sn")
+    assert camera is not None
+    assert camera.entity_type == async_xsense.EntityType.CAMERA
+    assert camera.online is True
 
 
 @pytest.mark.asyncio
@@ -1982,7 +2101,7 @@ async def test_update_camera_data_updates_known_camera_from_addx_device_list():
 
 
 @pytest.mark.asyncio
-async def test_update_camera_data_uses_addx_device_as_camera_authority():
+async def test_update_camera_data_keeps_existing_camera_stations_not_in_addx_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
     test_house.set_stations(
@@ -2023,7 +2142,7 @@ async def test_update_camera_data_uses_addx_device_as_camera_authority():
 
     await client.update_camera_data()
 
-    assert "stub-id" not in test_house.stations
+    assert test_house.get_station_by_sn("stub-sn") is not None
     camera = test_house.get_station_by_sn("real-sn")
     assert camera is not None
     assert camera.entity_id == "real-sn"
@@ -2508,7 +2627,7 @@ async def test_register_ipc_requires_house_region_instead_of_defaulting_to_us():
 
 
 @pytest.mark.asyncio
-async def test_update_camera_data_handles_empty_addx_camera_list():
+async def test_update_camera_data_keeps_existing_cameras_on_empty_addx_camera_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
     test_house.set_stations(
@@ -2537,7 +2656,7 @@ async def test_update_camera_data_handles_empty_addx_camera_list():
     await client.update_camera_data()
 
     assert calls == [("/device/listuserdevices", {})]
-    assert test_house.stations == {}
+    assert test_house.get_station_by_sn("stale-cam-sn") is not None
 
 
 def test_camera_data_normalizes_apk_integer_support_flags():


### PR DESCRIPTION
## Summary
- treat the ADDX camera list as the serial-based camera authority, matching the Android app path
- keep existing camera stations during empty or partial ADDX refreshes instead of deleting them
- preserve serial-matched camera identity even when ADDX house IDs differ from X-Sense house IDs

## Validation
- pytest -q
- git diff --check
- installed on HA 2026.6.1, ran ha core check, safety-checked mom/bathroom state, restarted HA, and verified XSense loaded without setup errors
