### PR TITLE
Align camera WebRTC signaling with APK wire format

### DIFF
--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -317,6 +317,11 @@ def make_ice_candidate_payload(
     return json.dumps(envelope, separators=(",", ":"))
 
 
+def make_signal_wire_payload(event: str, envelope: str) -> str:
+    """Return the signal-server wire message around an APK event envelope."""
+    return json.dumps({"method": event, "value": envelope}, separators=(",", ":"))
+
+
 def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
     """Return the APK-compatible data-channel startLive command."""
     return make_data_channel_command(
@@ -720,6 +725,9 @@ class XSenseWebRTCSession:
             elif track.kind == "audio":
                 self._audio.set_source(track)
 
+        # APK creates the audio transceiver during peer setup, before the
+        # data channel and before createOffer. Video is requested at offer time.
+        self._camera_pc.addTransceiver("audio", direction="recvonly")
         self._data_channel = self._camera_pc.createDataChannel(SIGNAL_DATA_CHANNEL)
 
         @self._data_channel.on("message")
@@ -837,11 +845,9 @@ class XSenseWebRTCSession:
 
     async def _start_camera_peer(self) -> None:
         LOGGER.debug("X-Sense WebRTC creating camera offer: %s", self._debug_context())
-        # The Android app asks createOffer to receive both video and audio.
-        # aiortc has no offer constraints, so recvonly transceivers are the
-        # equivalent offer shape.
+        # APK createOffer asks to receive video; audio is already present from
+        # peer setup, matching the SDK transceiver timing.
         self._camera_pc.addTransceiver("video", direction="recvonly")
-        self._camera_pc.addTransceiver("audio", direction="recvonly")
         offer = await self._camera_pc.createOffer()
         self._camera_offer_sdp = offer.sdp
         self._camera_local_description_task = asyncio.create_task(
@@ -865,15 +871,14 @@ class XSenseWebRTCSession:
                 offer_sdp_len=len(self._camera_offer_sdp),
             ),
         )
-        await self._ws.send_str(
-            make_sdp_offer_payload(
-                offer_sdp=self._camera_offer_sdp,
-                ticket=self._ticket,
-                recipient_client_id=self._recipient_client_id,
-                session_id=self._session_id,
-                resolution=self._resolution,
-            )
+        offer_payload = make_sdp_offer_payload(
+            offer_sdp=self._camera_offer_sdp,
+            ticket=self._ticket,
+            recipient_client_id=self._recipient_client_id,
+            session_id=self._session_id,
+            resolution=self._resolution,
         )
+        await self._ws.send_str(make_signal_wire_payload("SDP_OFFER", offer_payload))
         self._camera_offer_sent = True
         if self._camera_local_description_task:
             await self._camera_local_description_task
@@ -897,15 +902,16 @@ class XSenseWebRTCSession:
         for candidate in candidates:
             if self._closed or self._ws is None or getattr(self._ws, "closed", False):
                 return
+            candidate_payload = make_ice_candidate_payload(
+                candidate=candidate["candidate"],
+                sdp_mid=candidate["sdpMid"],
+                sdp_m_line_index=candidate["sdpMLineIndex"],
+                ticket=self._ticket,
+                recipient_client_id=self._recipient_client_id,
+                session_id=self._session_id,
+            )
             await self._ws.send_str(
-                make_ice_candidate_payload(
-                    candidate=candidate["candidate"],
-                    sdp_mid=candidate["sdpMid"],
-                    sdp_m_line_index=candidate["sdpMLineIndex"],
-                    ticket=self._ticket,
-                    recipient_client_id=self._recipient_client_id,
-                    session_id=self._session_id,
-                )
+                make_signal_wire_payload("ICE_CANDIDATE", candidate_payload)
             )
 
     async def _read_loop(self) -> None:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -176,6 +176,19 @@ def test_webrtc_ice_candidate_payload_matches_apk():
         "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
     }
 
+def test_signal_wire_payload_wraps_apk_envelope_for_raw_websocket():
+    envelope = make_sdp_offer_payload(
+        offer_sdp="v=0\r\n",
+        ticket=ticket(),
+        recipient_client_id="SSC0A123",
+        session_id="Android-client123-100000",
+        resolution="1280x720",
+    )
+
+    wire = json.loads(webrtc_signal.make_signal_wire_payload("SDP_OFFER", envelope))
+
+    assert wire == {"method": "SDP_OFFER", "value": envelope}
+
 
 def test_local_sdp_candidates_match_apk_loopback_and_tcp_filters():
     sdp = """v=0
@@ -346,7 +359,6 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
 
     assert session._camera_pc.transceivers == [
         ("video", {"direction": "recvonly"}),
-        ("audio", {"direction": "recvonly"}),
     ]
     assert session._camera_offer_sdp == "v=0\r\n"
     assert session._camera_local_description_task is not None
@@ -390,11 +402,12 @@ a=candidate:1 1 udp 1 192.0.2.1 123 typ host
 
     await session._send_offer()
 
-    assert [message["messageType"] for message in session._ws.messages] == [
+    assert [message["method"] for message in session._ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",
     ]
-    assert session._ws.messages[1] | {"messagePayload": "<decoded>"} == {
+    candidate_message = json.loads(session._ws.messages[1]["value"])
+    assert candidate_message | {"messagePayload": "<decoded>"} == {
         "messageType": "ICE_CANDIDATE",
         "messagePayload": "<decoded>",
         "recipientClientId": "SSC0A123",
@@ -968,7 +981,7 @@ async def test_camera_offer_does_not_wait_for_local_ice_gathering():
     task = asyncio.create_task(session._send_offer())
     await asyncio.sleep(0)
 
-    assert [message["messageType"] for message in session._ws.messages] == ["SDP_OFFER"]
+    assert [message["method"] for message in session._ws.messages] == ["SDP_OFFER"]
     assert session._camera_offer_sent is True
 
     session._camera_local_description_task.cancel()
@@ -1306,5 +1319,5 @@ async def test_offline_camera_waits_for_peer_in_before_offer_like_apk():
 
     await session._handle_signal_event("PEER_IN", "SSC0A123")
 
-    assert [message["messageType"] for message in session._ws.messages] == ["SDP_OFFER"]
+    assert [message["method"] for message in session._ws.messages] == ["SDP_OFFER"]
     assert session._camera_offer_sent is True


### PR DESCRIPTION
## Summary
- Wrap outgoing camera WebRTC signal messages in the same event/value wire shape used by the X-Sense APK.
- Align camera peer setup timing with the APK by creating the audio transceiver during peer setup and requesting video at offer time.
- Keep focused WebRTC regression coverage for the signaling wire format.

## Validation
- `pytest -q tests/test_webrtc_signal.py`
- `pytest -q`
- `git diff --check`
