### PR TITLE
Refine camera WebRTC first-frame handling

### DIFF
--- a/.github/release-notes/1.2.6.45.md
+++ b/.github/release-notes/1.2.6.45.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.2.6.45
+
+### 🎥 Camera WebRTC
+- Continues prerelease camera testing for accounts where camera audio starts but video still does not render.
+- Aligns the camera-facing SDP feedback path with Android WebRTC by advertising FIR support alongside PLI for video keyframes.
+- Keeps camera live-view resolution parsing conservative so unknown values do not get sent to the camera.
+
+### 🔎 Debug Logging
+- Keeps the sanitized `startLive` camera response in debug context for follow-up camera reports.
+- Keyframe debug now shows whether PLI/FIR requests are being sent for the active video SSRC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.2.6.45](.github/release-notes/1.2.6.45.md)
 - [1.2.6.44](.github/release-notes/1.2.6.44.md)
 - [1.2.6.43](.github/release-notes/1.2.6.43.md)
 - [1.2.6.42](.github/release-notes/1.2.6.42.md)

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -160,7 +160,7 @@ def _camera_resolution(value) -> str | None:
         return normalized
     if alias := _CAMERA_RESOLUTION_ALIASES.get(normalized.upper()):
         return alias
-    return normalized
+    return None
 
 
 def _camera_webrtc_ticket_valid(ticket: dict) -> bool:

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -156,6 +156,8 @@ class XSenseCameraEntity(XSenseEntity, Camera):
             _camera_debug_context(entity, session_id),
         )
 
+        await self._close_existing_webrtc_sessions()
+
         ticket_data = await self.coordinator.xsense.get_camera_webrtc_ticket(
             entity, force_refresh=True
         )
@@ -245,6 +247,22 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         """Forward a Home Assistant WebRTC candidate to X-Sense."""
         if session := self._webrtc_sessions.get(session_id):
             await session.add_candidate(candidate)
+
+    async def _close_existing_webrtc_sessions(self) -> None:
+        """Close previous ADDX camera WebRTC sessions before a new live view."""
+        active_sessions = getattr(self, "_webrtc_sessions", None)
+        if active_sessions is None:
+            return
+        sessions = list(active_sessions.values())
+        if not sessions:
+            return
+        LOGGER.debug(
+            "X-Sense camera closing previous WebRTC sessions before new offer: %s",
+            {"count": len(sessions)},
+        )
+        active_sessions.clear()
+        for session in sessions:
+            await session.close()
 
     @callback
     def close_webrtc_session(self, session_id: str) -> None:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.44"
+  "version": "1.2.6.45"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 from collections import Counter
 from dataclasses import dataclass
 from collections.abc import Coroutine
+from struct import pack
 from typing import Any, Callable
 from urllib.parse import urlparse, urlunparse
 
@@ -34,6 +35,7 @@ with warnings.catch_warnings():
         RTCSessionDescription,
     )
     from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
+    from aiortc.rtp import RTCP_PSFB_FIR, RtcpPsfbPacket
     from aiortc.sdp import candidate_from_sdp
 from homeassistant.components.camera.webrtc import (
     WebRTCAnswer,
@@ -439,6 +441,21 @@ def _receiver_media_ssrcs(receiver: Any) -> list[int]:
     return []
 
 
+def _fir_packet(receiver: Any, media_ssrc: int) -> RtcpPsfbPacket:
+    """Return an RTCP Full Intra Request for a camera media SSRC."""
+    sender_ssrc = int(getattr(receiver, "_RTCRtpReceiver__rtcp_ssrc", 0) or 0)
+    sequence_number = int(
+        getattr(receiver, "_xsense_fir_sequence_number", 0) % 256
+    )
+    setattr(receiver, "_xsense_fir_sequence_number", (sequence_number + 1) % 256)
+    return RtcpPsfbPacket(
+        fmt=RTCP_PSFB_FIR,
+        ssrc=sender_ssrc,
+        media_ssrc=0,
+        fci=pack("!LBBBB", int(media_ssrc), sequence_number, 0, 0, 0),
+    )
+
+
 def _sdp_fingerprints(sdp: str) -> list[str]:
     """Return compact DTLS fingerprint algorithms from SDP."""
     algorithms: list[str] = []
@@ -522,9 +539,9 @@ def _answer_reject_reason(payload: Any, ticket: XSenseWebRTCTicket) -> str:
         return "payload_not_dict"
     sender = payload.get("senderClientId")
     recipient = payload.get("recipientClientId")
-    if sender and sender != ticket.serial_number:
+    if sender != ticket.serial_number:
         return "sender_mismatch"
-    if recipient and recipient != ticket.client_id:
+    if recipient != ticket.client_id:
         return "recipient_mismatch"
     encoded = payload.get("messagePayload")
     if not isinstance(encoded, str):
@@ -703,9 +720,11 @@ def _looks_like_encoded_peer_payload(value: str) -> bool:
 
 
 def _base64_decode_required_text(value: str) -> str:
-    """Decode APK no-wrap base64 text, accepting stripped padding."""
+    """Decode Android Base64 text, accepting stripped padding and wrapping."""
     missing_padding = (-len(value)) % 4
-    return base64.b64decode(value + ("=" * missing_padding), validate=True).decode()
+    # Android Base64.DEFAULT accepts wrapped payloads; outbound APK payloads
+    # still use NO_WRAP through _b64_json.
+    return base64.b64decode(value + ("=" * missing_padding), validate=False).decode()
 
 
 def _base64_decode_text(value: str) -> str | None:
@@ -772,6 +791,7 @@ class XSenseWebRTCSession:
         self._first_frame_pli_task: asyncio.Task[None] | None = None
         self._keep_alive_task: asyncio.Task[None] | None = None
         self._start_live_sent = False
+        self._last_start_live_response: dict[str, Any] | None = None
         self._first_frame_received = False
         self._closed = False
         self._close_lock = asyncio.Lock()
@@ -803,6 +823,9 @@ class XSenseWebRTCSession:
                 "sdp_answer_received": getattr(self, "_sdp_answer_received", None),
                 "first_frame_received": getattr(self, "_first_frame_received", None),
                 "start_live_sent": getattr(self, "_start_live_sent", None),
+                "last_start_live_response": getattr(
+                    self, "_last_start_live_response", None
+                ),
                 "last_signal_event": getattr(self, "_last_signal_event", None),
                 "signal_events": dict(getattr(self, "_signal_event_counts", {})),
                 "local_candidate_count": getattr(
@@ -843,11 +866,19 @@ class XSenseWebRTCSession:
             LOGGER.debug("X-Sense WebRTC HA answer ready: %s", self._debug_context())
             await self._connect_signal()
             self._restart_play_timeout()
-            LOGGER.debug(
-                "X-Sense WebRTC waiting for PEER_IN before camera offer: %s",
-                self._debug_context(),
-            )
-            self._restart_peer_in_timeout()
+            if self._camera_online:
+                LOGGER.debug(
+                    "X-Sense WebRTC camera already online, starting offer path: %s",
+                    self._debug_context(),
+                )
+                self._camera_peer_ready = True
+                await self._start_camera_peer()
+            else:
+                LOGGER.debug(
+                    "X-Sense WebRTC waiting for PEER_IN before camera offer: %s",
+                    self._debug_context(),
+                )
+                self._restart_peer_in_timeout()
             return True
         except Exception as err:  # noqa: BLE001 - surface cleanly to HA frontend
             LOGGER.debug(
@@ -1218,12 +1249,13 @@ class XSenseWebRTCSession:
         """Ask the camera for a decodable first frame until one arrives."""
         try:
             while not self._closed and not self._first_frame_received:
-                pli_ssrcs = await self._send_camera_picture_loss_indication()
-                if pli_ssrcs:
+                keyframe_requests = await self._send_camera_keyframe_request()
+                if keyframe_requests:
                     LOGGER.debug(
                         "X-Sense WebRTC requested camera keyframe: %s",
                         self._debug_context(
-                            pli_count=len(pli_ssrcs), pli_ssrcs=pli_ssrcs
+                            keyframe_request_count=len(keyframe_requests),
+                            keyframe_requests=keyframe_requests,
                         ),
                     )
                 else:
@@ -1238,17 +1270,18 @@ class XSenseWebRTCSession:
             if getattr(self, "_first_frame_pli_task", None) is asyncio.current_task():
                 self._first_frame_pli_task = None
 
-    async def _send_camera_picture_loss_indication(self) -> list[int]:
-        """Send RTCP PLI for camera video receivers that have active SSRCs."""
+    async def _send_camera_keyframe_request(self) -> list[dict[str, Any]]:
+        """Send APK-compatible RTCP keyframe feedback for active video SSRCs."""
         camera_pc = self._camera_pc
         if camera_pc is None:
             return []
-        sent: list[int] = []
+        sent: list[dict[str, Any]] = []
         for receiver in list(getattr(camera_pc, "getReceivers", lambda: [])()):
             track = getattr(receiver, "track", None)
             if getattr(track, "kind", None) != "video":
                 continue
             send_pli = getattr(receiver, "_send_rtcp_pli", None)
+            send_rtcp = getattr(receiver, "_send_rtcp", None)
             if not callable(send_pli):
                 continue
             for ssrc in _receiver_media_ssrcs(receiver):
@@ -1260,8 +1293,18 @@ class XSenseWebRTCSession:
                         self._debug_context(error=type(err).__name__, message=str(err)),
                     )
                     continue
-                sent.append(ssrc)
+                feedback = {"ssrc": ssrc, "pli": True, "fir": False}
+                if callable(send_rtcp):
+                    with suppress(Exception):
+                        await send_rtcp(_fir_packet(receiver, ssrc))
+                        feedback["fir"] = True
+                sent.append(feedback)
         return sent
+
+    async def _send_camera_picture_loss_indication(self) -> list[int]:
+        """Send RTCP PLI for camera video receivers that have active SSRCs."""
+        requests = await self._send_camera_keyframe_request()
+        return [request["ssrc"] for request in requests if request.get("pli")]
 
     def _cancel_first_frame_keyframe_requests(self) -> None:
         task = getattr(self, "_first_frame_pli_task", None)
@@ -1460,6 +1503,8 @@ class XSenseWebRTCSession:
             self._create_task(self._send_change_transceiver_offer())
         elif action == "changeTransceiverOffer":
             self._create_task(self._apply_change_transceiver_answer(payload))
+        elif action == "startLive":
+            self._last_start_live_response = _data_channel_debug(payload)
 
     def _send_data_channel_json(self, payload: dict[str, Any]) -> bool:
         if getattr(self._data_channel, "readyState", None) != "open":
@@ -1530,7 +1575,11 @@ class XSenseWebRTCSession:
         ):
             return
         self._start_live_sent = True
-        if not self._first_frame_received and not self._first_frame_timeout_task:
+        if (
+            self._resolution != "auto"
+            and not self._first_frame_received
+            and not self._first_frame_timeout_task
+        ):
             self._first_frame_timeout_task = asyncio.create_task(
                 self._fail_after_timeout(
                     _FIRST_FRAME_TIMEOUT,
@@ -1845,9 +1894,9 @@ def _owned_answer_sdp(payload: Any, ticket: XSenseWebRTCTicket) -> str | None:
         return None
     sender = payload.get("senderClientId")
     recipient = payload.get("recipientClientId")
-    if sender and sender != ticket.serial_number:
+    if sender != ticket.serial_number:
         return None
-    if recipient and recipient != ticket.client_id:
+    if recipient != ticket.client_id:
         return None
     return _answer_sdp(payload)
 
@@ -1937,7 +1986,7 @@ def _apk_camera_offer_sdp(sdp: str) -> str:
 
 def _sdp_with_android_video_feedback(sdp: str) -> str:
     """Advertise Android WebRTC-style video feedback to X-Sense cameras."""
-    feedback_values = ("goog-remb", "nack", "nack pli")
+    feedback_values = ("goog-remb", "nack", "nack pli", "ccm fir")
     lines = sdp.splitlines()
     output: list[str] = []
     in_video = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests
 asyncio_mode = auto
 pythonpath = .
+filterwarnings =
+    ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning:homeassistant\.components\.http

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -2352,8 +2352,8 @@ async def test_update_camera_data_creates_camera_from_addx_without_home_camera_e
         ),
         ({"supportedRecordingResolutions": []}, "auto"),
         ({"supportedRecordingResolutions": ["P1296"]}, "auto"),
-        ({"deviceSupportResolution": ["bad", "P720"]}, "bad"),
-        ({"liveResolution": "UNKNOWN_RESOLUTION"}, "UNKNOWN_RESOLUTION"),
+        ({"deviceSupportResolution": ["bad", "P720"]}, "1280x720"),
+        ({"liveResolution": "UNKNOWN_RESOLUTION"}, "auto"),
     ],
 )
 async def test_start_camera_live_uses_apk_live_resolution(camera_data, expected):

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -490,6 +490,90 @@ async def test_failed_webrtc_start_is_removed_from_active_sessions(monkeypatch):
     assert not camera.is_streaming
 
 
+async def test_new_webrtc_offer_closes_previous_camera_session(monkeypatch):
+    from custom_components.xsense import camera as camera_module
+    from custom_components.xsense.camera import CAMERA_DESCRIPTION, XSenseCameraEntity
+
+    camera_entity = entity("SSC0A", {"streamProtocol": "webrtc", "supportWebrtc": True})
+    camera_entity.entity_id = "camera-test"
+    camera_entity.sn = "SSC0ATEST"
+    camera_entity.name = "Camera"
+    camera_entity.online = True
+
+    async def get_camera_webrtc_ticket(entity, *, force_refresh=False):
+        return {
+            "signalServer": "https://signal.example",
+            "groupId": "group",
+            "role": "viewer",
+            "id": "client123",
+            "traceId": "trace",
+            "sign": "sig",
+            "time": 123456,
+            "expirationTime": 9999999999999,
+            "iceServer": [],
+        }
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = SimpleNamespace(
+                get_camera_webrtc_ticket=get_camera_webrtc_ticket
+            )
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    class ExistingSession:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    created_sessions = []
+
+    class NewSession:
+        def __init__(self, **kwargs):
+            created_sessions.append(kwargs)
+
+        async def start(self):
+            return True
+
+        async def close(self):
+            pass
+
+    fake_module = SimpleNamespace(
+        XSenseWebRTCTicket=SimpleNamespace(
+            from_api=lambda serial_number, data: SimpleNamespace(is_valid=True)
+        ),
+        XSenseWebRTCSession=NewSession,
+    )
+
+    class FakeHass:
+        async def async_add_import_executor_job(self, func, module):
+            return fake_module
+
+    monkeypatch.setattr(
+        camera_module, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+
+    camera = XSenseCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+    camera.hass = FakeHass()
+    old_session = ExistingSession()
+    camera._webrtc_sessions["old-session"] = old_session
+
+    await camera.async_handle_async_webrtc_offer(
+        "v=0\r\n", "new-session", lambda message: None
+    )
+
+    assert old_session.closed is True
+    assert list(camera._webrtc_sessions) == ["new-session"]
+    assert len(created_sessions) == 1
+
+
 async def test_webrtc_camera_stream_source_does_not_start_native_live_url():
     from custom_components.xsense.camera import CAMERA_DESCRIPTION, XSenseCameraEntity
 

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -245,8 +245,11 @@ a=mid:2
     assert "m=video 9 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102" in apk_sdp
     assert "H264" in apk_sdp
     assert "a=rtcp-fb:99 nack pli" in apk_sdp
+    assert "a=rtcp-fb:99 ccm fir" in apk_sdp
     assert "a=rtcp-fb:101 nack pli" in apk_sdp
+    assert "a=rtcp-fb:101 ccm fir" in apk_sdp
     assert "a=rtcp-fb:100 nack pli" not in apk_sdp
+    assert "a=rtcp-fb:100 ccm fir" not in apk_sdp
     assert (
         "a=fmtp:99 level-asymmetry-allowed=1;profile-level-id=42001f;"
         "packetization-mode=1"
@@ -295,6 +298,26 @@ def test_data_channel_answer_accepts_apk_base64_without_padding():
         webrtc_signal._data_channel_answer_sdp({"data": {"answer": encoded}})
         == "answer"
     )
+
+
+def test_data_channel_answer_accepts_android_wrapped_base64():
+    encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
+    wrapped = encoded[:8] + "\n" + encoded[8:]
+
+    assert (
+        webrtc_signal._data_channel_answer_sdp({"data": {"answer": wrapped}})
+        == "answer"
+    )
+
+
+def test_data_channel_timestamp_uses_apk_seconds(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100.123)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    command = make_start_live_data_channel_message("1280x720")
+
+    assert command["requestID"] == "100123-321"
+    assert command["timeStamp"] == 100
 
 
 def test_change_transceiver_commands_match_apk(monkeypatch):
@@ -716,7 +739,7 @@ def test_parse_signal_message_preserves_answer_envelope_for_apk_validation():
     assert webrtc_signal._owned_answer_sdp(payload, ticket()) == "answer"
 
 
-def test_apk_sdp_answer_validation_allows_missing_optional_ids():
+def test_apk_sdp_answer_validation_requires_sender_and_recipient_ids():
     encoded = base64.b64encode(json.dumps({"sdp": "answer"}).encode()).decode()
 
     assert (
@@ -724,14 +747,36 @@ def test_apk_sdp_answer_validation_allows_missing_optional_ids():
             {"messagePayload": encoded, "senderClientId": "SSC0A123"},
             ticket(),
         )
-        == "answer"
+        is None
     )
     assert (
         webrtc_signal._owned_answer_sdp(
             {"messagePayload": encoded, "recipientClientId": "client123"},
             ticket(),
         )
-        == "answer"
+        is None
+    )
+    assert (
+        webrtc_signal._owned_answer_sdp(
+            {
+                "messagePayload": encoded,
+                "senderClientId": "",
+                "recipientClientId": "client123",
+            },
+            ticket(),
+        )
+        is None
+    )
+    assert (
+        webrtc_signal._owned_answer_sdp(
+            {
+                "messagePayload": encoded,
+                "senderClientId": "SSC0A123",
+                "recipientClientId": "",
+            },
+            ticket(),
+        )
+        is None
     )
 
 
@@ -799,6 +844,23 @@ def test_sdp_answer_reject_reason_keeps_debug_actionable():
                 "messagePayload": encoded,
                 "senderClientId": "SSC0A123",
                 "recipientClientId": "other-client",
+            },
+            signal_ticket,
+        )
+        == "recipient_mismatch"
+    )
+    assert (
+        webrtc_signal._answer_reject_reason(
+            {"messagePayload": encoded, "recipientClientId": "client123"},
+            signal_ticket,
+        )
+        == "sender_mismatch"
+    )
+    assert (
+        webrtc_signal._answer_reject_reason(
+            {
+                "messagePayload": encoded,
+                "senderClientId": "SSC0A123",
             },
             signal_ticket,
         )
@@ -1059,6 +1121,38 @@ def test_data_channel_debug_includes_safe_nested_codec_values():
     assert "parameter_token" not in debug
 
 
+def test_start_live_response_is_kept_in_debug_context():
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._last_start_live_response = None
+
+    session._handle_data_channel_message(
+        json.dumps(
+            {
+                "action": "startLive",
+                "returnValue": 17,
+                "data": json.dumps(
+                    {
+                        "videoCodec": "H264",
+                        "resolution": "1920x1080",
+                        "url": "rtsp://example.invalid/secret",
+                    }
+                ),
+                "parameters": {"size": "1920x1080", "token": "secret"},
+            }
+        )
+    )
+
+    assert session._last_start_live_response == {
+        "action": "startLive",
+        "returnValue": 17,
+        "data_keys": ["resolution", "url", "videoCodec"],
+        "data_videoCodec": "H264",
+        "data_resolution": "1920x1080",
+        "parameter_keys": ["size", "token"],
+        "parameter_size": "1920x1080",
+    }
+
+
 def test_camera_webrtc_resolution_uses_apk_normalization():
     from types import SimpleNamespace
 
@@ -1099,7 +1193,7 @@ def test_camera_webrtc_resolution_uses_apk_normalization():
         _camera_live_resolution(
             SimpleNamespace(data={"deviceSupportResolution": ["bad", "P720"]})
         )
-        == "bad"
+        == "1280x720"
     )
     assert (
         _camera_live_resolution(
@@ -1180,6 +1274,63 @@ def test_start_live_waits_for_camera_data_channel_connected_like_apk(monkeypatch
     assert len(created_tasks) == 2
     assert session._first_frame_timeout_task is created_tasks[0]
     assert session._first_frame_pli_task is created_tasks[1]
+
+
+def test_auto_resolution_start_live_skips_first_frame_timeout_like_apk(monkeypatch):
+    monkeypatch.setattr(webrtc_signal.time, "time", lambda: 100)
+    monkeypatch.setattr(webrtc_signal.random, "randint", lambda start, end: 321)
+
+    class FakeDataChannel:
+        readyState = "open"
+
+        def __init__(self):
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(json.loads(message))
+
+    class FakeTask:
+        def __init__(self, coro):
+            self.coro = coro
+            coro.close()
+
+        def done(self):
+            return False
+
+    created_tasks = []
+
+    def create_task(coro):
+        task = FakeTask(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(webrtc_signal.asyncio, "create_task", create_task)
+
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._resolution = "auto"
+    session._data_channel = FakeDataChannel()
+    session._data_channel_connected = True
+    session._start_live_sent = False
+    session._first_frame_received = False
+    session._first_frame_timeout_task = None
+    session._first_frame_pli_task = None
+    session._closed = False
+    session._debug_context = lambda **kwargs: kwargs
+
+    session._send_start_live_if_ready()
+
+    assert session._data_channel.messages == [
+        {
+            "requestID": "100000-321",
+            "connectionID": "7893feb",
+            "timeStamp": 100,
+            "action": "startLive",
+            "size": "1280x720",
+            "resolution": "auto",
+        }
+    ]
+    assert session._first_frame_timeout_task is None
+    assert session._first_frame_pli_task is created_tasks[0]
 
 
 def test_data_channel_connected_message_sends_start_live_like_apk(monkeypatch):
@@ -1917,7 +2068,7 @@ def test_reset_camera_peer_state_cancels_stale_attempt_state(monkeypatch):
     assert session._camera_local_description_task is None
 
 
-async def test_camera_keyframe_request_sends_pli_for_video_ssrcs():
+async def test_camera_keyframe_request_sends_pli_and_fir_for_video_ssrcs():
     class FakeTrack:
         kind = "video"
 
@@ -1927,10 +2078,15 @@ async def test_camera_keyframe_request_sends_pli_for_video_ssrcs():
         def __init__(self):
             self._RTCRtpReceiver__active_ssrc = {1234: object()}
             self._RTCRtpReceiver__remote_streams = {5678: object()}
-            self.sent = []
+            self._RTCRtpReceiver__rtcp_ssrc = 9999
+            self.pli_sent = []
+            self.rtcp_sent = []
 
         async def _send_rtcp_pli(self, ssrc):
-            self.sent.append(ssrc)
+            self.pli_sent.append(ssrc)
+
+        async def _send_rtcp(self, packet):
+            self.rtcp_sent.append(packet)
 
     class FakeAudioReceiver:
         class Track:
@@ -1953,8 +2109,15 @@ async def test_camera_keyframe_request_sends_pli_for_video_ssrcs():
     session._camera_pc = FakePeer([receiver, FakeAudioReceiver()])
     session._debug_context = lambda **extra: extra
 
-    assert await session._send_camera_picture_loss_indication() == [5678]
-    assert receiver.sent == [5678]
+    assert await session._send_camera_keyframe_request() == [
+        {"ssrc": 5678, "pli": True, "fir": True}
+    ]
+    assert receiver.pli_sent == [5678]
+    fir = receiver.rtcp_sent[0]
+    assert fir.fmt == webrtc_signal.RTCP_PSFB_FIR
+    assert fir.ssrc == 9999
+    assert fir.media_ssrc == 0
+    assert fir.fci == b"\x00\x00\x16.\x00\x00\x00\x00"
 
 
 def test_receiver_media_ssrcs_prefers_remote_streams_over_active_ssrcs():
@@ -1982,7 +2145,7 @@ def test_receiver_media_ssrcs_maps_rtx_to_primary_media_ssrcs():
     assert webrtc_signal._receiver_media_ssrcs(FakeReceiver()) == [4321]
 
 
-async def test_online_camera_waits_for_peer_in_before_offer_like_apk():
+async def test_online_camera_starts_offer_without_peer_in_like_apk():
     class FakeWs:
         closed = False
 
@@ -2109,9 +2272,9 @@ async def test_online_camera_waits_for_peer_in_before_offer_like_apk():
 
     assert aio_session.ws.messages == []
     assert aio_session.connect_kwargs["heartbeat"] == 30
-    assert started == []
-    assert session._peer_in_timeout_task is not None
-    assert len(tasks) == 3
+    assert started == [True]
+    assert session._peer_in_timeout_task is None
+    assert len(tasks) == 2
     assert sent_messages[0].answer == "v=0\r\n"
 
 


### PR DESCRIPTION
## Summary
- align camera WebRTC SDP feedback with FIR support alongside PLI
- keep sanitized startLive response details in camera debug context
- avoid sending unknown camera live-resolution values into startLive
- bump prerelease metadata to 1.2.6.45 and add linked release notes

## Tests
- python3 -m pytest tests/test_webrtc_signal.py tests/test_camera_entity_guards.py tests/api/test_async_xsense.py -q
- python3 -m pytest -q