### PR TITLE
Refine camera WebRTC diagnostics

### DIFF
--- a/.github/release-notes/1.2.6.44.md
+++ b/.github/release-notes/1.2.6.44.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.2.6.44
+
+### 🎥 Camera WebRTC
+- Continues prerelease camera testing for accounts where camera audio starts but video never renders.
+- Keeps the camera-facing SDP closer to the Android WebRTC path by preserving H264 `level-asymmetry-allowed` and advertising only supported video feedback.
+- Ignores rejected `changeTransceiverOffer` answers unless the camera reports an APK-style successful `returnValue`.
+
+### 🔎 Debug Logging
+- Adds matched camera offer/answer SDP summaries to first-frame timeout logs.
+- Logs the video SSRCs used for keyframe requests, so follow-up reports show whether RTP and PLI are reaching the same media stream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.2.6.44](.github/release-notes/1.2.6.44.md)
 - [1.2.6.43](.github/release-notes/1.2.6.43.md)
 - [1.2.6.42](.github/release-notes/1.2.6.42.md)
 - [1.2.6.41](.github/release-notes/1.2.6.41.md)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.43"
+  "version": "1.2.6.44"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -320,6 +320,7 @@ def _sdp_debug(sdp: str | None) -> dict[str, Any]:
         "directions": _sdp_media_directions(sdp),
         "video_codecs": _sdp_media_codecs(sdp, "video"),
         "video_payloads": _sdp_media_payloads(sdp, "video"),
+        "video_feedback": _sdp_media_feedback(sdp, "video"),
         "fingerprints": _sdp_fingerprints(sdp),
         "candidate_lines": sum(
             1 for line in sdp.splitlines() if line.startswith("a=candidate:")
@@ -384,7 +385,12 @@ def _sdp_media_payloads(sdp: str, media_kind: str) -> list[dict[str, str]]:
             for item in fmtp.split(";"):
                 key_value = item.strip()
                 if key_value.startswith(
-                    ("profile-level-id=", "packetization-mode=", "apt=")
+                    (
+                        "level-asymmetry-allowed=",
+                        "profile-level-id=",
+                        "packetization-mode=",
+                        "apt=",
+                    )
                 ):
                     compact_fmtp.append(key_value)
             if compact_fmtp:
@@ -392,6 +398,20 @@ def _sdp_media_payloads(sdp: str, media_kind: str) -> list[dict[str, str]]:
                     compact_fmtp
                 )
     return list(payloads.values())
+
+
+def _sdp_media_feedback(sdp: str, media_kind: str) -> dict[str, list[str]]:
+    """Return compact RTP feedback lines for one SDP media section."""
+    feedback: dict[str, list[str]] = {}
+    in_section = False
+    for line in sdp.splitlines():
+        if line.startswith("m="):
+            in_section = line.startswith(f"m={media_kind} ")
+            continue
+        if in_section and line.startswith("a=rtcp-fb:"):
+            payload, value = line.removeprefix("a=rtcp-fb:").split(None, 1)
+            feedback.setdefault(payload, []).append(value)
+    return feedback
 
 
 def _receiver_media_ssrcs(receiver: Any) -> list[int]:
@@ -739,6 +759,7 @@ class XSenseWebRTCSession:
         self._data_channel_connected = False
         self._camera_offer_sent = False
         self._camera_offer_sdp: str | None = None
+        self._camera_answer_sdp: str | None = None
         self._sdp_answer_received = False
         self._camera_local_candidate_count = 0
         self._camera_remote_candidate_count = 0
@@ -964,6 +985,8 @@ class XSenseWebRTCSession:
         extra: dict[str, Any] = {"code": code, "timeout_s": delay}
         if code == "xsense_webrtc_first_frame_timeout":
             extra.update(await self._camera_receiver_stats_debug())
+            extra["camera_offer_sdp"] = _sdp_debug(self._camera_offer_sdp)
+            extra["camera_answer_sdp"] = _sdp_debug(self._camera_answer_sdp)
         LOGGER.debug(
             "X-Sense WebRTC timeout: %s",
             self._debug_context(**extra),
@@ -1160,6 +1183,7 @@ class XSenseWebRTCSession:
         self._session_id = self._ticket.session_id
         self._camera_offer_sent = False
         self._camera_offer_sdp = None
+        self._camera_answer_sdp = None
         self._sdp_answer_received = False
         local_description_task = self._camera_local_description_task
         if local_description_task:
@@ -1194,11 +1218,13 @@ class XSenseWebRTCSession:
         """Ask the camera for a decodable first frame until one arrives."""
         try:
             while not self._closed and not self._first_frame_received:
-                sent = await self._send_camera_picture_loss_indication()
-                if sent:
+                pli_ssrcs = await self._send_camera_picture_loss_indication()
+                if pli_ssrcs:
                     LOGGER.debug(
                         "X-Sense WebRTC requested camera keyframe: %s",
-                        self._debug_context(pli_count=sent),
+                        self._debug_context(
+                            pli_count=len(pli_ssrcs), pli_ssrcs=pli_ssrcs
+                        ),
                     )
                 else:
                     LOGGER.debug(
@@ -1212,12 +1238,12 @@ class XSenseWebRTCSession:
             if getattr(self, "_first_frame_pli_task", None) is asyncio.current_task():
                 self._first_frame_pli_task = None
 
-    async def _send_camera_picture_loss_indication(self) -> int:
+    async def _send_camera_picture_loss_indication(self) -> list[int]:
         """Send RTCP PLI for camera video receivers that have active SSRCs."""
         camera_pc = self._camera_pc
         if camera_pc is None:
-            return 0
-        sent = 0
+            return []
+        sent: list[int] = []
         for receiver in list(getattr(camera_pc, "getReceivers", lambda: [])()):
             track = getattr(receiver, "track", None)
             if getattr(track, "kind", None) != "video":
@@ -1234,7 +1260,7 @@ class XSenseWebRTCSession:
                         self._debug_context(error=type(err).__name__, message=str(err)),
                     )
                     continue
-                sent += 1
+                sent.append(ssrc)
         return sent
 
     def _cancel_first_frame_keyframe_requests(self) -> None:
@@ -1455,6 +1481,7 @@ class XSenseWebRTCSession:
         camera_offer = RTCSessionDescription(
             sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
         )
+        self._camera_offer_sdp = camera_offer.sdp
         local_description_task = asyncio.create_task(
             self._camera_pc.setLocalDescription(camera_offer)
         )
@@ -1477,12 +1504,13 @@ class XSenseWebRTCSession:
                 self._debug_context(payload=_payload_debug(payload)),
             )
             return
+        self._camera_answer_sdp = answer
         await self._camera_pc.setRemoteDescription(
             RTCSessionDescription(sdp=answer, type="answer")
         )
         LOGGER.debug(
             "X-Sense WebRTC applied changeTransceiverOffer answer: %s",
-            self._debug_context(),
+            self._debug_context(answer_sdp=_sdp_debug(answer)),
         )
 
     def _send_start_live_if_ready(self) -> None:
@@ -1698,6 +1726,7 @@ class XSenseWebRTCSession:
                 )
                 if self._camera_pc is None:
                     return
+                self._camera_answer_sdp = answer
                 await self._camera_pc.setRemoteDescription(
                     RTCSessionDescription(sdp=answer, type="answer")
                 )
@@ -1827,6 +1856,11 @@ def _data_channel_answer_sdp(payload: Any) -> str | None:
     """Return the APK changeTransceiverOffer answer SDP from data-channel JSON."""
     if not isinstance(payload, dict):
         return None
+    return_value = payload.get("returnValue", 0)
+    with suppress(TypeError, ValueError):
+        return_value = int(return_value)
+    if return_value != 0:
+        return None
     data = payload.get("data")
     if not isinstance(data, dict):
         return None
@@ -1896,7 +1930,72 @@ def _apk_camera_offer_sdp(sdp: str) -> str:
     # browser-style SDP with multiple DTLS fingerprint algorithms; Android's
     # WebRTC camera path uses the sha-256 fingerprint line, so keep that wire
     # shape for the camera-facing offer.
-    return _sdp_with_sha256_fingerprints(_sdp_without_local_candidates(sdp))
+    return _sdp_with_android_video_feedback(
+        _sdp_with_sha256_fingerprints(_sdp_without_local_candidates(sdp))
+    )
+
+
+def _sdp_with_android_video_feedback(sdp: str) -> str:
+    """Advertise Android WebRTC-style video feedback to X-Sense cameras."""
+    feedback_values = ("goog-remb", "nack", "nack pli")
+    lines = sdp.splitlines()
+    output: list[str] = []
+    in_video = False
+    video_payloads: set[str] = set()
+    video_feedback: set[tuple[str, str]] = set()
+
+    def flush_video_feedback() -> None:
+        for payload in sorted(video_payloads, key=int):
+            for value in feedback_values:
+                if (payload, value) not in video_feedback:
+                    output.append(f"a=rtcp-fb:{payload} {value}")
+
+    for line in lines:
+        if line.startswith("m="):
+            if in_video:
+                flush_video_feedback()
+            in_video = line.startswith("m=video ")
+            video_payloads = set()
+            video_feedback = set()
+            output.append(line)
+            continue
+        if in_video and line.startswith("a=rtpmap:"):
+            payload, codec = line.removeprefix("a=rtpmap:").split(None, 1)
+            if codec.split("/", 1)[0].upper() != "RTX":
+                video_payloads.add(payload)
+        elif in_video and line.startswith("a=rtcp-fb:"):
+            payload, value = line.removeprefix("a=rtcp-fb:").split(None, 1)
+            video_feedback.add((payload, value))
+        output.append(_sdp_with_android_h264_fmtp(line) if in_video else line)
+    if in_video:
+        flush_video_feedback()
+    ending = "\r\n" if "\r\n" in sdp else "\n"
+    return ending.join(output) + (ending if sdp.endswith(("\r\n", "\n")) else "")
+
+
+def _sdp_with_android_h264_fmtp(line: str) -> str:
+    """Keep H264 fmtp compatible with Android WebRTC offers."""
+    if not line.startswith("a=fmtp:") or "profile-level-id=" not in line:
+        return line
+    prefix, fmtp = line.split(None, 1)
+    values: dict[str, str] = {}
+    order: list[str] = []
+    for item in fmtp.split(";"):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if key not in values:
+            order.append(key)
+        values[key] = value
+    for key, value in (
+        ("level-asymmetry-allowed", "1"),
+        ("packetization-mode", "1"),
+    ):
+        if key not in values:
+            order.insert(0 if key == "level-asymmetry-allowed" else len(order), key)
+        values[key] = value
+    return prefix + " " + ";".join(f"{key}={values[key]}" for key in order)
 
 
 def _sdp_with_sha256_fingerprints(sdp: str) -> str:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -244,6 +244,17 @@ a=mid:2
 
     assert "m=video 9 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102" in apk_sdp
     assert "H264" in apk_sdp
+    assert "a=rtcp-fb:99 nack pli" in apk_sdp
+    assert "a=rtcp-fb:101 nack pli" in apk_sdp
+    assert "a=rtcp-fb:100 nack pli" not in apk_sdp
+    assert (
+        "a=fmtp:99 level-asymmetry-allowed=1;profile-level-id=42001f;"
+        "packetization-mode=1"
+    ) in apk_sdp
+    assert (
+        "a=fmtp:101 level-asymmetry-allowed=1;profile-level-id=42e01f;"
+        "packetization-mode=1"
+    ) in apk_sdp
     assert "a=fingerprint:sha-256" in apk_sdp
     assert "a=fingerprint:sha-384" not in apk_sdp
     assert "a=fingerprint:sha-512" not in apk_sdp
@@ -413,6 +424,44 @@ async def test_data_channel_request_change_transceiver_offer_matches_apk(monkeyp
 
     assert session._camera_pc.remote_descriptions[0].type == "answer"
     assert session._camera_pc.remote_descriptions[0].sdp == "v=0\r\nanswer"
+
+
+async def test_change_transceiver_answer_ignores_nonzero_return_value_like_apk(monkeypatch):
+    created_tasks = []
+
+    def create_task(coro):
+        task = asyncio.create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(webrtc_signal.asyncio, "create_task", create_task)
+
+    class FakePeer:
+        def __init__(self):
+            self.remote_descriptions = []
+
+        async def setRemoteDescription(self, description):
+            self.remote_descriptions.append(description)
+
+    encoded_answer = base64.b64encode(
+        json.dumps({"sdp": "v=0\r\nanswer"}).encode()
+    ).decode()
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._camera_pc = FakePeer()
+    session._debug_context = lambda **kwargs: kwargs
+
+    session._handle_data_channel_message(
+        json.dumps(
+            {
+                "action": "changeTransceiverOffer",
+                "returnValue": 17,
+                "data": {"answer": encoded_answer},
+            }
+        )
+    )
+    await asyncio.gather(*created_tasks)
+
+    assert session._camera_pc.remote_descriptions == []
 
 
 async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch):
@@ -963,24 +1012,29 @@ def test_sdp_debug_includes_media_directions():
     }
 
 
-def test_sdp_debug_includes_video_payload_fmtp():
+def test_sdp_debug_includes_video_payload_fmtp_and_feedback():
     sdp = (
         "v=0\r\n"
         "m=video 9 UDP/TLS/RTP/SAVPF 101 102\r\n"
         "a=rtpmap:101 H264/90000\r\n"
+        "a=rtcp-fb:101 nack\r\n"
+        "a=rtcp-fb:101 nack pli\r\n"
         "a=fmtp:101 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\n"
         "a=rtpmap:102 rtx/90000\r\n"
         "a=fmtp:102 apt=101\r\n"
     )
 
-    assert webrtc_signal._sdp_debug(sdp)["video_payloads"] == [
+    debug = webrtc_signal._sdp_debug(sdp)
+
+    assert debug["video_payloads"] == [
         {
             "payload": "101",
             "codec": "H264",
-            "fmtp": "packetization-mode=1;profile-level-id=42e01f",
+            "fmtp": "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
         },
         {"payload": "102", "codec": "RTX", "fmtp": "apt=101"},
     ]
+    assert debug["video_feedback"] == {"101": ["nack", "nack pli"]}
 
 
 def test_data_channel_debug_includes_safe_nested_codec_values():
@@ -1555,6 +1609,59 @@ async def test_webrtc_timeout_reports_error_and_closes_session():
     assert closed == [True]
 
 
+async def test_first_frame_timeout_debug_includes_camera_sdp_and_receiver_stats():
+    messages = []
+    closed = []
+    debug_contexts = []
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._send_message = messages.append
+    session._camera_offer_sdp = (
+        "v=0\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 101\r\n"
+        "a=rtpmap:101 H264/90000\r\n"
+        "a=rtcp-fb:101 nack pli\r\n"
+        "a=fmtp:101 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\n"
+    )
+    session._camera_answer_sdp = (
+        "v=0\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 101\r\n"
+        "a=rtpmap:101 H264/90000\r\n"
+        "a=sendonly\r\n"
+    )
+
+    async def stats():
+        return {"video_receiver_stats": [{"ssrcs": [1234], "packetsReceived": 10}]}
+
+    async def close():
+        closed.append(True)
+        session._closed = True
+
+    def debug_context(**extra):
+        debug_contexts.append(extra)
+        return extra
+
+    session._camera_receiver_stats_debug = stats
+    session._debug_context = debug_context
+    session.close = close
+
+    await session._fail_after_timeout(
+        0, "xsense_webrtc_first_frame_timeout", "Timed out"
+    )
+
+    assert messages[0].code == "xsense_webrtc_first_frame_timeout"
+    assert debug_contexts[0]["video_receiver_stats"] == [
+        {"ssrcs": [1234], "packetsReceived": 10}
+    ]
+    assert debug_contexts[0]["camera_offer_sdp"]["video_feedback"] == {
+        "101": ["nack pli"]
+    }
+    assert debug_contexts[0]["camera_answer_sdp"]["directions"] == {
+        "video": "sendonly"
+    }
+    assert closed == [True]
+
+
 def test_signal_close_schedules_apk_style_reconnect():
     scheduled = []
     session = object.__new__(webrtc_signal.XSenseWebRTCSession)
@@ -1846,7 +1953,7 @@ async def test_camera_keyframe_request_sends_pli_for_video_ssrcs():
     session._camera_pc = FakePeer([receiver, FakeAudioReceiver()])
     session._debug_context = lambda **extra: extra
 
-    assert await session._send_camera_picture_loss_indication() == 1
+    assert await session._send_camera_picture_loss_indication() == [5678]
     assert receiver.sent == [5678]
 
 


### PR DESCRIPTION
## Summary
- refine camera WebRTC SDP feedback/H264 fmtp handling for the camera-facing offer
- keep matched offer/answer SDP summaries and PLI SSRCs in first-frame timeout debug logs
- ignore rejected `changeTransceiverOffer` answers unless the camera reports a successful APK-style `returnValue`
- bump prerelease metadata to 1.2.6.44 and add linked release notes

## Tests
- `python3 -m pytest tests/test_webrtc_signal.py tests/test_release_metadata.py -q`
- `python3 -m pytest -q`
- Codex CLI deep audit: no concrete prerelease-blocking camera/WebRTC issues after the returnValue fix
