### PR TITLE
Harden camera ICE signaling and prerelease workflow

### DIFF
--- a/.github/release-notes/1.2.6.24.md
+++ b/.github/release-notes/1.2.6.24.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security 1.2.6.24
+
+### 🎥 Camera WebRTC
+- Handles a closing camera signal socket during ICE candidate sending without crashing the WebRTC reader.
+- Keeps additional debug context for camera sessions that still fail before an SDP answer arrives.
+
+### 🔧 Release Workflow
+- Supports non-v prerelease tags and no longer forces prereleases to become latest.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
 
 permissions:
@@ -29,8 +30,16 @@ jobs:
           notes_file=".github/release-notes/${tag}.md"
           title="Release ${tag}"
 
+          release_args=(--verify-tag --title "$title")
+          version="${tag#v}"
+          version="${version#v.}"
+          IFS='.' read -r -a version_parts <<< "$version"
+          if (( ${#version_parts[@]} >= 4 )); then
+            release_args+=(--prerelease)
+          fi
+
           if gh release view "$tag" >/dev/null 2>&1; then
-            args=(--verify-tag --title "$title" --draft=false)
+            args=("${release_args[@]}" --draft=false)
             if [[ -f "$notes_file" ]]; then
               args+=(--notes-file "$notes_file")
             fi
@@ -39,7 +48,7 @@ jobs:
           fi
 
           if [[ -f "$notes_file" ]]; then
-            gh release create "$tag" --verify-tag --title "$title" --notes-file "$notes_file"
+            gh release create "$tag" "${release_args[@]}" --notes-file "$notes_file"
           else
-            gh release create "$tag" --verify-tag --title "$title" --generate-notes
+            gh release create "$tag" "${release_args[@]}" --generate-notes
           fi

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -910,9 +910,21 @@ class XSenseWebRTCSession:
                 recipient_client_id=self._recipient_client_id,
                 session_id=self._session_id,
             )
-            await self._ws.send_str(
-                make_signal_wire_payload("ICE_CANDIDATE", candidate_payload)
+            with suppress(
+                aiohttp.ClientConnectionError,
+                aiohttp.ClientConnectionResetError,
+                ConnectionError,
+                RuntimeError,
+            ):
+                await self._ws.send_str(
+                    make_signal_wire_payload("ICE_CANDIDATE", candidate_payload)
+                )
+                continue
+            LOGGER.debug(
+                "X-Sense WebRTC stopped sending ICE candidates because signal closed: %s",
+                self._debug_context(candidate_count=len(candidates)),
             )
+            return
 
     async def _read_loop(self) -> None:
         if self._ws is None:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 import asyncio
+import aiohttp
 import base64
 import json
 
@@ -874,6 +875,61 @@ async def test_closed_session_ignores_late_browser_ice_candidates():
 
     assert session._pending_ha_candidates == []
 
+
+
+async def test_send_offer_stops_cleanly_when_signal_closes_during_ice():
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._ticket = ticket()
+    session._recipient_client_id = "SSC0A123"
+    session._session_id = "Android-client123-100000"
+    session._resolution = "auto"
+    session._camera_local_candidate_count = 0
+    session._camera_offer_sent = False
+    session._camera_local_description_task = None
+    session._camera_pc = type(
+        "FakePeer",
+        (),
+        {
+            "localDescription": type(
+                "LocalDescription",
+                (),
+                {
+                    "sdp": """v=0
+a=ice-ufrag:test
+a=candidate:1 1 udp 1 192.0.2.1 123 typ host
+a=candidate:2 1 udp 1 192.0.2.2 124 typ host
+"""
+                },
+            )()
+        },
+    )()
+    session._debug_context = lambda **kwargs: kwargs
+    session._camera_offer_sdp = """v=0
+a=ice-ufrag:test
+a=candidate:1 1 udp 1 192.0.2.1 123 typ host
+a=candidate:2 1 udp 1 192.0.2.2 124 typ host
+"""
+
+    class ClosingWebSocket:
+        closed = False
+
+        def __init__(self):
+            self.messages = []
+
+        async def send_str(self, message):
+            self.messages.append(json.loads(message))
+            if len(self.messages) > 1:
+                raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+
+    session._ws = ClosingWebSocket()
+
+    await session._send_offer()
+
+    assert [message["method"] for message in session._ws.messages] == [
+        "SDP_OFFER",
+        "ICE_CANDIDATE",
+    ]
 
 async def test_close_is_idempotent_and_waits_for_reader_task():
     class FakeWs:


### PR DESCRIPTION
## Summary
- Let the release workflow trigger for non-v tags and mark four-part patch tags as prereleases without forcing `--latest`.
- Stop treating a closing WebRTC signal socket during ICE candidate send as an unhandled reader crash.
- Add focused coverage for the signal-closing-during-ICE path.

## Validation
- `pytest -q tests/test_webrtc_signal.py`
- `pytest -q`
- `git diff --check`
- Confirmed no `--latest` remains under `.github`
