### PR TITLE
Fix camera WebRTC peer object handling

### DIFF
--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.16"
+  "version": "1.2.6.17"
 }

--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -48,6 +48,12 @@ type SocketType = mqtt.WebsocketWrapper | Any
 type PublishPayloadType = str | bytes | int | float | None
 
 
+def _redact_account_title(title: str) -> str:
+    if title.startswith("XSense Account "):
+        return "XSense Account <redacted>"
+    return title
+
+
 def _subscription_accepts_id() -> bool:
     """Return whether this Home Assistant version wants subscription_id."""
     try:
@@ -90,6 +96,7 @@ class XSenseMQTT:
 
         # self.topics: list[str] = []
         self.on_data: Callable[[str, bytes], None] | None = None
+        self._debug_name = _redact_account_title(config_entry.title)
 
         self.connected = False
         self._connection_lock = asyncio.Lock()
@@ -165,7 +172,7 @@ class XSenseMQTT:
     def _async_start_misc_periodic(self) -> None:
         """Start the misc periodic."""
         assert self._misc_timer is None, "Misc periodic already started"
-        _LOGGER.debug("%s: Starting client misc loop", self.config_entry.title)
+        _LOGGER.debug("%s: Starting client misc loop", self._debug_name)
         # pylint: disable=import-outside-toplevel
         # import paho.mqtt.client as mqtt
 
@@ -197,7 +204,7 @@ class XSenseMQTT:
     ) -> None:
         """Handle socket open."""
         fileno = sock.fileno()
-        _LOGGER.debug("%s: connection opened %s", self.config_entry.title, fileno)
+        _LOGGER.debug("%s: connection opened %s", self._debug_name, fileno)
         if fileno > -1:
             self.loop.add_reader(sock, partial(self._async_reader_callback, client))
         if not self._misc_timer:
@@ -213,7 +220,7 @@ class XSenseMQTT:
     ) -> None:
         """Handle socket close."""
         fileno = sock.fileno()
-        _LOGGER.debug("%s: connection closed %s", self.config_entry.title, fileno)
+        _LOGGER.debug("%s: connection closed %s", self._debug_name, fileno)
         # If socket close is called before the connect
         # result is set make sure the first connection result is set
         self._async_connection_result(False)
@@ -245,7 +252,7 @@ class XSenseMQTT:
     ) -> None:
         """Register the socket for writing."""
         fileno = sock.fileno()
-        _LOGGER.debug("%s: register write %s", self.config_entry.title, fileno)
+        _LOGGER.debug("%s: register write %s", self._debug_name, fileno)
         if fileno > -1:
             self.loop.add_writer(sock, partial(self._async_writer_callback, client))
 
@@ -256,7 +263,7 @@ class XSenseMQTT:
     ) -> None:
         """Unregister the socket for writing."""
         fileno = sock.fileno()
-        _LOGGER.debug("%s: unregister write %s", self.config_entry.title, fileno)
+        _LOGGER.debug("%s: unregister write %s", self._debug_name, fileno)
         if fileno > -1:
             self.loop.remove_writer(sock)
 

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -232,12 +232,15 @@ def _payload_debug(payload: Any) -> str:
 
 
 def _peer_event_debug(payload: Any, serial_number: str) -> dict[str, Any]:
-    text = payload.strip() if isinstance(payload, str) else None
+    match = _matching_peer_id(payload, serial_number)
     return {
         "payload": _payload_debug(payload),
-        "payload_matches_camera": text == serial_number,
+        "payload_matches_camera": match is not None,
         "camera": _short_id(serial_number),
-        "peer": _short_id(text),
+        "peer": _short_id(match),
+        "peer_candidates": [
+            _short_id(value) for value in _peer_payload_candidates(payload)
+        ],
     }
 
 
@@ -856,7 +859,10 @@ class XSenseWebRTCSession:
                         **_peer_event_debug(payload, self._ticket.serial_number),
                     ),
                 )
-                self._recipient_client_id = str(payload).strip()
+                self._recipient_client_id = (
+                    _matching_peer_id(payload, self._ticket.serial_number)
+                    or self._ticket.serial_number
+                )
                 self._camera_peer_ready = True
                 task = getattr(self, "_peer_in_timeout_task", None)
                 if task:
@@ -987,7 +993,38 @@ def _owned_answer_sdp(payload: Any, ticket: XSenseWebRTCTicket) -> str | None:
 
 def _is_owned_peer_message(payload: Any, serial_number: str) -> bool:
     """Return whether a PEER_IN/PEER_OUT payload belongs to this camera."""
-    return isinstance(payload, str) and payload.strip() == serial_number
+    return _matching_peer_id(payload, serial_number) is not None
+
+
+def _matching_peer_id(payload: Any, serial_number: str) -> str | None:
+    for value in _peer_payload_candidates(payload):
+        if value == serial_number:
+            return value
+    return None
+
+
+def _peer_payload_candidates(payload: Any) -> list[str]:
+    if isinstance(payload, str):
+        return [payload.strip()]
+    if not isinstance(payload, dict):
+        return []
+    candidates: list[str] = []
+    for key in (
+        "clientId",
+        "serialNumber",
+        "deviceSn",
+        "deviceSN",
+        "sn",
+        "id",
+        "name",
+    ):
+        value = payload.get(key)
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text and text not in candidates:
+            candidates.append(text)
+    return candidates
 
 
 def _sdp_without_local_candidates(sdp: str) -> str:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -155,6 +155,14 @@ def test_mqtt_helper_publish_uses_compact_utf8_json():
     ]
 
 
+def test_xsense_mqtt_debug_title_redacts_account_email():
+    assert (
+        xsense_mqtt._redact_account_title("XSense Account user@example.com")
+        == "XSense Account <redacted>"
+    )
+    assert xsense_mqtt._redact_account_title("Other title") == "Other title"
+
+
 def test_xsense_mqtt_clean_disconnect_is_not_a_warning(caplog):
     caplog.set_level(logging.DEBUG)
     client = object.__new__(xsense_mqtt.XSenseMQTT)

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -439,6 +439,33 @@ def test_parse_signal_message_does_not_decode_plain_serial_like_peer_id():
     ) == ("PEER_IN", "MTAwMDA0")
 
 
+def test_object_peer_event_matches_camera_by_apk_signal_id():
+    event, payload = parse_signal_message(
+        json.dumps(
+            {
+                "messageType": "PEER_IN",
+                "messagePayload": {
+                    "group": "camera-group",
+                    "id": "SSC0A123",
+                    "name": "test-123",
+                    "role": "device",
+                },
+            }
+        )
+    )
+
+    assert event == "PEER_IN"
+    assert webrtc_signal._is_owned_peer_message(payload, "SSC0A123")
+    assert not webrtc_signal._is_owned_peer_message(payload, "SSC0B456")
+    assert webrtc_signal._peer_event_debug(payload, "SSC0A123") == {
+        "payload": "dict_keys=['group', 'id', 'name', 'role']",
+        "payload_matches_camera": True,
+        "camera": "...C0A123",
+        "peer": "...C0A123",
+        "peer_candidates": ["...C0A123", "...st-123"],
+    }
+
+
 
 def test_stop_live_data_channel_command_matches_apk(monkeypatch):
     monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)


### PR DESCRIPTION
## Summary
- handle object-shaped X-Sense WebRTC PEER_IN/PEER_OUT payloads from the signal server
- keep the APK-style serial ownership gate before accepting a camera peer
- redact X-Sense account email from MQTT debug socket logs
- bump manifest to 1.2.6.17

## Validation
- pytest -q tests/test_webrtc_signal.py tests/api/test_async_xsense.py
- pytest -q
- git diff --check

Home Assistant install/restart was skipped because the safety check reported mom_up is on.