### PR TITLE
Align camera WebRTC ticket startup

### DIFF
--- a/.github/release-notes/1.2.6.39.md
+++ b/.github/release-notes/1.2.6.39.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.2.6.39
+
+### 🎥 Camera WebRTC
+- Continues prerelease camera testing with a fresh WebRTC ticket request whenever Home Assistant starts a camera live view.
+- Keeps the camera offer gated behind the camera `PEER_IN` signal so the signaling flow follows the Android app path.
+
+### 🔎 Debug Logging
+- Keeps focused WebRTC debug context for ticket, PEER, SDP, candidate, and data-channel follow-up reports without dumping sensitive payloads.

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -156,7 +156,9 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             _camera_debug_context(entity, session_id),
         )
 
-        ticket_data = await self.coordinator.xsense.get_camera_webrtc_ticket(entity)
+        ticket_data = await self.coordinator.xsense.get_camera_webrtc_ticket(
+            entity, force_refresh=True
+        )
         LOGGER.debug(
             "X-Sense camera WebRTC ticket response: %s",
             _ticket_data_debug_context(ticket_data),

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.38"
+  "version": "1.2.6.39"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -67,7 +67,7 @@ _PEER_IN_TIMEOUT = 20
 _PLAY_TIMEOUT = 40
 _FIRST_FRAME_TIMEOUT = 10
 _DEFAULT_SIGNAL_HEARTBEAT = 30
-_SIGNAL_RECONNECT_DELAY = 3
+_SIGNAL_RECONNECT_DELAY = 5
 _SIGNAL_TERMINAL_CLOSE_CODES = {3002, 3004}
 
 
@@ -391,6 +391,7 @@ def _signal_envelope_debug(payload: str) -> dict[str, Any]:
             }
     return {"raw_len": len(payload)}
 
+
 def _answer_reject_reason(payload: Any, ticket: XSenseWebRTCTicket) -> str:
     if not isinstance(payload, dict):
         return "payload_not_dict"
@@ -555,11 +556,6 @@ def _signal_payload(data: dict[str, Any]) -> Any:
 def _signal_peer_payload(payload: Any) -> Any:
     if isinstance(payload, str):
         payload = _decode_signal_peer_payload(payload)
-    if isinstance(payload, dict):
-        for key in ("clientId", "serialNumber", "deviceSn", "deviceSN", "sn"):
-            value = payload.get(key)
-            if value:
-                return str(value)
     return payload
 
 
@@ -603,9 +599,9 @@ class XSenseWebRTCSession:
         session_id: str | None = None,
         on_close: Callable[[], None] | None = None,
         camera_online: bool = False,
-        refresh_ticket: Callable[
-            [], Coroutine[Any, Any, XSenseWebRTCTicket | None]
-        ] | None = None,
+        refresh_ticket: (
+            Callable[[], Coroutine[Any, Any, XSenseWebRTCTicket | None]] | None
+        ) = None,
     ) -> None:
         self._session = session
         self._ticket = ticket
@@ -713,20 +709,13 @@ class XSenseWebRTCSession:
                     "Camera did not start the WebRTC stream",
                 )
             )
-            if self._camera_online:
-                LOGGER.debug(
-                    "X-Sense WebRTC camera already online, starting peer without PEER_IN: %s",
-                    self._debug_context(),
-                )
-                await self._start_camera_peer()
-            else:
-                LOGGER.debug(
-                    "X-Sense WebRTC waiting for PEER_IN: %s",
-                    self._debug_context(),
-                )
-                self._peer_in_timeout_task = asyncio.create_task(
-                    self._handle_peer_in_timeout()
-                )
+            LOGGER.debug(
+                "X-Sense WebRTC waiting for PEER_IN before camera offer: %s",
+                self._debug_context(),
+            )
+            self._peer_in_timeout_task = asyncio.create_task(
+                self._handle_peer_in_timeout()
+            )
             return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
             LOGGER.debug(
@@ -753,7 +742,9 @@ class XSenseWebRTCSession:
             )
             return
         await self._ha_pc.addIceCandidate(parsed)
-        LOGGER.debug("X-Sense WebRTC applied HA ICE candidate: %s", self._debug_context())
+        LOGGER.debug(
+            "X-Sense WebRTC applied HA ICE candidate: %s", self._debug_context()
+        )
 
     async def close(self) -> None:
         """Close the X-Sense signaling and WebRTC sessions."""
@@ -901,7 +892,9 @@ class XSenseWebRTCSession:
             return
         try:
             new_ticket = await refresh_ticket()
-        except Exception as err:  # noqa: BLE001 - ticket refresh failures are non-fatal here
+        except (
+            Exception
+        ) as err:  # noqa: BLE001 - ticket refresh failures are non-fatal here
             LOGGER.debug(
                 "X-Sense WebRTC ticket refresh after PEER_IN timeout failed: %s",
                 self._debug_context(error=type(err).__name__, message=str(err)),
@@ -997,7 +990,9 @@ class XSenseWebRTCSession:
         task = getattr(self, "_peer_reconnect_task", None)
         if self._closed or (task and not task.done()):
             return
-        self._peer_reconnect_task = asyncio.create_task(self._reconnect_camera_peer(state))
+        self._peer_reconnect_task = asyncio.create_task(
+            self._reconnect_camera_peer(state)
+        )
 
     async def _reconnect_camera_peer(self, state: str) -> None:
         """Recreate the camera peer and restart the APK live-view send path."""
@@ -1155,13 +1150,20 @@ class XSenseWebRTCSession:
         if self._camera_pc is None:
             return
         offer = await self._camera_pc.createOffer()
-        await self._camera_pc.setLocalDescription(offer)
-        if self._send_data_channel_json(
-            make_change_transceiver_offer_command(offer.sdp)
-        ):
+        camera_offer = RTCSessionDescription(
+            sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
+        )
+        local_description_task = asyncio.create_task(
+            self._camera_pc.setLocalDescription(camera_offer)
+        )
+        sent = self._send_data_channel_json(
+            make_change_transceiver_offer_command(camera_offer.sdp)
+        )
+        await local_description_task
+        if sent:
             LOGGER.debug(
                 "X-Sense WebRTC sent changeTransceiverOffer: %s",
-                self._debug_context(offer_sdp_len=len(offer.sdp)),
+                self._debug_context(offer_sdp=_sdp_debug(camera_offer.sdp)),
             )
 
     async def _apply_change_transceiver_answer(self, payload: dict[str, Any]) -> None:
@@ -1435,9 +1437,7 @@ class XSenseWebRTCSession:
                         local_candidate_count=self._camera_local_candidate_count,
                         remote_candidate_count=self._camera_remote_candidate_count,
                         pending_ha_candidates=len(self._pending_ha_candidates),
-                        pending_camera_candidates=len(
-                            self._pending_camera_candidates
-                        ),
+                        pending_camera_candidates=len(self._pending_camera_candidates),
                         **_peer_event_debug(payload, self._ticket.serial_number),
                     ),
                 )
@@ -1580,10 +1580,24 @@ def _sdp_without_local_candidates(sdp: str) -> str:
 
 def _apk_camera_offer_sdp(sdp: str) -> str:
     """Return the camera offer SDP in the APK createOffer callback shape."""
-    # The APK forwards SessionDescription.description from createOffer before
-    # trickled ICE candidates are appended. It does not rewrite codecs or DTLS
-    # fingerprints, so only strip local candidates gathered by aiortc.
-    return _sdp_without_local_candidates(sdp)
+    # The APK forwards SessionDescription.description from native Android
+    # WebRTC before trickled ICE candidates are appended. aiortc exposes a
+    # browser-style SDP with multiple DTLS fingerprint algorithms; Android's
+    # WebRTC camera path uses the sha-256 fingerprint line, so keep that wire
+    # shape for the camera-facing offer.
+    return _sdp_with_sha256_fingerprints(_sdp_without_local_candidates(sdp))
+
+
+def _sdp_with_sha256_fingerprints(sdp: str) -> str:
+    """Keep the DTLS fingerprint algorithm Android WebRTC offers to cameras."""
+    lines = [
+        line
+        for line in sdp.splitlines()
+        if not line.startswith("a=fingerprint:")
+        or line.startswith("a=fingerprint:sha-256 ")
+    ]
+    ending = "\r\n" if "\r\n" in sdp else "\n"
+    return ending.join(lines) + (ending if sdp.endswith(("\r\n", "\n")) else "")
 
 
 def _local_sdp_candidates(sdp: str) -> list[dict[str, Any]]:
@@ -1616,11 +1630,7 @@ def _is_apk_supported_local_candidate(candidate: str) -> bool:
     """Return whether the APK would signal this local ICE candidate."""
     parts = candidate.split()
     protocol = parts[2].lower() if len(parts) > 2 else ""
-    return (
-        protocol != "tcp"
-        and "127.0.0.1" not in candidate
-        and "::1" not in candidate
-    )
+    return protocol != "tcp" and "127.0.0.1" not in candidate and "::1" not in candidate
 
 
 def _candidate_payload_to_aiortc(payload: Any) -> RTCIceCandidate | None:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -137,8 +137,8 @@ async def test_webrtc_offer_uses_ticket_without_direct_stream_keepalive():
         async def keep_camera_live_alive(self, entity):
             raise AssertionError("WebRTC path should not call direct-stream keepalive")
 
-        async def get_camera_webrtc_ticket(self, entity):
-            calls.append(("ticket", entity.sn))
+        async def get_camera_webrtc_ticket(self, entity, *, force_refresh=False):
+            calls.append(("ticket", entity.sn, force_refresh))
             return None
 
     entity = SimpleNamespace(sn="SSC0A123", online=True, data={})
@@ -151,7 +151,7 @@ async def test_webrtc_offer_uses_ticket_without_direct_stream_keepalive():
         "v=0\r\n", "session-1", messages.append
     )
 
-    assert calls == [("ticket", "SSC0A123")]
+    assert calls == [("ticket", "SSC0A123", True)]
     assert messages[0].code == "xsense_webrtc_ticket_failed"
 
 
@@ -404,7 +404,7 @@ async def test_failed_webrtc_start_is_removed_from_active_sessions(monkeypatch):
     camera_entity.name = "Camera"
     camera_entity.online = True
 
-    async def get_camera_webrtc_ticket(entity):
+    async def get_camera_webrtc_ticket(entity, *, force_refresh=False):
         return {"signalServer": "signal"}
 
     class Coordinator:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -156,8 +156,6 @@ def test_sdp_offer_payload_strips_local_candidates_like_apk_create_offer():
     assert decoded["sdp"].endswith("\r\n")
 
 
-
-
 def test_parse_signal_message_accepts_apk_raw_ice_candidate_json():
     raw_candidate = {
         "sdpMid": "0",
@@ -166,7 +164,12 @@ def test_parse_signal_message_accepts_apk_raw_ice_candidate_json():
     }
 
     assert webrtc_signal.parse_signal_message(
-        json.dumps({"messageType": "ICE_CANDIDATE", "messagePayload": json.dumps(raw_candidate)})
+        json.dumps(
+            {
+                "messageType": "ICE_CANDIDATE",
+                "messagePayload": json.dumps(raw_candidate),
+            }
+        )
     ) == ("ICE_CANDIDATE", raw_candidate)
 
 
@@ -196,7 +199,7 @@ def test_webrtc_ice_candidate_payload_matches_apk():
     }
 
 
-def test_apk_camera_offer_sdp_preserves_create_offer_sdp_shape():
+def test_apk_camera_offer_sdp_matches_android_camera_offer_shape():
     sdp = """v=0
 m=audio 9 UDP/TLS/RTP/SAVPF 96
 a=mid:0
@@ -226,15 +229,12 @@ a=mid:2
 
     apk_sdp = webrtc_signal._apk_camera_offer_sdp(sdp)
 
-    assert apk_sdp == sdp
     assert "m=video 9 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102" in apk_sdp
-    assert "VP8" in apk_sdp
-    assert "apt=97" in apk_sdp
     assert "H264" in apk_sdp
     assert "a=fingerprint:sha-256" in apk_sdp
-    assert "a=fingerprint:sha-384" in apk_sdp
-    assert "a=fingerprint:sha-512" in apk_sdp
-    assert apk_sdp.endswith('\n')
+    assert "a=fingerprint:sha-384" not in apk_sdp
+    assert "a=fingerprint:sha-512" not in apk_sdp
+    assert apk_sdp.endswith("\n")
 
 
 def test_local_sdp_candidates_match_apk_tcp_and_loopback_filter():
@@ -285,9 +285,10 @@ def test_change_transceiver_commands_match_apk(monkeypatch):
         "action": "changeTransceiverOffer",
         "parameters": {"offer": "<decoded>"},
     }
-    assert json.loads(
-        base64.b64decode(command["parameters"]["offer"]).decode()
-    ) == {"type": "offer", "sdp": "v=0\r\n"}
+    assert json.loads(base64.b64decode(command["parameters"]["offer"]).decode()) == {
+        "type": "offer",
+        "sdp": "v=0\r\n",
+    }
 
 
 async def test_data_channel_request_change_transceiver_offer_matches_apk(monkeypatch):
@@ -295,7 +296,16 @@ async def test_data_channel_request_change_transceiver_offer_matches_apk(monkeyp
     monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
 
     class Offer:
-        sdp = "v=0\r\n"
+        type = "offer"
+        sdp = (
+            "v=0\r\n"
+            "m=video 9 UDP/TLS/RTP/SAVPF 99\r\n"
+            "a=mid:0\r\n"
+            "a=rtpmap:99 H264/90000\r\n"
+            "a=fingerprint:sha-256 AA:BB\r\n"
+            "a=fingerprint:sha-384 CC:DD\r\n"
+            "a=candidate:1 1 udp 1 192.0.2.1 123 typ host\r\n"
+        )
 
     class FakePeerConnection:
         connectionState = "connected"
@@ -356,6 +366,14 @@ async def test_data_channel_request_change_transceiver_offer_matches_apk(monkeyp
         "action": "changeTransceiverOffer",
         "parameters": {"offer": "<decoded>"},
     }
+    decoded_offer = json.loads(
+        base64.b64decode(second_message["parameters"]["offer"]).decode()
+    )
+    assert decoded_offer["type"] == "offer"
+    assert session._camera_pc.local_descriptions[0].sdp == decoded_offer["sdp"]
+    assert "a=fingerprint:sha-256" in decoded_offer["sdp"]
+    assert "a=fingerprint:sha-384" not in decoded_offer["sdp"]
+    assert "a=candidate:" not in decoded_offer["sdp"]
 
     encoded_answer = base64.b64encode(
         json.dumps({"sdp": "v=0\r\nanswer"}).encode()
@@ -382,6 +400,7 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
 
         def addTransceiver(self, kind, **kwargs):
             self.transceivers.append((kind, kwargs))
+            return object()
 
         async def createOffer(self):
             class Offer:
@@ -405,9 +424,8 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
 
     await session._start_camera_peer()
 
-    assert session._camera_pc.transceivers == [
-        ("video", {"direction": "recvonly"}),
-    ]
+    assert len(session._camera_pc.transceivers) == 1
+    assert session._camera_pc.transceivers[0] == ("video", {"direction": "recvonly"})
     assert session._camera_offer_sdp == "v=0\r\n"
     assert session._camera_local_description_task is not None
     session._camera_local_description_task.cancel()
@@ -731,16 +749,20 @@ def test_sdp_answer_reject_reason_keeps_debug_actionable():
 
 
 def test_parse_signal_message_accepts_apk_peer_event_wrappers():
-    assert parse_signal_message(
+    event, payload = parse_signal_message(
         json.dumps({"event": "PEER_IN", "data": {"clientId": "SSC0A123"}})
-    ) == ("PEER_IN", "SSC0A123")
-    assert webrtc_signal._is_owned_peer_message("SSC0A123", "SSC0A123")
-    assert not webrtc_signal._is_owned_peer_message("SSC0B456", "SSC0A123")
-    assert parse_signal_message(
+    )
+    assert event == "PEER_IN"
+    assert webrtc_signal._is_owned_peer_message(payload, "SSC0A123")
+    assert not webrtc_signal._is_owned_peer_message(payload, "SSC0B456")
+
+    event, payload = parse_signal_message(
         json.dumps(
             {"type": "PEER_OUT", "message": json.dumps({"deviceSN": "SSC0B456"})}
         )
-    ) == ("PEER_OUT", "SSC0B456")
+    )
+    assert event == "PEER_OUT"
+    assert webrtc_signal._is_owned_peer_message(payload, "SSC0B456")
 
 
 def test_parse_signal_message_decodes_base64_peer_events_from_signal_server():
@@ -754,9 +776,11 @@ def test_parse_signal_message_decodes_base64_peer_events_from_signal_server():
         json.dumps({"serialNumber": "SSC0A123"}).encode()
     ).decode()
 
-    assert parse_signal_message(
+    event, payload = parse_signal_message(
         json.dumps({"messageType": "PEER_OUT", "messagePayload": encoded_json})
-    ) == ("PEER_OUT", "SSC0A123")
+    )
+    assert event == "PEER_OUT"
+    assert webrtc_signal._is_owned_peer_message(payload, "SSC0A123")
 
 
 def test_parse_signal_message_keeps_plain_peer_payloads_from_apk_callback():
@@ -803,6 +827,24 @@ def test_object_peer_event_matches_camera_by_apk_signal_id():
         "peer_candidates": ["...C0A123", "...st-123"],
     }
 
+
+def test_object_peer_event_preserves_all_ids_for_camera_match():
+    event, payload = parse_signal_message(
+        json.dumps(
+            {
+                "messageType": "PEER_IN",
+                "messagePayload": {
+                    "clientId": "viewer-client",
+                    "serialNumber": "SSC0A123",
+                    "role": "device",
+                },
+            }
+        )
+    )
+
+    assert event == "PEER_IN"
+    assert payload["clientId"] == "viewer-client"
+    assert webrtc_signal._is_owned_peer_message(payload, "SSC0A123")
 
 
 def test_stop_live_data_channel_command_matches_apk(monkeypatch):
@@ -1054,7 +1096,6 @@ async def test_closed_session_ignores_late_browser_ice_candidates():
     assert session._pending_ha_candidates == []
 
 
-
 async def test_send_offer_stops_cleanly_when_signal_closes_during_ice():
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
     session._closed = False
@@ -1072,13 +1113,11 @@ async def test_send_offer_stops_cleanly_when_signal_closes_during_ice():
             "localDescription": type(
                 "LocalDescription",
                 (),
-                {
-                    "sdp": """v=0
+                {"sdp": """v=0
 a=ice-ufrag:test
 a=candidate:1 1 udp 1 192.0.2.1 123 typ host
 a=candidate:2 1 udp 1 192.0.2.2 124 typ host
-"""
-                },
+"""},
             )()
         },
     )()
@@ -1098,7 +1137,9 @@ a=candidate:2 1 udp 1 192.0.2.2 124 typ host
         async def send_str(self, message):
             self.messages.append(json.loads(message))
             if len(self.messages) > 1:
-                raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+                raise aiohttp.ClientConnectionResetError(
+                    "Cannot write to closing transport"
+                )
 
     session._ws = ClosingWebSocket()
 
@@ -1108,6 +1149,7 @@ a=candidate:2 1 udp 1 192.0.2.2 124 typ host
         "SDP_OFFER",
         "ICE_CANDIDATE",
     ]
+
 
 async def test_close_is_idempotent_and_waits_for_reader_task():
     class FakeWs:
@@ -1171,6 +1213,7 @@ async def test_close_is_idempotent_and_waits_for_reader_task():
     assert session._pending_ha_candidates == []
     assert session._pending_camera_candidates == []
     assert session._data_channel.messages[0]["action"] == "stopLive"
+
 
 async def test_closed_session_ignores_late_signal_events():
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
@@ -1256,7 +1299,6 @@ async def test_webrtc_close_does_not_cancel_current_timeout_task():
     assert not asyncio.current_task().cancelled()
 
 
-
 async def test_webrtc_close_stops_peer_transports_before_closing():
     import asyncio
 
@@ -1307,6 +1349,7 @@ async def test_webrtc_close_stops_peer_transports_before_closing():
     session._camera_local_description_task = None
     session._ws = None
     session._data_channel = None
+
     class TrackPart:
         def __init__(self, name):
             self.name = name
@@ -1340,6 +1383,7 @@ async def test_webrtc_close_stops_peer_transports_before_closing():
         "ha-receiver",
         "ha-close",
     ]
+
 
 async def test_webrtc_timeout_reports_error_and_closes_session():
     import asyncio
@@ -1388,6 +1432,28 @@ def test_signal_close_schedules_apk_style_reconnect():
 
     assert scheduled == ["reconnect-1000"]
 
+
+async def test_signal_reconnect_delay_matches_apk(monkeypatch):
+    delays = []
+    reconnected = []
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._debug_context = lambda **kwargs: kwargs
+
+    async def reconnect_signal():
+        reconnected.append(True)
+
+    async def sleep(delay):
+        delays.append(delay)
+
+    session._reconnect_signal = reconnect_signal
+
+    monkeypatch.setattr(webrtc_signal.asyncio, "sleep", sleep)
+
+    await session._signal_reconnect_after_delay(1000)
+
+    assert delays == [5]
+    assert reconnected == [True]
 
 def test_signal_close_skips_apk_terminal_close_codes():
     scheduled = []
@@ -1488,7 +1554,7 @@ async def test_first_video_frame_cancels_play_timeout():
     assert session._first_frame_timeout_task.cancelling()
 
 
-async def test_online_camera_starts_peer_without_peer_in_like_apk():
+async def test_online_camera_waits_for_peer_in_before_offer_like_apk():
     class FakeWs:
         closed = False
 
@@ -1615,9 +1681,9 @@ async def test_online_camera_starts_peer_without_peer_in_like_apk():
 
     assert aio_session.ws.messages == []
     assert aio_session.connect_kwargs["heartbeat"] == 30
-    assert started == [True]
-    assert session._peer_in_timeout_task is None
-    assert len(tasks) == 2
+    assert started == []
+    assert session._peer_in_timeout_task is not None
+    assert len(tasks) == 3
     assert sent_messages[0].answer == "v=0\r\n"
 
 


### PR DESCRIPTION
## Summary
- request a fresh WebRTC ticket when Home Assistant starts a camera live view
- keep camera offers gated behind the camera PEER_IN signal
- preserve structured PEER payload matching and APK-shaped camera SDP handling
- prepare prerelease 1.2.6.39

## Tests
- python3 -m pytest -q