### PR TITLE
Refine camera WebRTC APK flow

### DIFF
--- a/.github/release-notes/1.2.6.47.md
+++ b/.github/release-notes/1.2.6.47.md
@@ -1,0 +1,11 @@
+## X-Sense Home Security v1.2.6.47
+
+### Camera WebRTC
+- Continues prerelease camera testing for accounts where camera audio starts but video still does not render.
+- Removes the integration-side signal heartbeat so the WebRTC signal socket follows the APK connection behavior.
+- Resends an unanswered camera offer after the signal socket reconnects, matching the APK reconnect path.
+- Keeps the camera-facing offer on native WebRTC codec choices instead of forcing one H264 profile.
+- Uses a single supported camera resolution when that is all the API reports, matching the app resolution path.
+
+### Debug Logging
+- Keeps compact offer, answer, signal reconnect, candidate, and data-channel context for follow-up camera reports without logging sensitive tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.2.6.47](.github/release-notes/1.2.6.47.md)
 - [1.2.6.46](.github/release-notes/1.2.6.46.md)
 - [1.2.6.45](.github/release-notes/1.2.6.45.md)
 - [1.2.6.44](.github/release-notes/1.2.6.44.md)

--- a/custom_components/xsense/api/async_xsense.py
+++ b/custom_components/xsense/api/async_xsense.py
@@ -184,8 +184,6 @@ def _camera_supported_resolutions(camera: Entity) -> list[str]:
         supported = [supported]
     elif not isinstance(supported, (list, tuple)):
         return []
-    if len(supported) < 2:
-        return []
     resolutions: list[str] = []
     for value in supported:
         resolution = _camera_resolution(value)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,5 +20,5 @@
   "homeassistant": "2025.3.0",
   "ssdp": [],
   "zeroconf": [],
-  "version": "1.2.6.46"
+  "version": "1.2.6.47"
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -32,7 +32,6 @@ with warnings.catch_warnings():
         RTCIceCandidate,
         RTCIceServer as AiortcRTCIceServer,
         RTCPeerConnection,
-        RTCRtpReceiver,
         RTCSessionDescription,
     )
     from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
@@ -70,7 +69,6 @@ _PEER_IN_TIMEOUT = 20
 _PLAY_TIMEOUT = 40
 _FIRST_FRAME_TIMEOUT = 10
 _FIRST_FRAME_PLI_INTERVAL = 1
-_DEFAULT_SIGNAL_HEARTBEAT = 30
 _SIGNAL_RECONNECT_DELAY = 5
 _SIGNAL_TERMINAL_CLOSE_CODES = {3002, 3004}
 _DATA_CHANNEL_SAFE_VALUE_KEYS = {
@@ -251,12 +249,12 @@ def _ticket_debug_context(ticket: XSenseWebRTCTicket) -> dict[str, Any]:
     }
 
 
-def _signal_heartbeat(ticket: XSenseWebRTCTicket) -> float:
-    """Return the integration WebSocket heartbeat for the signal socket."""
-    # The APK stores signalPingInterval in the ticket, but the Java wrapper does
-    # not pass it into A4xSignal.init. Keep our client heartbeat stable instead
-    # of interpreting that ticket field as WebSocket ping timing.
-    return _DEFAULT_SIGNAL_HEARTBEAT
+def _signal_heartbeat(ticket: XSenseWebRTCTicket) -> None:
+    """Return the APK-aligned WebSocket heartbeat for the signal socket."""
+    # The APK Java wrapper does not pass a heartbeat interval into A4xSignal.init.
+    # Do not add aiohttp's client-side ping loop here; it can close the signal
+    # socket before the camera sends SDP_ANSWER.
+    return None
 
 
 def _payload_debug(payload: Any) -> str:
@@ -1100,9 +1098,9 @@ class XSenseWebRTCSession:
             self._debug_context(connect_host=_safe_host(connect_url)),
         )
         signal_heartbeat = _signal_heartbeat(self._ticket)
-        self._ws = await self._session.ws_connect(
-            connect_url, heartbeat=signal_heartbeat, **connect_options
-        )
+        if signal_heartbeat is not None:
+            connect_options["heartbeat"] = signal_heartbeat
+        self._ws = await self._session.ws_connect(connect_url, **connect_options)
         LOGGER.debug("X-Sense WebRTC signal connected: %s", self._debug_context())
         self._reader_task = asyncio.create_task(self._read_loop())
 
@@ -1211,6 +1209,15 @@ class XSenseWebRTCSession:
                 reconnect_delay_s=_SIGNAL_RECONNECT_DELAY,
             ),
         )
+        if getattr(self, "_camera_offer_sent", False) and not getattr(
+            self, "_sdp_answer_received", False
+        ):
+            self._camera_offer_sent = False
+            self._camera_local_candidate_count = 0
+            LOGGER.debug(
+                "X-Sense WebRTC will resend unanswered camera offer after signal reconnect: %s",
+                self._debug_context(signal_close_code=close_code),
+            )
         try:
             await self._reconnect_signal()
         except Exception as err:  # noqa: BLE001 - play timeout owns user-facing failure
@@ -1556,7 +1563,6 @@ class XSenseWebRTCSession:
             return
         if self._camera_pc is None:
             return
-        codec_preferences = _prefer_existing_camera_video_codecs(self._camera_pc)
         offer = await self._camera_pc.createOffer()
         camera_offer = RTCSessionDescription(
             sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
@@ -1572,10 +1578,7 @@ class XSenseWebRTCSession:
         if sent:
             LOGGER.debug(
                 "X-Sense WebRTC sent changeTransceiverOffer: %s",
-                self._debug_context(
-                    offer_sdp=_sdp_debug(camera_offer.sdp),
-                    codec_preferences=codec_preferences,
-                ),
+                self._debug_context(offer_sdp=_sdp_debug(camera_offer.sdp)),
             )
 
     async def _apply_change_transceiver_answer(self, payload: dict[str, Any]) -> None:
@@ -1639,10 +1642,7 @@ class XSenseWebRTCSession:
             raise RuntimeError("Camera peer connection was not created")
         # APK createOffer asks to receive video; audio is already present from
         # peer setup, matching the SDK transceiver timing.
-        video_transceiver = self._camera_pc.addTransceiver(
-            "video", direction="recvonly"
-        )
-        _prefer_camera_video_codecs(video_transceiver)
+        self._camera_pc.addTransceiver("video", direction="recvonly")
         offer = await self._camera_pc.createOffer()
         camera_offer = RTCSessionDescription(
             sdp=_apk_camera_offer_sdp(offer.sdp), type=offer.type
@@ -1674,7 +1674,7 @@ class XSenseWebRTCSession:
             self._debug_context(
                 recipient=_short_id(self._recipient_client_id),
                 offer_sdp=_sdp_debug(self._camera_offer_sdp),
-                codec_preferences=_sdp_codec_preference_debug(self._camera_offer_sdp),
+                offer_h264_profiles=_sdp_codec_preference_debug(self._camera_offer_sdp),
                 offer_envelope=_signal_envelope_debug(offer_payload),
                 offer_resolution=bool(self._resolution),
             ),
@@ -1896,37 +1896,6 @@ class XSenseWebRTCSession:
             await self._camera_pc.addIceCandidate(
                 self._pending_camera_candidates.pop(0)
             )
-
-
-def _prefer_camera_video_codecs(transceiver: Any) -> list[str]:
-    """Constrain aiortc to the H264 profile that the Python decoder can handle."""
-    set_preferences = getattr(transceiver, "setCodecPreferences", None)
-    if not callable(set_preferences):
-        return []
-    codecs = []
-    for codec in RTCRtpReceiver.getCapabilities("video").codecs:
-        if codec.mimeType.lower() != "video/h264":
-            continue
-        if codec.parameters.get("profile-level-id") == "42001f":
-            codecs.append(codec)
-    if not codecs:
-        return []
-    set_preferences(codecs)
-    return [codec.parameters.get("profile-level-id") for codec in codecs]
-
-
-def _prefer_existing_camera_video_codecs(peer_connection: Any) -> list[str]:
-    """Keep renegotiated camera offers on the same decoder-safe H264 profile."""
-    get_transceivers = getattr(peer_connection, "getTransceivers", None)
-    if not callable(get_transceivers):
-        return []
-    preferences: list[str] = []
-    for transceiver in get_transceivers():
-        receiver = getattr(transceiver, "receiver", None)
-        track = getattr(receiver, "track", None)
-        if getattr(track, "kind", None) == "video":
-            preferences.extend(_prefer_camera_video_codecs(transceiver))
-    return preferences
 
 
 def _camera_rtc_configuration(ticket: XSenseWebRTCTicket) -> AiortcRTCConfiguration:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -2351,7 +2351,7 @@ async def test_update_camera_data_creates_camera_from_addx_without_home_camera_e
             "2304x1296",
         ),
         ({"supportedRecordingResolutions": []}, "auto"),
-        ({"supportedRecordingResolutions": ["P1296"]}, "auto"),
+        ({"supportedRecordingResolutions": ["P1296"]}, "2304x1296"),
         ({"deviceSupportResolution": ["bad", "P720"]}, "1280x720"),
         ({"liveResolution": "UNKNOWN_RESOLUTION"}, "auto"),
     ],

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -51,8 +51,8 @@ def test_ticket_connect_details_match_apk(monkeypatch):
         "wss://signal.example:443/group/viewer/client123"
         "?traceId=trace&time=123456&sign=sig&name=test-123"
     )
-    assert webrtc_signal._signal_heartbeat(signal_ticket) == 30
-    assert webrtc_signal._signal_heartbeat(ticket(signalPingInterval=0)) == 30
+    assert webrtc_signal._signal_heartbeat(signal_ticket) is None
+    assert webrtc_signal._signal_heartbeat(ticket(signalPingInterval=0)) is None
     assert signal_ticket.signal_connect_options() == {
         "url": (
             "wss://203.0.113.10:443/group/viewer/client123"
@@ -529,10 +529,7 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
     assert len(session._camera_pc.transceivers) == 1
     kind, kwargs, transceiver = session._camera_pc.transceivers[0]
     assert (kind, kwargs) == ("video", {"direction": "recvonly"})
-    assert [
-        codec.parameters.get("profile-level-id")
-        for codec in transceiver.codec_preferences
-    ] == ["42001f"]
+    assert transceiver.codec_preferences is None
     assert session._camera_offer_sdp == "v=0\r\n"
     assert session._camera_local_description_task is not None
     session._camera_local_description_task.cancel()
@@ -540,59 +537,22 @@ async def test_start_camera_peer_uses_apk_receive_media_offer_shape(monkeypatch)
         await session._camera_local_description_task
 
 
-def test_existing_camera_video_transceiver_prefers_decoder_safe_h264_profile():
-    class FakeTrack:
-        kind = "video"
-
-    class FakeReceiver:
-        track = FakeTrack()
-
-    class FakeTransceiver:
-        receiver = FakeReceiver()
-
-        def __init__(self):
-            self.codec_preferences = None
-
-        def setCodecPreferences(self, codecs):
-            self.codec_preferences = codecs
-
-    class FakePeerConnection:
-        def __init__(self):
-            self.video = FakeTransceiver()
-
-        def getTransceivers(self):
-            return [self.video]
-
-    peer = FakePeerConnection()
-
-    webrtc_signal._prefer_existing_camera_video_codecs(peer)
-
-    assert [
-        codec.parameters.get("profile-level-id")
-        for codec in peer.video.codec_preferences
-    ] == ["42001f"]
-
-
-async def test_camera_offer_prefers_decoder_safe_h264_profile():
+async def test_camera_offer_keeps_native_webrtc_codec_choices_like_apk():
     pc = webrtc_signal.RTCPeerConnection()
     try:
         pc.addTransceiver("audio")
-        video_transceiver = pc.addTransceiver("video", direction="recvonly")
-        webrtc_signal._prefer_camera_video_codecs(video_transceiver)
+        pc.addTransceiver("video", direction="recvonly")
         offer = await pc.createOffer()
         camera_sdp = webrtc_signal._apk_camera_offer_sdp(offer.sdp)
     finally:
         await pc.close()
 
     payloads = webrtc_signal._sdp_media_payloads(camera_sdp, "video")
-    assert payloads == [
-        {
-            "payload": "99",
-            "codec": "H264",
-            "fmtp": "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
-        }
-    ]
-    assert "profile-level-id=42e01f" not in camera_sdp
+    codecs = {payload.get("codec") for payload in payloads}
+    assert "H264" in codecs
+    assert len(payloads) > 1
+    assert "profile-level-id=42001f" in camera_sdp
+
 
 async def test_send_offer_sends_apk_offer_then_local_ice_candidates():
     class FakeWs:
@@ -1272,7 +1232,7 @@ def test_camera_webrtc_resolution_uses_apk_normalization():
         _camera_live_resolution(
             SimpleNamespace(data={"supportedRecordingResolutions": ["P1296"]})
         )
-        == "auto"
+        == "2304x1296"
     )
     assert _camera_live_resolution(SimpleNamespace(data={})) == "auto"
 
@@ -2344,11 +2304,55 @@ async def test_online_camera_starts_offer_without_peer_in_like_apk():
         webrtc_signal.asyncio.create_task = original_create_task
 
     assert aio_session.ws.messages == []
-    assert aio_session.connect_kwargs["heartbeat"] == 30
+    assert "heartbeat" not in aio_session.connect_kwargs
     assert started == [True]
     assert session._peer_in_timeout_task is None
     assert len(tasks) == 2
     assert sent_messages[0].answer == "v=0\r\n"
+
+
+async def test_signal_reconnect_resends_unanswered_offer_after_peer_in_like_apk():
+    session = object.__new__(webrtc_signal.XSenseWebRTCSession)
+    session._closed = False
+    session._camera_offer_sent = True
+    session._sdp_answer_received = False
+    session._camera_local_candidate_count = 33
+    session._camera_offer_sdp = "v=0\r\n"
+    session._camera_peer_ready = True
+    session._ticket = ticket()
+    session._recipient_client_id = "SSC0A123"
+    session._peer_in_timeout_task = None
+    session._debug_context = lambda **kwargs: kwargs
+    reconnected = []
+    sent_offers = []
+
+    async def reconnect_signal():
+        reconnected.append(True)
+
+    async def send_offer():
+        sent_offers.append(True)
+
+    async def no_sleep(_delay):
+        return None
+
+    session._reconnect_signal = reconnect_signal
+    session._send_offer = send_offer
+
+    original_sleep = webrtc_signal.asyncio.sleep
+    webrtc_signal.asyncio.sleep = no_sleep
+    try:
+        await session._signal_reconnect_after_delay(1006)
+    finally:
+        webrtc_signal.asyncio.sleep = original_sleep
+
+    assert reconnected == [True]
+    assert session._camera_offer_sent is False
+    assert session._camera_local_candidate_count == 0
+
+    await session._handle_signal_event("PEER_IN", "SSC0A123")
+
+    assert session._camera_peer_ready is True
+    assert sent_offers == [True]
 
 
 async def test_offline_camera_waits_for_peer_in_before_offer_like_apk():


### PR DESCRIPTION
## Summary
- align camera signal reconnect behavior with the APK path by resending unanswered offers after reconnect
- remove the integration-side signal heartbeat and forced H264 codec preference
- keep single reported camera resolutions available for live view

## Tests
- python3 -m pytest -q tests/test_release_metadata.py tests/test_webrtc_signal.py tests/test_camera_entity_guards.py tests/api/test_async_xsense.py -k "camera or webrtc or resolution or release"
- python3 -m pytest -q
- git diff --check