### PR TITLE
Prepare v1.4.13.4 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,7 +23,7 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.13.3):
+- **X-Sense-Integration Version** (z. B. 1.4.13.4):
   (e.g., 1.4.13.2)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)

--- a/.github/release-notes/1.4.13.4.md
+++ b/.github/release-notes/1.4.13.4.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.13.4
+
+### 📷 Cameras
+- Normalizes repeated browser SDP fingerprints before relaying the live camera offer to X-Sense.
+- Keeps the camera peer-wait signaling path from the previous prerelease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.13.4](.github/release-notes/1.4.13.4.md)
 - [1.4.13.3](.github/release-notes/1.4.13.3.md)
 - [1.4.13.2](.github/release-notes/1.4.13.2.md)
 - [1.4.13.1](.github/release-notes/1.4.13.1.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.13.3"
+PANEL_ASSET_VERSION = "1.4.13.4"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -24,6 +24,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.13.3",
+  "version": "1.4.13.4",
   "zeroconf": []
 }

--- a/custom_components/xsense/webrtc_signal.py
+++ b/custom_components/xsense/webrtc_signal.py
@@ -882,6 +882,7 @@ def _relay_offer_sdp(sdp: str) -> tuple[str, dict[str, Any]]:
     if not sections:
         return sdp, {"sections": 0}
 
+    sections, fingerprint_context = _normalize_offer_fingerprint_scope(sections)
     normalized_sections: list[list[str]] = [sections[0]]
     context: dict[str, Any] = {
         "sections": len(sections),
@@ -889,6 +890,7 @@ def _relay_offer_sdp(sdp: str) -> tuple[str, dict[str, Any]]:
         "video_removed_payloads": 0,
         "audio_kept_payloads": 0,
         "video_kept_payloads": 0,
+        **fingerprint_context,
     }
     for section in sections[1:]:
         normalized, section_context = _normalize_offer_media_section(section)
@@ -900,6 +902,61 @@ def _relay_offer_sdp(sdp: str) -> tuple[str, dict[str, Any]]:
             ]
             context[f"{kind}_kept_payloads"] += section_context["kept_payloads"]
     return "".join(line for section in normalized_sections for line in section), context
+
+
+def _normalize_offer_fingerprint_scope(
+    sections: list[list[str]],
+) -> tuple[list[list[str]], dict[str, Any]]:
+    """Collapse repeated media fingerprints to the APK-style session fingerprint."""
+    session = list(sections[0])
+    media_sections = [list(section) for section in sections[1:]]
+    session_fingerprints = [
+        line for line in session if line.startswith("a=fingerprint:")
+    ]
+    media_fingerprints = [
+        line
+        for section in media_sections
+        for line in section
+        if line.startswith("a=fingerprint:")
+    ]
+    context: dict[str, Any] = {
+        "fingerprint_scope": "unchanged",
+        "fingerprints_removed": 0,
+    }
+    if not media_fingerprints:
+        return [session, *media_sections], context
+
+    fingerprint_values = {
+        line.rstrip("\r\n") for line in [*session_fingerprints, *media_fingerprints]
+    }
+    if len(fingerprint_values) != 1:
+        context["fingerprint_scope"] = "mixed"
+        return [session, *media_sections], context
+
+    fingerprint_line = session_fingerprints[0] if session_fingerprints else media_fingerprints[0]
+    if not session_fingerprints:
+        insert_at = _session_fingerprint_insert_index(session)
+        session.insert(insert_at, fingerprint_line)
+        context["fingerprint_scope"] = "promoted_to_session"
+    else:
+        context["fingerprint_scope"] = "deduplicated_to_session"
+
+    normalized_media_sections: list[list[str]] = []
+    for section in media_sections:
+        normalized = [
+            line for line in section if not line.startswith("a=fingerprint:")
+        ]
+        context["fingerprints_removed"] += len(section) - len(normalized)
+        normalized_media_sections.append(normalized)
+    return [session, *normalized_media_sections], context
+
+
+def _session_fingerprint_insert_index(session: list[str]) -> int:
+    """Return where a session-level fingerprint belongs in the SDP session section."""
+    for index, line in enumerate(session):
+        if line.startswith("m="):
+            return index
+    return len(session)
 
 
 def _sdp_sections(sdp: str) -> list[list[str]]:

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -124,13 +124,38 @@ def test_relay_offer_sdp_prunes_to_pcmu_audio_and_h264_video():
     assert "VP8/90000" not in relay_sdp
     assert "AV1/90000" not in relay_sdp
     assert "a=candidate:" not in relay_sdp
-    assert context == {
-        "sections": 4,
-        "audio_removed_payloads": 2,
-        "video_removed_payloads": 3,
-        "audio_kept_payloads": 1,
-        "video_kept_payloads": 2,
-    }
+    assert context["sections"] == 4
+    assert context["audio_removed_payloads"] == 2
+    assert context["video_removed_payloads"] == 3
+    assert context["audio_kept_payloads"] == 1
+    assert context["video_kept_payloads"] == 2
+    assert context["fingerprint_scope"] == "unchanged"
+    assert context["fingerprints_removed"] == 0
+
+
+def test_relay_offer_sdp_promotes_repeated_media_fingerprint_to_session_scope():
+    fingerprint = "a=fingerprint:sha-256 AA:BB:CC\r\n"
+    sdp = (
+        "v=0\r\n"
+        "a=group:BUNDLE 0 1 2\r\n"
+        "m=audio 9 UDP/TLS/RTP/SAVPF 0\r\n"
+        "a=mid:0\r\n"
+        f"{fingerprint}"
+        "m=video 9 UDP/TLS/RTP/SAVPF 103\r\n"
+        "a=mid:1\r\n"
+        f"{fingerprint}"
+        "a=rtpmap:103 H264/90000\r\n"
+        "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        "a=mid:2\r\n"
+        f"{fingerprint}"
+    )
+
+    relay_sdp, context = webrtc_signal._relay_offer_sdp(sdp)
+
+    assert relay_sdp.count("a=fingerprint:") == 1
+    assert relay_sdp.index("a=fingerprint:") < relay_sdp.index("m=audio")
+    assert context["fingerprint_scope"] == "promoted_to_session"
+    assert context["fingerprints_removed"] == 3
 
 
 def test_sdp_offer_payload_uses_camera_friendly_relay_offer():


### PR DESCRIPTION
## Summary
- normalizes repeated media-level SDP fingerprints to a single session-level fingerprint before relaying live camera offers
- keeps the camera PEER_IN wait path from the previous prerelease
- adds regression coverage for the browser SDP shape seen in issue 182 logs

## Checks
- python -m pytest tests\test_webrtc_signal.py tests\test_camera_entity_guards.py tests\test_release_metadata.py -q
- python -m pytest -q
- git diff --check