### PR TITLE
Prepare camera WebRTC prerelease 1.2.6.21

### DIFF
--- a/.github/release-notes/v1.2.6.21.md
+++ b/.github/release-notes/v1.2.6.21.md
@@ -1,0 +1,9 @@
+## X-Sense Home Security v1.2.6.21
+
+### Camera/WebRTC prerelease
+- Moves the active camera/WebRTC work to prerelease builds while testing continues, so stable releases stay less cluttered.
+- Camera users who want to test the newest camera updates should enable prereleases in HACS/GitHub to see this update.
+- Aligns more of the camera signaling and data-channel flow with the Android app behavior.
+
+### Support diagnostics
+- Adds compact debug and diagnostics context for future reports without logging raw payloads, tokens, serials, or stream URLs.

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -12,6 +12,7 @@ from .entity_map import EntityType, entities
 from .exceptions import SessionExpired, APIFailure, XSenseError
 from .house import House
 from .station import Station
+from ..const import LOGGER
 
 CAMERA_TYPES = {"SSC0A", "SSC0B"}
 CAMERA_LIVE_URL_MAX_AGE_SECONDS = 240
@@ -92,6 +93,25 @@ _SECOND_INFO_DEVICE_TYPES = {
     "XP0J-iA",
     "XR0A-iR",
 }
+
+
+def _debug_keys(value: Any) -> list[str]:
+    """Return sorted mapping keys for debug logs without dumping values."""
+    if not isinstance(value, dict):
+        return []
+    return sorted(str(key) for key in value)
+
+
+def _debug_data_shape(value: Any) -> dict[str, Any]:
+    """Return compact response shape details for debug logs."""
+    if isinstance(value, dict):
+        shape: dict[str, Any] = {"keys": _debug_keys(value)}
+        if isinstance(value.get("list"), list):
+            shape["list_count"] = len(value["list"])
+        return shape
+    if isinstance(value, list):
+        return {"list_count": len(value)}
+    return {"type": type(value).__name__}
 
 
 def _station_state_shadow_names(station: Station) -> tuple[str, ...]:
@@ -210,14 +230,33 @@ class AsyncXSense(XSenseBase):
             data = await response.json()
 
             if response.status >= 400:
+                LOGGER.debug(
+                    "X-Sense API failure context: code=%s status=%s keys=%s",
+                    code,
+                    response.status,
+                    _debug_keys(data),
+                )
                 message = data.get("message") or "unknown error"
                 raise APIFailure(f"API failure: {response.status}/{message}")
 
             if "reCode" not in data:
+                LOGGER.debug(
+                    "X-Sense API unexpected response context: code=%s status=%s keys=%s",
+                    code,
+                    response.status,
+                    _debug_keys(data),
+                )
                 raise APIFailure("API failure: Cannot understand response")
 
             if data["reCode"] != 200:
                 errCode = data.get("errCode", 0)
+                LOGGER.debug(
+                    "X-Sense API error context: code=%s reCode=%s errCode=%s keys=%s",
+                    code,
+                    data["reCode"],
+                    errCode,
+                    _debug_keys(data),
+                )
                 if errCode in ("10000008", "10000020"):
                     raise SessionExpired(data.get("reMsg"))
                 raise APIFailure(
@@ -240,11 +279,24 @@ class AsyncXSense(XSenseBase):
             data = await response.json()
 
             if response.status >= 400:
+                LOGGER.debug(
+                    "X-Sense IPC failure context: code=%s status=%s keys=%s",
+                    code,
+                    response.status,
+                    _debug_keys(data),
+                )
                 message = data.get("message") or data.get("reMsg") or "unknown error"
                 raise APIFailure(f"IPC API failure: {response.status}/{message}")
 
             if str(data.get("reCode")) != "200":
                 err_code = data.get("errCode", 0)
+                LOGGER.debug(
+                    "X-Sense IPC error context: code=%s reCode=%s errCode=%s keys=%s",
+                    code,
+                    data.get("reCode"),
+                    err_code,
+                    _debug_keys(data),
+                )
                 if err_code in ("10000008", "10000020"):
                     raise SessionExpired(data.get("reMsg"))
                 raise APIFailure(
@@ -277,6 +329,14 @@ class AsyncXSense(XSenseBase):
             result = await response.json()
 
             if response.status >= 400:
+                LOGGER.debug(
+                    "X-Sense ADDX failure context: endpoint=%s status=%s node=%s keys=%s data_shape=%s",
+                    endpoint,
+                    response.status,
+                    node,
+                    _debug_keys(result),
+                    _debug_data_shape(result.get("data")),
+                )
                 if response.status in (401, 403) and _retry:
                     self._addx_session = await self.register_ipc()
                     return await self.addx_call(endpoint, _retry=False, **kwargs)
@@ -284,6 +344,14 @@ class AsyncXSense(XSenseBase):
                 raise APIFailure(f"ADDX API failure: {response.status}/{message}")
 
             if result.get("result") not in (0, None):
+                LOGGER.debug(
+                    "X-Sense ADDX error context: endpoint=%s result=%s node=%s keys=%s data_shape=%s",
+                    endpoint,
+                    result.get("result"),
+                    node,
+                    _debug_keys(result),
+                    _debug_data_shape(result.get("data")),
+                )
                 raise APIFailure(
                     f"ADDX request for {endpoint} failed with error {result.get('result')}/{result.get('msg')}"
                 )
@@ -298,17 +366,17 @@ class AsyncXSense(XSenseBase):
         language = addx_session.get("language")
         if not language:
             raise APIFailure("Missing ADDX language from IPC registration")
-        tenant = addx_session.get("tenantId")
         result["countryNo"] = country
         result["language"] = language
         result["app"] = {
-            "appName": "X-Sense Home Security",
+            "appName": self.ADDX_APP_NAME,
             "appType": "Android",
-            "bundle": "com.xsense.security",
-            "channelId": 0,
-            "tenantId": tenant,
-            "version": int(self.IPC_APPCODE),
-            "versionName": self.IPC_VERSION,
+            "bundle": self.ADDX_APP_BUNDLE,
+            "channelId": self.ADDX_APP_CHANNEL_ID,
+            "countlyId": self.ADDX_APP_COUNTLY_ID,
+            "tenantId": self.ADDX_APP_TENANT_ID,
+            "version": self.ADDX_APP_VERSION,
+            "versionName": self.ADDX_APP_VERSION_NAME,
         }
         return result
 

--- a/custom_components/xsense/api/base.py
+++ b/custom_components/xsense/api/base.py
@@ -53,6 +53,14 @@ class XSenseBase:
     IPC_APPCODE = APPCODE
     IPC_CLIENTTYPE = CLIENTYPE
 
+    ADDX_APP_NAME = "VicoHome"
+    ADDX_APP_BUNDLE = "com.ai.vicoo"
+    ADDX_APP_CHANNEL_ID = 1000
+    ADDX_APP_COUNTLY_ID = "b940908f19b8e858"
+    ADDX_APP_TENANT_ID = "guard"
+    ADDX_APP_VERSION = 200700500
+    ADDX_APP_VERSION_NAME = "2.7.5"
+
     userid = None
     username = None
     clientid = None

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -223,6 +223,15 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     devices.update(s.devices.items())
 
             self._merge_cached_camera_stations(stations)
+            LOGGER.debug(
+                "X-Sense coordinator refresh summary: stations=%s devices=%s camera_initialized=%s camera_cache=%s mqtt_servers=%s mqtt_connected=%s",
+                len(stations),
+                len(devices),
+                self._camera_initialized,
+                len(self._camera_station_cache),
+                len(self.mqtt_servers),
+                sum(1 for mqtt in self.mqtt_servers.values() if mqtt.connected),
+            )
 
         except (SessionExpired, AuthFailed) as ex:
             if not retry:
@@ -264,6 +273,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return False
         else:
             self._camera_initialized = True
+            LOGGER.debug("X-Sense camera metadata refresh completed")
             return True
 
     def _cache_camera_stations(self) -> None:

--- a/custom_components/xsense/diagnostics.py
+++ b/custom_components/xsense/diagnostics.py
@@ -142,6 +142,46 @@ def entity_diagnostics(entity) -> dict[str, Any]:
     }
 
 
+def _type_counts(entities) -> dict[str, int]:
+    """Return compact type counts for diagnostics."""
+    counts: dict[str, int] = {}
+    for entity in entities:
+        entity_type = str(getattr(entity, "type", "") or "unknown")
+        counts[entity_type] = counts.get(entity_type, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def coordinator_diagnostics(
+    coordinator: XSenseDataUpdateCoordinator,
+) -> dict[str, Any]:
+    """Return compact coordinator state for future support reports."""
+    stations = (coordinator.data or {}).get("stations", {})
+    devices = (coordinator.data or {}).get("devices", {})
+    last_camera_update = coordinator._last_camera_update_attempt
+    return {
+        "last_update_success": coordinator.last_update_success,
+        "last_exception": (
+            type(coordinator.last_exception).__name__
+            if coordinator.last_exception
+            else None
+        ),
+        "initialized": coordinator._initialized,
+        "camera_initialized": coordinator._camera_initialized,
+        "last_camera_update_attempt": (
+            last_camera_update.isoformat() if last_camera_update else None
+        ),
+        "camera_station_cache_count": len(coordinator._camera_station_cache),
+        "mqtt_server_count": len(coordinator.mqtt_servers),
+        "mqtt_connected_count": sum(
+            1 for mqtt in coordinator.mqtt_servers.values() if mqtt.connected
+        ),
+        "station_count": len(stations),
+        "device_count": len(devices),
+        "station_types": _type_counts(stations.values()),
+        "device_types": _type_counts(devices.values()),
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
@@ -151,6 +191,7 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "coordinator": coordinator_diagnostics(coordinator),
         "data": {
             "stations": [
                 entity_diagnostics(station)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.20"
+  "version": "1.2.6.21"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -319,24 +319,50 @@ def make_ice_candidate_payload(
 
 def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
     """Return the APK-compatible data-channel startLive command."""
-    message = make_data_channel_command("startLive")
-    message.update(
-        {
+    return make_data_channel_command(
+        "startLive",
+        top_level_parameters={
             "size": _map_video_size(resolution),
             "resolution": resolution,
-        }
+        },
     )
-    return message
 
 
-def make_data_channel_command(action: str) -> dict[str, Any]:
+def make_data_channel_command(
+    action: str,
+    *,
+    request_id: str | None = None,
+    parameters: dict[str, Any] | None = None,
+    top_level_parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Return the APK-compatible base data-channel command."""
-    return {
-        "requestID": f"{int(time.time() * 1000)}-{random.randint(0, 999)}",
+    message: dict[str, Any] = {
+        "requestID": request_id
+        or f"{int(time.time() * 1000)}-{random.randint(0, 999)}",
         "connectionID": "7893feb",
         "timeStamp": int(time.time()),
         "action": action,
     }
+    if top_level_parameters:
+        message.update(top_level_parameters)
+    elif parameters:
+        message["parameters"] = parameters
+    return message
+
+
+def make_change_transceiver_offer_command(offer_sdp: str) -> dict[str, Any]:
+    """Return the APK-compatible changeTransceiverOffer command."""
+    encoded_offer = _b64_json({"type": "offer", "sdp": offer_sdp})
+    return make_data_channel_command(
+        "changeTransceiverOffer", parameters={"offer": encoded_offer}
+    )
+
+
+def make_data_channel_answer_command(request_id: str, action: str) -> dict[str, Any]:
+    """Return the APK-compatible data-channel command acknowledgement."""
+    return make_data_channel_command(
+        action, request_id=request_id, parameters={"returnValue": "0"}
+    )
 
 
 def parse_signal_message(raw: str | bytes) -> tuple[str | None, Any]:
@@ -674,13 +700,7 @@ class XSenseWebRTCSession:
         """Send the APK stopLive data-channel command before closing."""
         if getattr(self._data_channel, "readyState", None) != "open":
             return
-        with suppress(Exception):
-            self._data_channel.send(
-                json.dumps(
-                    make_data_channel_command("stopLive"),
-                    separators=(",", ":"),
-                )
-            )
+        self._send_data_channel_json(make_data_channel_command("stopLive"))
 
     def _setup_camera_peer(self) -> None:
         @self._camera_pc.on("track")
@@ -727,9 +747,62 @@ class XSenseWebRTCSession:
             )
         except (TypeError, json.JSONDecodeError):
             return
-        if payload.get("action") == "dataChannelConnected":
+        action = payload.get("action")
+        if action == "dataChannelConnected":
             self._data_channel_connected = True
             self._send_start_live_if_ready()
+        elif action == "requestChangeTransceiverOffer":
+            request_id = payload.get("requestID")
+            if isinstance(request_id, str):
+                self._send_data_channel_json(
+                    make_data_channel_answer_command(
+                        request_id, "requestChangeTransceiverOffer"
+                    )
+                )
+            self._create_task(self._send_change_transceiver_offer())
+        elif action == "changeTransceiverOffer":
+            self._create_task(self._apply_change_transceiver_answer(payload))
+
+    def _send_data_channel_json(self, payload: dict[str, Any]) -> bool:
+        if getattr(self._data_channel, "readyState", None) != "open":
+            return False
+        try:
+            self._data_channel.send(json.dumps(payload, separators=(",", ":")))
+        except Exception as err:
+            LOGGER.debug("Unable to send X-Sense data-channel command", exc_info=err)
+            return False
+        return True
+
+    async def _send_change_transceiver_offer(self) -> None:
+        """Respond to requestChangeTransceiverOffer like the Android app."""
+        if self._closed or getattr(self._data_channel, "readyState", None) != "open":
+            return
+        offer = await self._camera_pc.createOffer()
+        await self._camera_pc.setLocalDescription(offer)
+        if self._send_data_channel_json(
+            make_change_transceiver_offer_command(offer.sdp)
+        ):
+            LOGGER.debug(
+                "X-Sense WebRTC sent changeTransceiverOffer: %s",
+                self._debug_context(offer_sdp_len=len(offer.sdp)),
+            )
+
+    async def _apply_change_transceiver_answer(self, payload: dict[str, Any]) -> None:
+        """Apply the APK changeTransceiverOffer answer from the data channel."""
+        answer = _data_channel_answer_sdp(payload)
+        if not answer:
+            LOGGER.debug(
+                "X-Sense WebRTC ignored invalid changeTransceiverOffer answer: %s",
+                self._debug_context(payload=_payload_debug(payload)),
+            )
+            return
+        await self._camera_pc.setRemoteDescription(
+            RTCSessionDescription(sdp=answer, type="answer")
+        )
+        LOGGER.debug(
+            "X-Sense WebRTC applied changeTransceiverOffer answer: %s",
+            self._debug_context(),
+        )
 
     def _send_start_live_if_ready(self) -> None:
         """Send startLive when the APK would: after dataChannelConnected."""
@@ -742,15 +815,9 @@ class XSenseWebRTCSession:
             return
         if self._camera_pc.connectionState != "connected":
             return
-        try:
-            self._data_channel.send(
-                json.dumps(
-                    make_start_live_data_channel_message(self._resolution),
-                    separators=(",", ":"),
-                )
-            )
-        except Exception as err:
-            LOGGER.debug("Unable to send X-Sense startLive command", exc_info=err)
+        if not self._send_data_channel_json(
+            make_start_live_data_channel_message(self._resolution)
+        ):
             return
         self._start_live_sent = True
         LOGGER.debug(
@@ -760,6 +827,9 @@ class XSenseWebRTCSession:
 
     async def _start_camera_peer(self) -> None:
         LOGGER.debug("X-Sense WebRTC creating camera offer: %s", self._debug_context())
+        # The Android app asks createOffer to receive both video and audio.
+        # aiortc has no offer constraints, so recvonly transceivers are the
+        # equivalent offer shape.
         self._camera_pc.addTransceiver("video", direction="recvonly")
         self._camera_pc.addTransceiver("audio", direction="recvonly")
         offer = await self._camera_pc.createOffer()
@@ -1013,6 +1083,24 @@ def _owned_answer_sdp(payload: Any, ticket: XSenseWebRTCTicket) -> str | None:
     if recipient and recipient != ticket.client_id:
         return None
     return _answer_sdp(payload)
+
+
+def _data_channel_answer_sdp(payload: Any) -> str | None:
+    """Return the APK changeTransceiverOffer answer SDP from data-channel JSON."""
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    encoded = data.get("answer")
+    if not isinstance(encoded, str):
+        return None
+    with suppress(Exception):
+        decoded = json.loads(base64.b64decode(encoded).decode())
+        sdp = decoded.get("sdp")
+        if isinstance(sdp, str):
+            return sdp
+    return None
 
 
 def _is_owned_peer_message(payload: Any, serial_number: str) -> bool:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -2964,3 +2964,32 @@ async def test_update_camera_data_reraises_real_camera_api_errors():
 
     with pytest.raises(exceptions.APIFailure):
         await client.update_camera_data()
+
+def test_addx_body_uses_apk_app_info():
+    """ADDX camera requests use the app info object from the Android SDK."""
+    api = async_xsense.AsyncXSense()
+
+    body = api._addx_body(
+        {
+            "countryNo": "US",
+            "language": "en",
+            "tenantId": "ignored-session-tenant",
+        },
+        {"serialNumber": "SSC0A123"},
+    )
+
+    assert body == {
+        "serialNumber": "SSC0A123",
+        "countryNo": "US",
+        "language": "en",
+        "app": {
+            "appName": "VicoHome",
+            "appType": "Android",
+            "bundle": "com.ai.vicoo",
+            "channelId": 1000,
+            "countlyId": "b940908f19b8e858",
+            "tenantId": "guard",
+            "version": 200700500,
+            "versionName": "2.7.5",
+        },
+    }

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+import asyncio
 import base64
 import json
 
@@ -8,6 +9,8 @@ from custom_components.xsense import webrtc_signal
 from custom_components.xsense.webrtc_signal import (
     SIGNAL_DATA_CHANNEL,
     XSenseWebRTCTicket,
+    make_change_transceiver_offer_command,
+    make_data_channel_answer_command,
     make_ice_candidate_payload,
     make_sdp_offer_payload,
     make_start_live_data_channel_message,
@@ -199,6 +202,157 @@ a=candidate:4 1 udp 1 ::1 790 typ host
             "candidate": "candidate:3 1 udp 1 2001:db8::2 789 typ host",
         },
     ]
+
+
+def test_change_transceiver_commands_match_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    ack = make_data_channel_answer_command("request-1", "requestChangeTransceiverOffer")
+    assert ack == {
+        "requestID": "request-1",
+        "connectionID": "7893feb",
+        "timeStamp": 100,
+        "action": "requestChangeTransceiverOffer",
+        "parameters": {"returnValue": "0"},
+    }
+
+    command = make_change_transceiver_offer_command("v=0\r\n")
+    assert command | {"parameters": {"offer": "<decoded>"}} == {
+        "requestID": "100000-321",
+        "connectionID": "7893feb",
+        "timeStamp": 100,
+        "action": "changeTransceiverOffer",
+        "parameters": {"offer": "<decoded>"},
+    }
+    assert json.loads(
+        base64.b64decode(command["parameters"]["offer"]).decode()
+    ) == {"type": "offer", "sdp": "v=0\r\n"}
+
+
+async def test_data_channel_request_change_transceiver_offer_matches_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    class Offer:
+        sdp = "v=0\r\n"
+
+    class FakePeerConnection:
+        connectionState = "connected"
+
+        def __init__(self):
+            self.local_descriptions = []
+            self.remote_descriptions = []
+
+        async def createOffer(self):
+            return Offer()
+
+        async def setLocalDescription(self, offer):
+            self.local_descriptions.append(offer)
+
+        async def setRemoteDescription(self, answer):
+            self.remote_descriptions.append(answer)
+
+    class FakeDataChannel:
+        readyState = "open"
+
+        def __init__(self):
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(json.loads(message))
+
+    created_tasks = []
+
+    def create_task(coro):
+        task = asyncio.create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._camera_pc = FakePeerConnection()
+    session._data_channel = FakeDataChannel()
+    session._create_task = create_task
+    session._debug_context = lambda **kwargs: kwargs
+
+    session._handle_data_channel_message(
+        json.dumps({"action": "requestChangeTransceiverOffer", "requestID": "req-1"})
+    )
+    await asyncio.gather(*created_tasks)
+
+    assert session._data_channel.messages[0] == {
+        "requestID": "req-1",
+        "connectionID": "7893feb",
+        "timeStamp": 100,
+        "action": "requestChangeTransceiverOffer",
+        "parameters": {"returnValue": "0"},
+    }
+    second_message = session._data_channel.messages[1]
+    assert second_message | {"parameters": {"offer": "<decoded>"}} == {
+        "requestID": "100000-321",
+        "connectionID": "7893feb",
+        "timeStamp": 100,
+        "action": "changeTransceiverOffer",
+        "parameters": {"offer": "<decoded>"},
+    }
+
+    encoded_answer = base64.b64encode(
+        json.dumps({"sdp": "v=0\r\nanswer"}).encode()
+    ).decode()
+    created_tasks.clear()
+    session._handle_data_channel_message(
+        json.dumps(
+            {
+                "action": "changeTransceiverOffer",
+                "data": {"answer": encoded_answer},
+            }
+        )
+    )
+    await asyncio.gather(*created_tasks)
+
+    assert session._camera_pc.remote_descriptions[0].type == "answer"
+    assert session._camera_pc.remote_descriptions[0].sdp == "v=0\r\nanswer"
+
+
+async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch):
+    class FakePeer:
+        def __init__(self):
+            self.transceivers = []
+
+        def addTransceiver(self, kind, **kwargs):
+            self.transceivers.append((kind, kwargs))
+
+        async def createOffer(self):
+            class Offer:
+                sdp = "v=0\r\n"
+
+            return Offer()
+
+        async def setLocalDescription(self, offer):
+            self.localDescription = offer
+
+    async def noop_send_offer():
+        return None
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._camera_pc = FakePeer()
+    session._debug_context = lambda **kwargs: {}
+    session._send_offer = noop_send_offer
+    session._camera_local_description_task = None
+    session._camera_offer_sdp = None
+
+    await session._start_camera_peer()
+
+    assert session._camera_pc.transceivers == [
+        ("video", {"direction": "recvonly"}),
+        ("audio", {"direction": "recvonly"}),
+    ]
+    assert session._camera_offer_sdp == "v=0\r\n"
+    assert session._camera_local_description_task is not None
+    session._camera_local_description_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await session._camera_local_description_task
 
 
 async def test_send_offer_sends_apk_offer_then_local_ice_candidates():


### PR DESCRIPTION
## Summary
- align camera WebRTC signaling and data-channel handling with the Android app flow
- use APK ADDX app metadata for camera API calls
- add compact debug and diagnostics context for future support reports
- bump manifest to 1.2.6.21 and add prerelease notes for camera testers

## Tests
- `git diff --check`
- `python3 -m compileall -q custom_components/xsense tests`
- `pytest -q tests/api/test_async_xsense.py tests/test_webrtc_signal.py tests/test_diagnostics.py`
- `pytest -q`