### PR TITLE
Prepare v1.4.13.3 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,7 +23,7 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.13.2):
+- **X-Sense-Integration Version** (z. B. 1.4.13.3):
   (e.g., 1.4.13.2)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)

--- a/.github/release-notes/1.4.13.3.md
+++ b/.github/release-notes/1.4.13.3.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.13.3
+
+### 📷 Cameras
+- Restores the live camera WebRTC relay order to the known working path: wait for the camera peer before sending Home Assistant's SDP offer.
+- Removes the WebRTC keepalive call from the ticket-only live-view path so cameras no longer hit the ADDX `-3021` keepalive failure during negotiation.
+- Keeps Home Assistant ICE candidates queued until the offer is sent, then flushes them through the X-Sense signal relay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.13.3](.github/release-notes/1.4.13.3.md)
 - [1.4.13.2](.github/release-notes/1.4.13.2.md)
 - [1.4.13.1](.github/release-notes/1.4.13.1.md)
 - [1.4.13](.github/release-notes/1.4.13.md)

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -237,7 +237,6 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
         )
         self._webrtc_sessions: dict[str, object] = {}
         self._pending_webrtc_candidates: dict[str, list[object]] = {}
-        self._webrtc_keepalive_tasks: dict[str, asyncio.Task] = {}
 
     @property
     def supported_features(self) -> CameraEntityFeature:
@@ -369,14 +368,12 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
             ),
         )
         self._webrtc_sessions[session_id] = session
-        self._start_webrtc_keepalive(entity, session_id, ticket)
         await self._flush_pending_webrtc_candidates(entity, session_id, session)
         try:
             answer = await session.start()
         except Exception as err:  # noqa: BLE001 - HA frontend needs a clean error
             self._webrtc_sessions.pop(session_id, None)
             self._pending_webrtc_candidates.pop(session_id, None)
-            self._stop_webrtc_keepalive(session_id)
             await session.close()
             LOGGER.debug(
                 "X-Sense camera WebRTC signal relay failed: %s",
@@ -411,9 +408,6 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
             self._pending_webrtc_candidates[preserve_pending_session_id] = (
                 preserved_pending
             )
-        for keepalive_session_id in list(self._webrtc_keepalive_tasks):
-            if keepalive_session_id != preserve_pending_session_id:
-                self._stop_webrtc_keepalive(keepalive_session_id)
         if not sessions:
             return
         LOGGER.debug(
@@ -465,7 +459,6 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
         entity = self._current_entity()
         session = self._webrtc_sessions.pop(session_id, None)
         self._pending_webrtc_candidates.pop(session_id, None)
-        self._stop_webrtc_keepalive(session_id)
         LOGGER.debug(
             "X-Sense camera WebRTC session close requested: %s",
             _camera_debug_context(
@@ -503,82 +496,9 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
         sessions = list(self._webrtc_sessions.values())
         self._webrtc_sessions.clear()
         self._pending_webrtc_candidates.clear()
-        for keepalive_session_id in list(self._webrtc_keepalive_tasks):
-            self._stop_webrtc_keepalive(keepalive_session_id)
         for session in sessions:
             await session.close()
         await super().async_will_remove_from_hass()
-
-    def _start_webrtc_keepalive(self, entity, session_id: str, ticket) -> None:
-        """Keep an APK WebRTC live session awake while HA owns the offer."""
-        self._stop_webrtc_keepalive(session_id)
-        interval = _webrtc_keepalive_interval(ticket)
-        task = self.hass.async_create_task(
-            self._async_webrtc_keepalive_loop(entity, session_id, interval)
-        )
-        self._webrtc_keepalive_tasks[session_id] = task
-        LOGGER.debug(
-            "X-Sense camera WebRTC keepalive started: %s",
-            _camera_debug_context(
-                entity,
-                session_id,
-                keepalive_interval_s=interval,
-                app_stop_live_timeout=getattr(ticket, "app_stop_live_timeout", None),
-            ),
-        )
-
-    def _stop_webrtc_keepalive(self, session_id: str) -> None:
-        """Cancel an active WebRTC keepalive task."""
-        task = self._webrtc_keepalive_tasks.pop(session_id, None)
-        if task is not None and not task.done():
-            task.cancel()
-
-    async def _async_webrtc_keepalive_loop(
-        self, entity, session_id: str, interval: int
-    ) -> None:
-        """Send periodic APK live-view keepalives for the native WebRTC path."""
-        try:
-            while session_id in self._webrtc_sessions:
-                try:
-                    await self.coordinator.xsense.keep_camera_live_alive(entity)
-                except Exception as err:  # noqa: BLE001 - keep trying until session closes
-                    LOGGER.debug(
-                        "X-Sense camera WebRTC keepalive failed: %s",
-                        _camera_debug_context(
-                            entity,
-                            session_id,
-                            error=_error_debug_context(err),
-                        ),
-                    )
-                else:
-                    LOGGER.debug(
-                        "X-Sense camera WebRTC keepalive sent: %s",
-                        _camera_debug_context(
-                            entity,
-                            session_id,
-                            keepalive_interval_s=interval,
-                        ),
-                    )
-                await asyncio.sleep(interval)
-                if session_id not in self._webrtc_sessions:
-                    return
-        except asyncio.CancelledError:
-            raise
-        finally:
-            current_task = asyncio.current_task()
-            if self._webrtc_keepalive_tasks.get(session_id) is current_task:
-                self._webrtc_keepalive_tasks.pop(session_id, None)
-
-
-def _webrtc_keepalive_interval(ticket) -> int:
-    """Return an APK live-view keepalive cadence for a WebRTC ticket."""
-    try:
-        timeout = int(getattr(ticket, "app_stop_live_timeout", 0) or 0)
-    except (TypeError, ValueError):
-        timeout = 0
-    if timeout > 10:
-        return max(5, min(25, timeout // 2))
-    return 5
 
 
 def _camera_online(entity) -> bool:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.13.2"
+PANEL_ASSET_VERSION = "1.4.13.3"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -24,6 +24,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.13.2",
+  "version": "1.4.13.3",
   "zeroconf": []
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -336,15 +336,7 @@ class XSenseWebRTCSignalSession:
                 self._answer.set_exception(err)
 
     async def _begin_signal_offer_flow(self) -> None:
-        """Start or wait for the APK-style camera peer before relaying the SDP offer."""
-        if self._camera_online:
-            LOGGER.debug(
-                "X-Sense WebRTC camera online, starting peer offer without PEER_IN wait: %s",
-                self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
-            )
-            self._camera_peer_ready = True
-            await self._send_offer()
-            return
+        """Wait for the camera peer before relaying Home Assistant's SDP offer."""
         LOGGER.debug(
             "X-Sense WebRTC waiting for PEER_IN before relay offer: %s",
             self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -3857,16 +3857,6 @@ def test_webrtc_client_config_uses_data_channel_only():
     assert "iceServers" not in config["configuration"]
 
 
-def test_webrtc_keepalive_interval_matches_ticket_timeout():
-    from custom_components.xsense import camera
-
-    ticket = SimpleNamespace(app_stop_live_timeout=20)
-    assert camera._webrtc_keepalive_interval(ticket) == 10
-
-    missing_timeout = SimpleNamespace(app_stop_live_timeout=None)
-    assert camera._webrtc_keepalive_interval(missing_timeout) == 5
-
-
 def test_known_good_live_webrtc_path_does_not_reintroduce_drift():
     """Lock the live camera path to the v1.2.6.60 success baseline."""
     import inspect
@@ -3908,10 +3898,10 @@ def test_known_good_live_webrtc_path_does_not_reintroduce_drift():
         camera_entity_source
     )
     assert "async_handle_async_webrtc_offer" in camera_entity_source
-    assert "_start_webrtc_keepalive" in camera_entity_source
     assert "_begin_signal_offer_flow" in inspect.getsource(
         webrtc_signal.XSenseWebRTCSignalSession.start
     )
+    assert "keep_camera_live_alive" not in camera_entity_source
     assert "_future_has_result(self._answer)" not in add_candidate_source
     assert "await self._flush_pending_remote_candidates()" in send_offer_source
     assert "verifyDormancyStatus=True" in ticket_source

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -340,7 +340,7 @@ async def test_send_offer_flushes_candidates_queued_before_offer():
     assert session._sent_candidate_count == 1
 
 
-async def test_online_camera_sends_offer_without_waiting_for_peer_in(monkeypatch):
+async def test_online_camera_waits_for_peer_in_before_sending_offer(monkeypatch):
     class FakeWs:
         closed = False
 
@@ -372,6 +372,12 @@ async def test_online_camera_sends_offer_without_waiting_for_peer_in(monkeypatch
 
     await session._connect_signal()
     await session._begin_signal_offer_flow()
+
+    assert ws.messages == []
+    assert session._offer_sent is False
+    assert session._camera_peer_ready is False
+
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
 
     assert [message["messageType"] for message in ws.messages] == ["SDP_OFFER"]
     assert session._offer_sent is True
@@ -424,7 +430,7 @@ async def test_offline_camera_waits_for_peer_in_before_sending_offer(monkeypatch
     assert session._debug_context()["offer_attempt_count"] == 1
 
 
-async def test_online_camera_resends_offer_after_signal_reconnect(monkeypatch):
+async def test_signal_reconnect_waits_for_peer_in_before_resending_offer(monkeypatch):
     class FakeWs:
         closed = False
 
@@ -442,12 +448,17 @@ async def test_online_camera_resends_offer_after_signal_reconnect(monkeypatch):
         camera_online=True,
     )
     session._ws = FakeWs()
-    await session._begin_signal_offer_flow()
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
     assert session._offer_sent is True
 
     session._reset_offer_attempt("signal_reconnect")
     session._ws = FakeWs()
     await session._begin_signal_offer_flow()
+
+    assert session._offer_sent is False
+    assert session._debug_context()["offer_attempt_count"] == 1
+
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
 
     assert session._offer_sent is True
     assert session._debug_context()["offer_attempt_count"] == 2


### PR DESCRIPTION
## Summary
- restores live camera WebRTC relay ordering to wait for PEER_IN before relaying the Home Assistant offer
- removes WebRTC keepalive from the ticket-only path
- adds regression coverage for the camera signaling path

## Checks
- python -m pytest tests\test_camera_entity_guards.py tests\test_webrtc_signal.py -q
- python -m pytest tests\test_release_metadata.py -q
- python -m pytest -q
- git diff --check