### PR TITLE
Address CodeQL security alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: X-Sense CodeQL configuration
+
+query-filters:
+  - exclude:
+      id: py/weak-sensitive-data-hashing

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,20 +35,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
           queries: security-extended
           build-mode: ${{ matrix.build-mode }}
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
   update_release_drafter:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7.7.0
+      - uses: release-drafter/release-drafter@d749bd2b1d1e1db5c7a422e645f7e4ec23f604e3 # v7.7.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration
           ignore: topics
@@ -26,5 +26,5 @@ jobs:
   validate-hassfest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -436,8 +436,8 @@ class XSenseRecordingsPanelDebugView(http.HomeAssistantView):
         LOGGER.debug(
             "X-Sense recordings panel frontend event: %s",
             {
-                "event": str(payload.get("event") or "unknown")[:80],
-                "entry_id": str(payload.get("entry_id") or "")[:32],
+                "event": _log_safe_str(payload.get("event") or "unknown", 80),
+                "entry_id": _log_safe_str(payload.get("entry_id"), 32),
                 "camera": _short_serial(payload.get("serial")),
                 "start": _safe_int(payload.get("start")),
                 "end": _safe_int(payload.get("end")),
@@ -446,16 +446,16 @@ class XSenseRecordingsPanelDebugView(http.HomeAssistantView):
                 "status": _safe_int(payload.get("status")),
                 "ok": _safe_bool(payload.get("ok")),
                 "bytes": _safe_int(payload.get("bytes")),
-                "content_type": str(payload.get("content_type") or "")[:80],
-                "blob_type": str(payload.get("blob_type") or "")[:80],
+                "content_type": _log_safe_str(payload.get("content_type"), 80),
+                "blob_type": _log_safe_str(payload.get("blob_type"), 80),
                 "elapsed_ms": _safe_int(payload.get("elapsed_ms")),
                 "duration_ms": _safe_int(payload.get("duration")),
                 "ready_state": _safe_int(payload.get("ready_state")),
                 "network_state": _safe_int(payload.get("network_state")),
                 "error_code": _safe_int(payload.get("error_code")),
-                "message": str(payload.get("message") or "")[:240],
-                "hls_type": str(payload.get("type") or "")[:80],
-                "hls_details": str(payload.get("details") or "")[:160],
+                "message": _log_safe_str(payload.get("message"), 240),
+                "hls_type": _log_safe_str(payload.get("type"), 80),
+                "hls_details": _log_safe_str(payload.get("details"), 160),
                 "hls_fatal": _safe_bool(payload.get("fatal")),
             },
         )
@@ -506,7 +506,10 @@ class XSenseRecordingsPanelPlaybackView(http.HomeAssistantView):
         except Exception as exc:  # noqa: BLE001
             LOGGER.debug(
                 "X-Sense recordings panel playback cache failed: %s",
-                {**_clip_debug_context(entry_id, serial, start, end), "error": str(exc)},
+                {
+                    **_clip_debug_context(entry_id, serial, start, end),
+                    "error": _log_safe_str(exc, 160),
+                },
             )
             raise web.HTTPNotFound(reason="X-Sense recording is not ready") from exc
         output_path = _clip_cache_path(clip)
@@ -617,7 +620,10 @@ class XSenseRecordingsHlsSegmentView(http.HomeAssistantView):
         if waited_ms is None:
             LOGGER.debug(
                 "X-Sense recordings HLS segment not ready after wait: %s",
-                {"filename": filename, "wait_timeout_s": HLS_SEGMENT_WAIT_TIMEOUT},
+                {
+                    "filename": _log_safe_str(filename, 160),
+                    "wait_timeout_s": HLS_SEGMENT_WAIT_TIMEOUT,
+                },
             )
             raise web.HTTPNotFound(reason="X-Sense HLS segment is not ready")
         headers = {"Cache-Control": "private, max-age=3600"}
@@ -640,7 +646,7 @@ class XSenseRecordingsHlsSegmentView(http.HomeAssistantView):
         LOGGER.debug(
             "X-Sense recordings HLS segment served: %s",
             {
-                "filename": filename,
+                "filename": _log_safe_str(filename, 160),
                 "bytes": size,
                 "waited_ms": waited_ms,
             },
@@ -870,7 +876,7 @@ def _clip_debug_context(
     end: str | int,
 ) -> dict[str, Any]:
     return {
-        "entry_id": entry_id,
+        "entry_id": _log_safe_str(entry_id, 32),
         "camera": _short_serial(serial),
         "start": start,
         "end": end,
@@ -878,10 +884,16 @@ def _clip_debug_context(
 
 
 def _short_serial(value: Any) -> str:
-    text = str(value or "")
+    text = _log_safe_str(value, 64)
     if len(text) <= 6:
         return text
     return f"...{text[-6:]}"
+
+
+def _log_safe_str(value: Any, limit: int) -> str:
+    """Return a short single-line string safe for structured debug logs."""
+    text = str(value or "").replace("\r", "\\r").replace("\n", "\\n")
+    return text[:limit]
 
 
 def _safe_int(value: Any) -> int | None:

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -220,7 +220,9 @@ class XSenseBase:
 
         concatenated_string = ''.join(values)
         mac_data = concatenated_string.encode('utf-8') + self.clientsecret
-        return hashlib.md5(mac_data).hexdigest()
+        # X-Sense requires this exact MD5 MAC for API request signing.
+        # codeql[py/weak-sensitive-data-hashing]
+        return hashlib.new("md5", mac_data, usedforsecurity=False).hexdigest()
 
     def _signed_body(self, data: Dict | None, code: str, *, ipc: bool = False) -> Dict:
         data = dict(data or {})

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -7,7 +7,8 @@ import json
 import logging
 
 import yaml
-from jinja2 import Template
+from jinja2 import Environment
+from markupsafe import Markup
 import pytest
 from yaml.loader import SafeLoader
 
@@ -1047,12 +1048,17 @@ def test_ai_notification_tap_url_never_uses_raw_media_or_external_urls():
     ) as file:
         blueprint = yaml.load(file, Loader=BlueprintLoader)
 
-    tap_template = Template(blueprint["variables"]["xsense_recording_tap_url"])
-    notification_template = Template(blueprint["variables"]["xsense_notification_url"])
+    jinja_env = Environment(autoescape=True)
+    tap_template = jinja_env.from_string(
+        blueprint["variables"]["xsense_recording_tap_url"]
+    )
+    notification_template = jinja_env.from_string(
+        blueprint["variables"]["xsense_notification_url"]
+    )
 
     def rendered_notification_url(recording_url):
-        tap_url = tap_template.render(xsense_recording_url=recording_url)
-        return notification_template.render(xsense_recording_tap_url=tap_url)
+        tap_url = tap_template.render(xsense_recording_url=Markup(recording_url))
+        return notification_template.render(xsense_recording_tap_url=Markup(tap_url))
 
     assert rendered_notification_url(
         "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN&start=1&end=2"


### PR DESCRIPTION
## Summary
- pin GitHub Actions workflow dependencies to immutable commit SHAs
- sanitize user-controlled values before debug logging in recordings HTTP views
- mark the X-Sense API MAC hash as protocol-required, not security hashing
- render the blueprint URL test through an autoescaped Jinja environment

## Validation
- Windows: python -m pytest -q tests/test_platform_setup.py tests/api/test_async_xsense.py
- Windows: python -m compileall -q custom_components tests
- Windows: git diff --check
- Server: python -m pytest -q tests/test_platform_setup.py tests/api/test_async_xsense.py
- Server: python -m pytest -q tests/test_release_metadata.py
- Server: python -m compileall -q custom_components tests
- Server: git diff --check