### PR TITLE
Prepare X-Sense 1.2.6.22 prerelease

### DIFF
--- a/.github/release-notes/1.2.6.22.md
+++ b/.github/release-notes/1.2.6.22.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.2.6.22
+
+### Camera/WebRTC prerelease
+- Continues camera/WebRTC testing in a prerelease build.
+- Handles APK-style signal callback messages where the signal event is carried in `method` and the payload body is carried in `value`.
+- Keeps camera debug output focused on useful event names, state, and payload shape for follow-up reports.
+
+### Notes for testers
+- Camera users who want to test this build should enable prereleases in HACS/GitHub.
+- Stable users can remain on the latest stable release.

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.21"
+  "version": "1.2.6.22"
 }


### PR DESCRIPTION
## Summary
- bump manifest to 1.2.6.22 for prerelease testing
- add release notes for the camera/WebRTC signal parser update
- keep release notes/docs wording with `v1.2.6.22`, while the release tag/title remain numeric

## Tests
- `git diff --check`
- `python3 -m compileall -q custom_components/xsense tests`
- `pytest -q tests/api/test_async_xsense.py tests/test_webrtc_signal.py tests/test_diagnostics.py`
- `pytest -q`