### PR TITLE
Release v1.4.16

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.15):
-  (e.g., 1.4.15)
+- **X-Sense-Integration Version** (z. B. 1.4.16):
+  (e.g., 1.4.16)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.16.md
+++ b/.github/release-notes/1.4.16.md
@@ -1,0 +1,14 @@
+## X-Sense Home Security v1.4.16
+
+### 🏠 Home Assistant 2026.8
+- Removes the Home Assistant 2026.8 warning about the deprecated CO parts-per-million unit constant.
+- Keeps CO level entities on the supported Home Assistant unit path while staying compatible with older Home Assistant versions.
+
+### 📷 Cameras
+- Removes unused WebRTC bridge helper code that was no longer part of the live-view path.
+- Keeps camera live view on the Home Assistant signal-relay path.
+
+### 🔒 Maintenance
+- Enables CodeQL scanning for the integration, frontend, workflow, and Go adapter code.
+- Replaces the inactive Renovate config with Dependabot update checks that run directly through GitHub.
+- Updates GitHub Actions and Go adapter dependencies from the first Dependabot runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.16](.github/release-notes/1.4.16.md)
 - [1.4.15](.github/release-notes/1.4.15.md)
 - [1.4.14.5](.github/release-notes/1.4.14.5.md)
 - [1.4.14.4](.github/release-notes/1.4.14.4.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.15"
+PANEL_ASSET_VERSION = "1.4.16"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -24,6 +24,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.15",
+  "version": "1.4.16",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary

- bump X-Sense Home Security to 1.4.16
- add release notes for the HA 2026.8 CO ppm warning fix, camera relay cleanup, and dependency/security automation
- update changelog, issue template example, and frontend cache-buster version

## Validation

- Windows: python -m pytest -q -> 699 passed
- JSON/YAML parsing, compileall, and git diff --check passed
- Dependabot replacement and first Dependabot PRs have already run and merged on main