### PR TITLE
Restore release note section formatting

### DIFF
--- a/.github/release-notes/1.2.6.42.md
+++ b/.github/release-notes/1.2.6.42.md
@@ -1,9 +1,9 @@
 ## X-Sense Home Security v1.2.6.42
 
-### Camera WebRTC
+### 🎥 Camera WebRTC
 - Continues prerelease camera testing with a tighter retry path for cameras that report `PEER_OUT` before the first frame.
 - Restarts the WebRTC play timeout for each camera offer attempt, so a second `PEER_IN` retry gets its own full start window.
 - Clears stale camera peer state before retrying, including the prior local-description task and APK-style session id.
 
-### Debug Logging
+### 🔎 Debug Logging
 - Keeps the camera startup trace focused on signaling events, offer/answer state, ICE counts, data-channel state, and first-frame timing for follow-up reports.

--- a/.github/release-notes/1.2.6.43.md
+++ b/.github/release-notes/1.2.6.43.md
@@ -1,10 +1,10 @@
 ## X-Sense Home Security v1.2.6.43
 
-### Camera WebRTC
+### 🎥 Camera WebRTC
 - Continues prerelease camera testing for accounts where camera audio starts but video never renders.
 - Aligns the live-view start sequence with the APK by waiting for the camera `dataChannelConnected` message before sending `startLive`.
 - Requests a video keyframe while waiting for the first frame, targeting the primary media SSRC used by the camera stream.
 
-### Debug Logging
+### 🔎 Debug Logging
 - Adds focused video SDP payload and receiver RTP stats to help identify whether video packets are arriving when no frame renders.
 - Accepts APK-style base64 signal and data-channel payloads even when padding is omitted.


### PR DESCRIPTION
## Summary
- restore the icon section headings used by recent release notes for 1.2.6.42 and 1.2.6.43
- keep the published GitHub release bodies and checked-in release-note files consistent

## Tests
- not run; release-note formatting only