### PR TITLE
Add security automation and HA 2026.8 fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/tools/xsense_pion_adapter"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      go-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "23 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -627,25 +627,6 @@ def make_data_channel_command_payload(
     return json.dumps(payload, separators=(",", ":"))
 
 
-def make_start_live_data_channel_command_payload(
-    resolution: str,
-    *,
-    request_id: str | None = None,
-    timestamp: int | None = None,
-) -> str:
-    """Return the APK startLive data-channel command."""
-    timestamp = int(timestamp if timestamp is not None else time.time())
-    payload: dict[str, Any] = {
-        "requestID": request_id or _make_data_channel_request_id(),
-        "connectionID": _DATA_CHANNEL_CONNECTION_ID,
-        "timeStamp": timestamp,
-        "action": "startLive",
-        "size": resolution,
-        "resolution": resolution,
-    }
-    return json.dumps(payload, separators=(",", ":"))
-
-
 def make_sd_video_list_command_payload(
     start_time: int,
     stop_time: int,
@@ -1105,16 +1086,6 @@ def _sdp_media_directions(sdp: str) -> dict[str, str]:
             if current_mid is not None:
                 directions[current_mid] = line.removeprefix("a=")
     return directions
-
-
-def _map_video_size(resolution: str) -> str:
-    """Return the APK data-channel video size token for a resolution."""
-    value = str(resolution or "").lower()
-    if value in {"1920x1080", "1080p", "hd"}:
-        return "FHD"
-    if value in {"1280x720", "720p", "sd"}:
-        return "HD"
-    return "AUTO"
 
 
 def _normalize_answer_sdp(

--- a/custom_components/xsense/sensor.py
+++ b/custom_components/xsense/sensor.py
@@ -13,6 +13,7 @@ from .python_xsense.entity import Entity
 from .python_xsense.entity_map import EntityType, entities
 
 from homeassistant import config_entries
+from homeassistant import const as ha_const
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -20,7 +21,6 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
@@ -36,6 +36,10 @@ from .entity import (
     coordinator_devices,
     coordinator_stations,
     device_station_id,
+)
+
+UNIT_PARTS_PER_MILLION = getattr(
+    getattr(ha_const, "UnitOfRatio", None), "PARTS_PER_MILLION", "ppm"
 )
 
 
@@ -267,7 +271,7 @@ _ALL_SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="co",
         translation_key="co_reading",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UNIT_PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=optional_data_value("coPpm"),
@@ -276,7 +280,7 @@ _ALL_SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="co_peak",
         translation_key="peak_co_level",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UNIT_PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=data_value("coPpmPeak"),
@@ -575,7 +579,7 @@ _ALL_SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="short_warning_co",
         name="Short-Term CO Warning Level",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UNIT_PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=data_value("warnShortCoPpm"),
@@ -592,7 +596,7 @@ _ALL_SENSORS: tuple[XSenseSensorEntityDescription, ...] = (
     XSenseSensorEntityDescription(
         key="long_warning_co",
         name="Long-Term CO Warning Level",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UNIT_PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=data_value("warnLongCoPpm"),

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "timezone": "America/St_Johns",
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "labels": [
+    "dependency-update"
+  ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 1,
+  "rangeStrategy": "bump",
+  "enabledManagers": [
+    "github-actions",
+    "gomod",
+    "pip_requirements"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "Go dependencies"
+    },
+    {
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "groupName": "Python test dependencies"
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,14 @@
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import custom_components.xsense.sensor as sensor_module
 from custom_components.xsense.python_xsense.entity_map import EntityType
 from custom_components.xsense.sensor import (
     SENSORS,
+    UNIT_PARTS_PER_MILLION,
     battery_percentage,
     has_report_time,
     has_self_test_report,
@@ -40,6 +43,18 @@ def test_device_report_time_remains_available():
     )
 
     assert has_report_time(entity)
+
+
+def test_co_sensor_units_do_not_use_deprecated_ha_constant():
+    source = Path(sensor_module.__file__).read_text(encoding="utf-8")
+
+    assert "CONCENTRATION_PARTS_PER_MILLION" not in source
+    assert UNIT_PARTS_PER_MILLION == "ppm"
+    for key in ("co", "co_peak", "short_warning_co", "long_warning_co"):
+        assert (
+            _sensor_description(key).native_unit_of_measurement
+            == UNIT_PARTS_PER_MILLION
+        )
 
 
 def test_self_test_result_success_code_matches_apk():

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -68,23 +68,6 @@ def test_sdp_offer_payload_strips_candidates_and_keeps_resolution():
     assert "a=end-of-candidates" not in offer["sdp"]
 
 
-def test_start_live_data_channel_command_matches_apk_shape():
-    payload = json.loads(
-        webrtc_signal.make_start_live_data_channel_command_payload(
-            "1920x1080", request_id="req-1", timestamp=123
-        )
-    )
-
-    assert payload == {
-        "requestID": "req-1",
-        "connectionID": "7893feb",
-        "timeStamp": 123,
-        "action": "startLive",
-        "size": "1920x1080",
-        "resolution": "1920x1080",
-    }
-
-
 def test_sd_video_list_data_channel_command_matches_apk_shape():
     payload = json.loads(
         webrtc_signal.make_sd_video_list_command_payload(
@@ -181,6 +164,7 @@ def test_webrtc_signal_relay_path_is_locked_to_known_success_shape():
     assert "class XSenseWebRTCSignalSession" in source
     assert "aiortc" not in source
     assert "RTCPeerConnection" not in source
+    assert "homeassistant" not in source
     assert "_send_offer" in source
     assert "make_sdp_offer_payload" in source
     assert "start_forwarding_remote_candidates" in source
@@ -244,4 +228,50 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
         "sdpMid": "0",
         "sdpMLineIndex": 0,
         "candidate": "candidate:1 1 udp 1 192.0.2.1 123 typ host",
+    }
+
+
+async def test_webrtc_signal_sends_ha_candidates_immediately_after_offer():
+    fake_ws = FakeWebSocket()
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp=(
+            "v=0\r\n"
+            "m=audio 9 UDP/TLS/RTP/SAVPF 0\r\n"
+            "a=mid:0\r\n"
+            "m=video 9 UDP/TLS/RTP/SAVPF 96\r\n"
+            "a=mid:1\r\n"
+        ),
+        resolution="1920x1080",
+        camera_online=True,
+    )
+    candidate = SimpleNamespace(
+        candidate="candidate:2 1 udp 1 192.0.2.2 456 typ host",
+        sdp_mid="1",
+        sdp_m_line_index=1,
+    )
+    session._ws = fake_ws
+    session._recipient_client_id = "SSC0ATEST"
+
+    await session._send_offer()
+    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
+    assert len(session._pending_remote_candidates) == 0
+    assert not session._answer.done()
+
+    await session.add_candidate(candidate)
+
+    assert len(session._pending_remote_candidates) == 0
+    assert not session._answer.done()
+    assert [message["messageType"] for message in fake_ws.messages] == [
+        "SDP_OFFER",
+        "ICE_CANDIDATE",
+    ]
+    ice_payload = json.loads(
+        base64.b64decode(fake_ws.messages[1]["messagePayload"]).decode()
+    )
+    assert ice_payload == {
+        "sdpMid": "1",
+        "sdpMLineIndex": 1,
+        "candidate": "candidate:2 1 udp 1 192.0.2.2 456 typ host",
     }


### PR DESCRIPTION
## Summary

- remove unused WebRTC bridge helpers and keep the live camera path locked to the signal-relay flow
- replace Home Assistant's deprecated CO ppm constant with the new `UnitOfRatio` path while keeping compatibility with older HA test environments
- add Renovate for dependency update PRs, CodeQL security scanning, and security-only Dependabot coverage

## Validation

- Windows: `python -m pytest -q` -> 699 passed
- Server: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q` -> 699 passed
- Renovate config validator passed on Windows and server
- JSON/YAML parsing, `compileall`, and `git diff --check` passed

## Notes

Dependabot version update PRs are disabled in config so Renovate remains the dependency-update owner. Dependabot is included here for security update coverage only.
