### PR TITLE
Prepare v1.4.13.2 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.13.1):
-  (e.g., 1.4.13.1)
+- **X-Sense-Integration Version** (z. B. 1.4.13.2):
+  (e.g., 1.4.13.2)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.13.2.md
+++ b/.github/release-notes/1.4.13.2.md
@@ -1,0 +1,7 @@
+## X-Sense Home Security v1.4.13.2
+
+### 🔑 Keypad
+- Fixes the camera blueprint auto-update so imported SKP0A keypad blueprints are no longer replaced by the camera notification blueprint during startup maintenance.
+
+### 🧪 Validation
+- Adds regression coverage to keep keypad blueprints untouched by camera blueprint maintenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.13.2](.github/release-notes/1.4.13.2.md)
 - [1.4.13.1](.github/release-notes/1.4.13.1.md)
 - [1.4.13](.github/release-notes/1.4.13.md)
 - [1.4.12.1](.github/release-notes/1.4.12.1.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.13.1"
+PANEL_ASSET_VERSION = "1.4.13.2"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -24,6 +24,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.13.1",
+  "version": "1.4.13.2",
   "zeroconf": []
 }

--- a/custom_components/xsense/repairs.py
+++ b/custom_components/xsense/repairs.py
@@ -24,7 +24,13 @@ _BLUEPRINT_VERSION_RE = re.compile(r"^\s*xsense_blueprint_version:\s*(\d+)\s*$",
 _CAMERA_BLUEPRINT_MARKERS = (
     "X-Sense Camera Event",
     "camera_ai_notification.yaml",
-    "Jarnsen/ha-xsense-component_test",
+    "event_type: xsense_camera_event",
+)
+_KEYPAD_BLUEPRINT_MARKERS = (
+    "X-Sense Keypad Code",
+    "keypad_code_action.yaml",
+    "keypad_code_router.yaml",
+    "event_type: xsense_keypad_code",
 )
 _CURRENT_BLUEPRINT_MARKERS = (
     "xsense_event_data is mapping",
@@ -230,6 +236,8 @@ def _stale_camera_blueprint_paths(
 
 def _is_xsense_camera_blueprint(text: str) -> bool:
     """Return whether the YAML text looks like the X-Sense camera blueprint."""
+    if any(marker in text for marker in _KEYPAD_BLUEPRINT_MARKERS):
+        return False
     return any(marker in text for marker in _CAMERA_BLUEPRINT_MARKERS)
 
 

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1119,6 +1119,57 @@ variables:
     ]
 
 
+def test_keypad_blueprints_are_not_treated_as_stale_camera_blueprints(tmp_path):
+    blueprint_dir = tmp_path / "blueprints" / "automation" / "xsense"
+    blueprint_dir.mkdir(parents=True)
+
+    for filename in ("keypad_code_action.yaml", "keypad_code_router.yaml"):
+        source = Path("blueprints/automation/xsense") / filename
+        target = blueprint_dir / filename
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert repairs._stale_camera_blueprint_files(blueprint_dir.parent) == []
+
+
+def test_keypad_blueprints_are_not_replaced_by_camera_blueprint_maintenance(
+    tmp_path, monkeypatch
+):
+    blueprint_dir = tmp_path / "blueprints" / "automation" / "xsense"
+    blueprint_dir.mkdir(parents=True)
+
+    keypad_paths = {}
+    for filename in ("keypad_code_action.yaml", "keypad_code_router.yaml"):
+        source = Path("blueprints/automation/xsense") / filename
+        target = blueprint_dir / filename
+        contents = source.read_text(encoding="utf-8")
+        target.write_text(contents, encoding="utf-8")
+        keypad_paths[filename] = contents
+
+    async def async_add_executor_job(func, *args):
+        return func(*args)
+
+    reload_calls = []
+
+    class Services:
+        def has_service(self, domain, service):
+            return (domain, service) == ("automation", "reload")
+
+        async def async_call(self, domain, service, **kwargs):
+            reload_calls.append((domain, service, kwargs))
+
+    hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts))),
+        async_add_executor_job=async_add_executor_job,
+        services=Services(),
+    )
+
+    asyncio.run(repairs.async_check_stale_camera_blueprints(hass))
+
+    for filename, original in keypad_paths.items():
+        assert blueprint_dir.joinpath(filename).read_text(encoding="utf-8") == original
+    assert reload_calls == []
+
+
 def test_stale_camera_blueprint_auto_updates_and_reloads_automations(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- Fixes camera blueprint auto-update incorrectly replacing imported SKP0A keypad blueprints during startup maintenance.
- Adds regression coverage so keypad blueprints stay untouched by camera blueprint maintenance.

## Test plan
- [x] `658` tests passed locally with `-p no:homeassistant`
- [x] Release metadata checks passed for `1.4.13.2`
- [x] Keypad blueprint maintenance regression tests passed
