### PR TITLE
Send camera signal messages as APK envelopes

### DIFF
--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -65,6 +65,7 @@ _SIGNAL_NAME = "test-123"
 _DEFAULT_RESOLUTION = "auto"
 _PEER_IN_TIMEOUT = 20
 _PLAY_TIMEOUT = 40
+_FIRST_FRAME_TIMEOUT = 10
 
 
 @dataclass(slots=True)
@@ -485,6 +486,7 @@ class XSenseWebRTCSession:
         self._camera_local_description_task: asyncio.Task[None] | None = None
         self._peer_in_timeout_task: asyncio.Task[None] | None = None
         self._play_timeout_task: asyncio.Task[None] | None = None
+        self._first_frame_timeout_task: asyncio.Task[None] | None = None
         self._start_live_sent = False
         self._first_frame_received = False
         self._closed = False
@@ -509,7 +511,21 @@ class XSenseWebRTCSession:
                 "offer_sent": getattr(self, "_camera_offer_sent", None),
                 "sdp_answer_received": getattr(self, "_sdp_answer_received", None),
                 "first_frame_received": getattr(self, "_first_frame_received", None),
+                "start_live_sent": getattr(self, "_start_live_sent", None),
                 "last_signal_event": getattr(self, "_last_signal_event", None),
+                "signal_events": dict(getattr(self, "_signal_event_counts", {})),
+                "local_candidate_count": getattr(
+                    self, "_camera_local_candidate_count", None
+                ),
+                "remote_candidate_count": getattr(
+                    self, "_camera_remote_candidate_count", None
+                ),
+                "pending_ha_candidates": len(
+                    getattr(self, "_pending_ha_candidates", [])
+                ),
+                "pending_camera_candidates": len(
+                    getattr(self, "_pending_camera_candidates", [])
+                ),
             }
         )
         context.update(extra)
@@ -606,6 +622,7 @@ class XSenseWebRTCSession:
                     await self._reader_task
             await self._cancel_task(getattr(self, "_peer_in_timeout_task", None))
             await self._cancel_task(getattr(self, "_play_timeout_task", None))
+            await self._cancel_task(getattr(self, "_first_frame_timeout_task", None))
             if self._camera_local_description_task:
                 self._camera_local_description_task.cancel()
                 with suppress(asyncio.CancelledError, Exception):
@@ -705,6 +722,9 @@ class XSenseWebRTCSession:
         play_task = getattr(self, "_play_timeout_task", None)
         if play_task:
             play_task.cancel()
+        first_frame_task = getattr(self, "_first_frame_timeout_task", None)
+        if first_frame_task:
+            first_frame_task.cancel()
 
     def _send_stop_live(self) -> None:
         """Send the APK stopLive data-channel command before closing."""
@@ -831,6 +851,14 @@ class XSenseWebRTCSession:
         ):
             return
         self._start_live_sent = True
+        if not self._first_frame_received and not self._first_frame_timeout_task:
+            self._first_frame_timeout_task = asyncio.create_task(
+                self._fail_after_timeout(
+                    _FIRST_FRAME_TIMEOUT,
+                    "xsense_webrtc_first_frame_timeout",
+                    "Camera connected but did not send a video frame",
+                )
+            )
         LOGGER.debug(
             "X-Sense WebRTC sent startLive: %s",
             self._debug_context(size=_map_video_size(self._resolution)),
@@ -942,7 +970,30 @@ class XSenseWebRTCSession:
             raise
         except Exception as err:  # noqa: BLE001 - signal server can close mid-session
             if not self._closed:
-                LOGGER.debug("X-Sense WebRTC signal reader stopped", exc_info=err)
+                LOGGER.debug(
+                    "X-Sense WebRTC signal reader stopped: %s",
+                    self._debug_context(
+                        error=type(err).__name__,
+                        message=str(err),
+                        signal_close_code=getattr(self._ws, "close_code", None),
+                    ),
+                    exc_info=err,
+                )
+        finally:
+            if (
+                not self._closed
+                and self._ws is not None
+                and getattr(self._ws, "closed", False)
+            ):
+                LOGGER.debug(
+                    "X-Sense WebRTC signal websocket closed: %s",
+                    self._debug_context(
+                        signal_close_code=getattr(self._ws, "close_code", None),
+                        signal_exception=repr(
+                            getattr(self._ws, "exception", lambda: None)()
+                        ),
+                    ),
+                )
 
     async def _handle_signal_event(self, event: str | None, payload: Any) -> None:
         if self._closed:

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -317,11 +317,6 @@ def make_ice_candidate_payload(
     return json.dumps(envelope, separators=(",", ":"))
 
 
-def make_signal_wire_payload(event: str, envelope: str) -> str:
-    """Return the signal-server wire message around an APK event envelope."""
-    return json.dumps({"method": event, "value": envelope}, separators=(",", ":"))
-
-
 def make_start_live_data_channel_message(resolution: str) -> dict[str, Any]:
     """Return the APK-compatible data-channel startLive command."""
     return make_data_channel_command(
@@ -831,8 +826,6 @@ class XSenseWebRTCSession:
             or getattr(self._data_channel, "readyState", None) != "open"
         ):
             return
-        if self._camera_pc.connectionState != "connected":
-            return
         if not self._send_data_channel_json(
             make_start_live_data_channel_message(self._resolution)
         ):
@@ -878,7 +871,7 @@ class XSenseWebRTCSession:
             session_id=self._session_id,
             resolution=self._resolution,
         )
-        await self._ws.send_str(make_signal_wire_payload("SDP_OFFER", offer_payload))
+        await self._ws.send_str(offer_payload)
         self._camera_offer_sent = True
         if self._camera_local_description_task:
             await self._camera_local_description_task
@@ -916,9 +909,7 @@ class XSenseWebRTCSession:
                 ConnectionError,
                 RuntimeError,
             ):
-                await self._ws.send_str(
-                    make_signal_wire_payload("ICE_CANDIDATE", candidate_payload)
-                )
+                await self._ws.send_str(candidate_payload)
                 continue
             LOGGER.debug(
                 "X-Sense WebRTC stopped sending ICE candidates because signal closed: %s",

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -177,19 +177,6 @@ def test_webrtc_ice_candidate_payload_matches_apk():
         "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
     }
 
-def test_signal_wire_payload_wraps_apk_envelope_for_raw_websocket():
-    envelope = make_sdp_offer_payload(
-        offer_sdp="v=0\r\n",
-        ticket=ticket(),
-        recipient_client_id="SSC0A123",
-        session_id="Android-client123-100000",
-        resolution="1280x720",
-    )
-
-    wire = json.loads(webrtc_signal.make_signal_wire_payload("SDP_OFFER", envelope))
-
-    assert wire == {"method": "SDP_OFFER", "value": envelope}
-
 
 def test_local_sdp_candidates_match_apk_loopback_and_tcp_filters():
     sdp = """v=0
@@ -403,11 +390,11 @@ a=candidate:1 1 udp 1 192.0.2.1 123 typ host
 
     await session._send_offer()
 
-    assert [message["method"] for message in session._ws.messages] == [
+    assert [message["messageType"] for message in session._ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",
     ]
-    candidate_message = json.loads(session._ws.messages[1]["value"])
+    candidate_message = session._ws.messages[1]
     assert candidate_message | {"messagePayload": "<decoded>"} == {
         "messageType": "ICE_CANDIDATE",
         "messagePayload": "<decoded>",
@@ -762,7 +749,7 @@ def test_camera_webrtc_resolution_uses_apk_normalization():
     assert _camera_live_resolution(SimpleNamespace(data={})) == "auto"
 
 
-def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
+def test_start_live_waits_for_data_channel_connected_like_apk(monkeypatch):
     monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
     monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
 
@@ -796,15 +783,11 @@ def test_start_live_waits_for_data_channel_and_peer_connection(monkeypatch):
     session._send_start_live_if_ready()
     assert session._data_channel.messages == []
 
-    session._camera_pc.connectionState = "connected"
-    assert session._data_channel.messages == []
-
     session._data_channel.readyState = "open"
     session._send_start_live_if_ready()
     assert session._data_channel.messages == []
 
     session._handle_data_channel_message(json.dumps({"action": "dataChannelConnected"}))
-    session._send_start_live_if_ready()
 
     assert [json.loads(message) for message in session._data_channel.messages] == [
         {
@@ -926,7 +909,7 @@ a=candidate:2 1 udp 1 192.0.2.2 124 typ host
 
     await session._send_offer()
 
-    assert [message["method"] for message in session._ws.messages] == [
+    assert [message["messageType"] for message in session._ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",
     ]
@@ -1037,7 +1020,7 @@ async def test_camera_offer_does_not_wait_for_local_ice_gathering():
     task = asyncio.create_task(session._send_offer())
     await asyncio.sleep(0)
 
-    assert [message["method"] for message in session._ws.messages] == ["SDP_OFFER"]
+    assert [message["messageType"] for message in session._ws.messages] == ["SDP_OFFER"]
     assert session._camera_offer_sent is True
 
     session._camera_local_description_task.cancel()
@@ -1375,5 +1358,5 @@ async def test_offline_camera_waits_for_peer_in_before_offer_like_apk():
 
     await session._handle_signal_event("PEER_IN", "SSC0A123")
 
-    assert [message["method"] for message in session._ws.messages] == ["SDP_OFFER"]
+    assert [message["messageType"] for message in session._ws.messages] == ["SDP_OFFER"]
     assert session._camera_offer_sent is True

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -771,14 +771,25 @@ def test_start_live_waits_for_data_channel_connected_like_apk(monkeypatch):
     session._data_channel = FakeDataChannel()
     session._start_live_sent = False
     session._data_channel_connected = False
+    session._first_frame_received = False
+    session._first_frame_timeout_task = None
     created_tasks = []
 
-    def create_task(coro):
-        created_tasks.append(coro)
-        coro.close()
-        return None
+    class FakeTask:
+        def __init__(self, coro):
+            self.coro = coro
+            self.cancelled = False
+            coro.close()
 
-    session._create_task = create_task
+        def cancel(self):
+            self.cancelled = True
+
+    def create_task(coro):
+        task = FakeTask(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(webrtc_signal.asyncio, "create_task", create_task)
 
     session._send_start_live_if_ready()
     assert session._data_channel.messages == []
@@ -799,7 +810,8 @@ def test_start_live_waits_for_data_channel_connected_like_apk(monkeypatch):
             "resolution": "2560x1440",
         }
     ]
-    assert created_tasks == []
+    assert len(created_tasks) == 1
+    assert session._first_frame_timeout_task is created_tasks[0]
 
 
 async def test_browser_ice_candidates_wait_for_ha_remote_description():
@@ -1173,6 +1185,7 @@ async def test_first_video_frame_cancels_play_timeout():
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
     session._first_frame_received = False
     session._play_timeout_task = asyncio.create_task(asyncio.sleep(60))
+    session._first_frame_timeout_task = asyncio.create_task(asyncio.sleep(60))
     track = webrtc_signal._ProxyTrack("video", session._mark_first_frame_received)
     track.set_source(FakeSource())
 
@@ -1181,6 +1194,7 @@ async def test_first_video_frame_cancels_play_timeout():
     assert session._first_frame_received is True
     await asyncio.sleep(0)
     assert session._play_timeout_task.cancelled()
+    assert session._first_frame_timeout_task.cancelling()
 
 
 async def test_online_camera_waits_for_peer_in_before_offer_like_apk():


### PR DESCRIPTION
## Summary
- Send outgoing camera SDP and ICE signal messages as the raw APK JSON envelopes produced by `makeSendSdpOffer` / `createIceCandidate`.
- Remove the extra outgoing `method` / `value` wrapper that is not present in the Java send path.
- Send the data-channel `startLive` command when the camera reports `dataChannelConnected`, matching the APK command trigger instead of waiting for the peer state to become `connected`.

## Validation
- `pytest -q tests/test_webrtc_signal.py`
- `pytest -q`
- `git diff --check`
