### PR TITLE
Handle camera method/value signal messages

### DIFF
--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -374,10 +374,20 @@ def parse_signal_message(raw: str | bytes) -> tuple[str | None, Any]:
     except (TypeError, json.JSONDecodeError):
         return None, raw
 
-    event = data.get("messageType") or data.get("event") or data.get("type")
+    event = (
+        data.get("messageType")
+        or data.get("event")
+        or data.get("type")
+        or data.get("method")
+    )
     payload: Any = _signal_payload(data)
     if isinstance(payload, str) and event == "SDP_ANSWER":
-        payload = data
+        with suppress(Exception):
+            decoded = json.loads(payload)
+            if isinstance(decoded, dict):
+                payload = decoded
+        if isinstance(payload, str):
+            payload = data
     elif isinstance(payload, str) and event == "ICE_CANDIDATE":
         with suppress(Exception):
             payload = json.loads(base64.b64decode(payload).decode())
@@ -387,7 +397,7 @@ def parse_signal_message(raw: str | bytes) -> tuple[str | None, Any]:
 
 
 def _signal_payload(data: dict[str, Any]) -> Any:
-    for key in ("messagePayload", "payload", "data", "message", "body"):
+    for key in ("messagePayload", "payload", "data", "message", "body", "value"):
         if key in data:
             return data[key]
     return data

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -430,6 +430,50 @@ def test_send_ha_message_ignores_closed_browser_socket():
     assert session._send_ha_message(message) is False
 
 
+def test_parse_signal_message_accepts_signal_method_value_events():
+    raw = json.dumps(
+        {
+            "id": "message-1",
+            "method": "SDP_ANSWER",
+            "name": "test-123",
+            "time": 123,
+            "value": json.dumps(
+                {
+                    "messagePayload": base64.b64encode(
+                        json.dumps({"type": "answer", "sdp": "v=0\r\n"}).encode()
+                    ).decode(),
+                    "senderClientId": "SSC0A123",
+                    "recipientClientId": "client123",
+                    "sessionId": "Android-client123-100000",
+                }
+            ),
+        }
+    )
+
+    event, payload = parse_signal_message(raw)
+
+    assert event == "SDP_ANSWER"
+    assert payload["senderClientId"] == "SSC0A123"
+    assert payload["recipientClientId"] == "client123"
+
+
+def test_parse_signal_message_keeps_unknown_method_value_for_debug():
+    raw = json.dumps(
+        {
+            "id": "message-2",
+            "method": "cameraStatus",
+            "name": "test-123",
+            "time": 123,
+            "value": json.dumps({"value": 1}),
+        }
+    )
+
+    event, payload = parse_signal_message(raw)
+
+    assert event == "cameraStatus"
+    assert payload == json.dumps({"value": 1})
+
+
 def test_parse_signal_message_preserves_answer_envelope_for_apk_validation():
     encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
     raw = json.dumps(


### PR DESCRIPTION
## Summary
- handle signal-server messages that carry the APK callback event in `method` and the callback body in `value`
- decode `method=SDP_ANSWER` value payloads so camera answers follow the same validation path as APK `onMsgRecv`
- keep unknown method/value messages visible as compact debug context instead of dropping them as `event=None`

## Tests
- `git diff --check`
- `python3 -m compileall -q custom_components/xsense tests`
- `pytest -q tests/test_webrtc_signal.py`
- `pytest -q tests/api/test_async_xsense.py tests/test_webrtc_signal.py tests/test_diagnostics.py`
- `pytest -q`