### PR TITLE
Refine camera WebRTC codec handling

### DIFF
--- a/.github/release-notes/1.2.6.46.md
+++ b/.github/release-notes/1.2.6.46.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.2.6.46
+
+### 🎥 Camera WebRTC
+- Continues prerelease camera testing for accounts where camera audio starts but video still does not render.
+- Narrows the camera-facing video offer to the H264 profile that the Python WebRTC bridge can decode reliably.
+- Keeps the initial offer and camera-requested renegotiation offer on the same video codec profile.
+
+### 🔎 Debug Logging
+- Adds compact video payload and H264 profile details to camera SDP debug summaries.
+- Adds camera metadata codec fields to WebRTC debug context for follow-up camera reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.2.6.46](.github/release-notes/1.2.6.46.md)
 - [1.2.6.45](.github/release-notes/1.2.6.45.md)
 - [1.2.6.44](.github/release-notes/1.2.6.44.md)
 - [1.2.6.43](.github/release-notes/1.2.6.43.md)

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -346,6 +346,8 @@ def _camera_debug_context(entity, session_id, **extra):
         "device_status": entity.data.get("deviceStatus"),
         "awake": entity.data.get("awake"),
         "support_webrtc": entity.data.get("supportWebrtc"),
+        "codec": entity.data.get("codec"),
+        "default_codec": entity.data.get("defaultCodec"),
         "resolution": _camera_live_resolution(entity),
     }
     context.update(extra)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.45"
+  "version": "1.2.6.46"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -32,6 +32,7 @@ with warnings.catch_warnings():
         RTCIceCandidate,
         RTCIceServer as AiortcRTCIceServer,
         RTCPeerConnection,
+        RTCRtpReceiver,
         RTCSessionDescription,
     )
     from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
@@ -322,6 +323,8 @@ def _sdp_debug(sdp: str | None) -> dict[str, Any]:
         "directions": _sdp_media_directions(sdp),
         "video_codecs": _sdp_media_codecs(sdp, "video"),
         "video_payloads": _sdp_media_payloads(sdp, "video"),
+        "video_primary_payload": _sdp_primary_media_payload(sdp, "video"),
+        "video_has_decoder_safe_h264": _sdp_has_h264_profile(sdp, "42001f"),
         "video_feedback": _sdp_media_feedback(sdp, "video"),
         "fingerprints": _sdp_fingerprints(sdp),
         "candidate_lines": sum(
@@ -400,6 +403,37 @@ def _sdp_media_payloads(sdp: str, media_kind: str) -> list[dict[str, str]]:
                     compact_fmtp
                 )
     return list(payloads.values())
+
+
+def _sdp_primary_media_payload(sdp: str, media_kind: str) -> dict[str, str] | None:
+    """Return the first non-RTX payload from one SDP media section."""
+    for payload in _sdp_media_payloads(sdp, media_kind):
+        if payload.get("codec") != "RTX":
+            return payload
+    return None
+
+
+def _sdp_has_h264_profile(sdp: str, profile_level_id: str) -> bool:
+    """Return whether the video SDP advertises one H264 profile-level-id."""
+    expected = f"profile-level-id={profile_level_id}"
+    return any(
+        payload.get("codec") == "H264" and expected in payload.get("fmtp", "")
+        for payload in _sdp_media_payloads(sdp, "video")
+    )
+
+
+def _sdp_codec_preference_debug(sdp: str | None) -> list[str]:
+    """Return compact H264 profile preferences visible in a camera offer."""
+    if not isinstance(sdp, str):
+        return []
+    profiles: list[str] = []
+    for payload in _sdp_media_payloads(sdp, "video"):
+        if payload.get("codec") != "H264":
+            continue
+        for item in payload.get("fmtp", "").split(";"):
+            if item.startswith("profile-level-id="):
+                profiles.append(item.removeprefix("profile-level-id="))
+    return profiles
 
 
 def _sdp_media_feedback(sdp: str, media_kind: str) -> dict[str, list[str]]:
@@ -1522,6 +1556,7 @@ class XSenseWebRTCSession:
             return
         if self._camera_pc is None:
             return
+        codec_preferences = _prefer_existing_camera_video_codecs(self._camera_pc)
         offer = await self._camera_pc.createOffer()
         camera_offer = RTCSessionDescription(
             sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
@@ -1537,7 +1572,10 @@ class XSenseWebRTCSession:
         if sent:
             LOGGER.debug(
                 "X-Sense WebRTC sent changeTransceiverOffer: %s",
-                self._debug_context(offer_sdp=_sdp_debug(camera_offer.sdp)),
+                self._debug_context(
+                    offer_sdp=_sdp_debug(camera_offer.sdp),
+                    codec_preferences=codec_preferences,
+                ),
             )
 
     async def _apply_change_transceiver_answer(self, payload: dict[str, Any]) -> None:
@@ -1601,7 +1639,10 @@ class XSenseWebRTCSession:
             raise RuntimeError("Camera peer connection was not created")
         # APK createOffer asks to receive video; audio is already present from
         # peer setup, matching the SDK transceiver timing.
-        self._camera_pc.addTransceiver("video", direction="recvonly")
+        video_transceiver = self._camera_pc.addTransceiver(
+            "video", direction="recvonly"
+        )
+        _prefer_camera_video_codecs(video_transceiver)
         offer = await self._camera_pc.createOffer()
         camera_offer = RTCSessionDescription(
             sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
@@ -1633,6 +1674,7 @@ class XSenseWebRTCSession:
             self._debug_context(
                 recipient=_short_id(self._recipient_client_id),
                 offer_sdp=_sdp_debug(self._camera_offer_sdp),
+                codec_preferences=_sdp_codec_preference_debug(self._camera_offer_sdp),
                 offer_envelope=_signal_envelope_debug(offer_payload),
                 offer_resolution=bool(self._resolution),
             ),
@@ -1856,6 +1898,37 @@ class XSenseWebRTCSession:
             )
 
 
+def _prefer_camera_video_codecs(transceiver: Any) -> list[str]:
+    """Constrain aiortc to the H264 profile that the Python decoder can handle."""
+    set_preferences = getattr(transceiver, "setCodecPreferences", None)
+    if not callable(set_preferences):
+        return []
+    codecs = []
+    for codec in RTCRtpReceiver.getCapabilities("video").codecs:
+        if codec.mimeType.lower() != "video/h264":
+            continue
+        if codec.parameters.get("profile-level-id") == "42001f":
+            codecs.append(codec)
+    if not codecs:
+        return []
+    set_preferences(codecs)
+    return [codec.parameters.get("profile-level-id") for codec in codecs]
+
+
+def _prefer_existing_camera_video_codecs(peer_connection: Any) -> list[str]:
+    """Keep renegotiated camera offers on the same decoder-safe H264 profile."""
+    get_transceivers = getattr(peer_connection, "getTransceivers", None)
+    if not callable(get_transceivers):
+        return []
+    preferences: list[str] = []
+    for transceiver in get_transceivers():
+        receiver = getattr(transceiver, "receiver", None)
+        track = getattr(receiver, "track", None)
+        if getattr(track, "kind", None) == "video":
+            preferences.extend(_prefer_camera_video_codecs(transceiver))
+    return preferences
+
+
 def _camera_rtc_configuration(ticket: XSenseWebRTCTicket) -> AiortcRTCConfiguration:
     servers = []
     for server in ticket.ice_servers or []:
@@ -1990,34 +2063,23 @@ def _sdp_with_android_video_feedback(sdp: str) -> str:
     lines = sdp.splitlines()
     output: list[str] = []
     in_video = False
-    video_payloads: set[str] = set()
-    video_feedback: set[tuple[str, str]] = set()
-
-    def flush_video_feedback() -> None:
-        for payload in sorted(video_payloads, key=int):
-            for value in feedback_values:
-                if (payload, value) not in video_feedback:
-                    output.append(f"a=rtcp-fb:{payload} {value}")
 
     for line in lines:
         if line.startswith("m="):
-            if in_video:
-                flush_video_feedback()
             in_video = line.startswith("m=video ")
-            video_payloads = set()
-            video_feedback = set()
             output.append(line)
             continue
+        if in_video and line.startswith("a=rtcp-fb:"):
+            continue
         if in_video and line.startswith("a=rtpmap:"):
+            output.append(line)
             payload, codec = line.removeprefix("a=rtpmap:").split(None, 1)
             if codec.split("/", 1)[0].upper() != "RTX":
-                video_payloads.add(payload)
-        elif in_video and line.startswith("a=rtcp-fb:"):
-            payload, value = line.removeprefix("a=rtcp-fb:").split(None, 1)
-            video_feedback.add((payload, value))
+                output.extend(
+                    f"a=rtcp-fb:{payload} {value}" for value in feedback_values
+                )
+            continue
         output.append(_sdp_with_android_h264_fmtp(line) if in_video else line)
-    if in_video:
-        flush_video_feedback()
     ending = "\r\n" if "\r\n" in sdp else "\n"
     return ending.join(output) + (ending if sdp.endswith(("\r\n", "\n")) else "")
 

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -488,13 +488,21 @@ async def test_change_transceiver_answer_ignores_nonzero_return_value_like_apk(m
 
 
 async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch):
+    class FakeTransceiver:
+        def __init__(self):
+            self.codec_preferences = None
+
+        def setCodecPreferences(self, codecs):
+            self.codec_preferences = codecs
+
     class FakePeer:
         def __init__(self):
             self.transceivers = []
 
         def addTransceiver(self, kind, **kwargs):
-            self.transceivers.append((kind, kwargs))
-            return object()
+            transceiver = FakeTransceiver()
+            self.transceivers.append((kind, kwargs, transceiver))
+            return transceiver
 
         async def createOffer(self):
             class Offer:
@@ -519,13 +527,72 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
     await session._start_camera_peer()
 
     assert len(session._camera_pc.transceivers) == 1
-    assert session._camera_pc.transceivers[0] == ("video", {"direction": "recvonly"})
+    kind, kwargs, transceiver = session._camera_pc.transceivers[0]
+    assert (kind, kwargs) == ("video", {"direction": "recvonly"})
+    assert [
+        codec.parameters.get("profile-level-id")
+        for codec in transceiver.codec_preferences
+    ] == ["42001f"]
     assert session._camera_offer_sdp == "v=0\r\n"
     assert session._camera_local_description_task is not None
     session._camera_local_description_task.cancel()
     with suppress(asyncio.CancelledError):
         await session._camera_local_description_task
 
+
+def test_existing_camera_video_transceiver_prefers_decoder_safe_h264_profile():
+    class FakeTrack:
+        kind = "video"
+
+    class FakeReceiver:
+        track = FakeTrack()
+
+    class FakeTransceiver:
+        receiver = FakeReceiver()
+
+        def __init__(self):
+            self.codec_preferences = None
+
+        def setCodecPreferences(self, codecs):
+            self.codec_preferences = codecs
+
+    class FakePeerConnection:
+        def __init__(self):
+            self.video = FakeTransceiver()
+
+        def getTransceivers(self):
+            return [self.video]
+
+    peer = FakePeerConnection()
+
+    webrtc_signal._prefer_existing_camera_video_codecs(peer)
+
+    assert [
+        codec.parameters.get("profile-level-id")
+        for codec in peer.video.codec_preferences
+    ] == ["42001f"]
+
+
+async def test_camera_offer_prefers_decoder_safe_h264_profile():
+    pc = webrtc_signal.RTCPeerConnection()
+    try:
+        pc.addTransceiver("audio")
+        video_transceiver = pc.addTransceiver("video", direction="recvonly")
+        webrtc_signal._prefer_camera_video_codecs(video_transceiver)
+        offer = await pc.createOffer()
+        camera_sdp = webrtc_signal._apk_camera_offer_sdp(offer.sdp)
+    finally:
+        await pc.close()
+
+    payloads = webrtc_signal._sdp_media_payloads(camera_sdp, "video")
+    assert payloads == [
+        {
+            "payload": "99",
+            "codec": "H264",
+            "fmtp": "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
+        }
+    ]
+    assert "profile-level-id=42e01f" not in camera_sdp
 
 async def test_send_offer_sends_apk_offer_then_local_ice_candidates():
     class FakeWs:
@@ -1096,6 +1163,12 @@ def test_sdp_debug_includes_video_payload_fmtp_and_feedback():
         },
         {"payload": "102", "codec": "RTX", "fmtp": "apt=101"},
     ]
+    assert debug["video_primary_payload"] == {
+        "payload": "101",
+        "codec": "H264",
+        "fmtp": "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+    }
+    assert debug["video_has_decoder_safe_h264"] is False
     assert debug["video_feedback"] == {"101": ["nack", "nack pli"]}
 
 


### PR DESCRIPTION
## Summary
- keep camera WebRTC offers on the decoder-safe H264 profile used by the Python bridge
- preserve the same codec preference during camera renegotiation
- add compact camera SDP/debug context for video payload and codec follow-up reports
- add prerelease notes and bump the manifest to 1.2.6.46

## Validation
- python3 -m pytest -q
- git diff --check
