### PR TITLE
Align camera WebRTC startup with APK

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,10 +34,10 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 no-changes-template: 'No changes'
 
-tag-prefix: 'v.'
+tag-prefix: 'v'
 version-template: '$MAJOR.$MINOR.$PATCH'
-tag-template: 'v.$RESOLVED_VERSION'
-name-template: 'Release v.$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+name-template: 'Release v$RESOLVED_VERSION'
 
 exclude-labels:
   - 'wontfix'

--- a/.github/release-notes/v1.2.6.19.md
+++ b/.github/release-notes/v1.2.6.19.md
@@ -1,0 +1,13 @@
+## X-Sense Home Security v1.2.6.19
+
+### 🎥 Camera WebRTC
+- Restores the Android app WebRTC branch for cameras already reported online: after the signal connection opens, the camera peer starts immediately instead of waiting for another `PEER_IN` event.
+
+### 🔧 Availability
+- Keeps explicit `online` / `onLine` states from being downgraded by stale shadow `onlineTime` values, which can affect devices such as XS01-WX when the app still reports them online.
+
+### 🧩 HACS Updates
+- Updates Release Drafter to use HACS-friendly future tag names such as `v1.2.6.19` instead of `v.1.2.6.19`.
+
+### ✅ Validation
+- Full test suite passed: 250 tests.

--- a/custom_components/xsense/api/entity.py
+++ b/custom_components/xsense/api/entity.py
@@ -48,6 +48,7 @@ class Entity:
         self.online = None
         self.room_id = kwargs.get("roomId")
         self._data = {}
+        self._online_from_explicit_flag = False
 
         entity = entities.get(self.type, {})
         self.entity_type = entity.get("type")
@@ -61,6 +62,7 @@ class Entity:
         online = bool_state(value)
         if online is not None:
             self.online = online
+            self._online_from_explicit_flag = True
 
     def set_data(self, values: dict):
         data = values.copy()
@@ -73,7 +75,16 @@ class Entity:
         if not has_online_flag:
             online = _online_from_report_time(data, self.type)
             if online is not None:
-                self.online = online
+                # The app treats online/onLine as the authoritative connection
+                # state. Report timestamps can confirm a device is awake, but
+                # should not turn an explicitly online device offline.
+                if (
+                    online
+                    or self.online is not True
+                    or not self._online_from_explicit_flag
+                ):
+                    self.online = online
+                    self._online_from_explicit_flag = False
         status_data = data.pop("status", {}) or {}
         if isinstance(status_data, dict):
             data.update(status_data)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.18"
+  "version": "1.2.6.19"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -506,17 +506,24 @@ class XSenseWebRTCSession:
                     "Camera did not start the WebRTC stream",
                 )
             )
-            LOGGER.debug(
-                "X-Sense WebRTC waiting for PEER_IN: %s",
-                self._debug_context(),
-            )
-            self._peer_in_timeout_task = asyncio.create_task(
-                self._fail_after_timeout(
-                    _PEER_IN_TIMEOUT,
-                    "xsense_webrtc_peer_in_timeout",
-                    "Camera did not join the WebRTC session",
+            if self._camera_online:
+                LOGGER.debug(
+                    "X-Sense WebRTC camera online, starting peer: %s",
+                    self._debug_context(),
                 )
-            )
+                await self._start_camera_peer()
+            else:
+                LOGGER.debug(
+                    "X-Sense WebRTC waiting for PEER_IN: %s",
+                    self._debug_context(),
+                )
+                self._peer_in_timeout_task = asyncio.create_task(
+                    self._fail_after_timeout(
+                        _PEER_IN_TIMEOUT,
+                        "xsense_webrtc_peer_in_timeout",
+                        "Camera did not join the WebRTC session",
+                    )
+                )
             return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
             LOGGER.debug(

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -231,6 +231,21 @@ def test_malformed_online_time_does_not_invent_online_state():
     assert station.online is None
 
 
+def test_stale_shadow_online_time_does_not_override_explicit_online_state():
+    station = Station(
+        House(),
+        stationId="station-id",
+        stationName="Smoke Alarm",
+        stationSn="station-sn",
+        category="XS01-WX",
+        online=1,
+    )
+
+    station.set_data({"onlineTime": "20260601000000", "utcTime": "20260603000000"})
+
+    assert station.online is True
+
+
 def test_alarm_control_panel_requires_security_device_family():
     smoke_station = _xs01_wx_from_real_shadow()
     smoke_station.type = "SBS50"

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -933,7 +933,7 @@ async def test_first_video_frame_cancels_play_timeout():
     assert session._play_timeout_task.cancelled()
 
 
-async def test_online_camera_waits_for_peer_in_during_start_like_apk():
+async def test_online_camera_starts_peer_without_waiting_for_peer_in_like_apk():
     class FakeWs:
         closed = False
 
@@ -1054,9 +1054,9 @@ async def test_online_camera_waits_for_peer_in_during_start_like_apk():
         webrtc_signal.asyncio.create_task = original_create_task
 
     assert aio_session.ws.messages == []
-    assert started == []
-    assert session._peer_in_timeout_task is tasks[-1]
-    assert len(tasks) == 3
+    assert started == [True]
+    assert session._peer_in_timeout_task is None
+    assert len(tasks) == 2
     assert sent_messages[0].answer == "v=0\r\n"
 
 


### PR DESCRIPTION
## Summary
- restore the Android app WebRTC branch for cameras already reported online so the camera peer starts after signal connect instead of waiting for another PEER_IN event
- keep explicit online/onLine state from being downgraded by stale shadow onlineTime values
- update Release Drafter to use HACS-friendly future tags like v1.2.6.19
- bump manifest to 1.2.6.19 and add release notes

## Validation
- pytest -q: 250 passed