### PR TITLE
Match 1.2.6.20 release note style

### DIFF
--- a/.github/release-notes/1.2.6.20.md
+++ b/.github/release-notes/1.2.6.20.md
@@ -1,8 +1,8 @@
-## X-Sense Home Security 1.2.6.20
+## X-Sense Home Security v1.2.6.20
 
-### Camera WebRTC
-- Adjusts camera startup to wait for the camera peer signal before sending the WebRTC offer, matching the signal sequence seen in current camera logs.
+### 🎥 Camera WebRTC
+- Adjusts camera startup so the WebRTC offer is sent after the camera peer signal is seen, matching the signal sequence from current camera debug logs.
 
-### Debug Logging
-- Adds compact camera WebRTC debug summaries for peer dropouts, including signal event counts and ICE candidate counts.
-- Removes noisy MQTT socket write-loop debug messages so debug logs stay focused on useful troubleshooting details.
+### 🔎 Debug Logging
+- Adds compact WebRTC debug summaries for camera peer dropouts, including signal event counts and ICE candidate counts.
+- Removes noisy MQTT socket write-loop messages so debug logs stay focused on useful troubleshooting details.


### PR DESCRIPTION
## Summary
- update the 1.2.6.20 release-note heading/body to match the established release-note style

## Tests
- not run; release-note text only
