### PR TITLE
Clean up workflow and hassfest warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11.0.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Dieses Issue wurde als inaktiv markiert, da es seit 30 Tagen keine Aktivität gab.'

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import (
     CONNECTION_BLUETOOTH,
     CONNECTION_NETWORK_MAC,
@@ -48,6 +49,8 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
 ]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 LEGACY_OBSOLETE_SENSOR_KEYS: tuple[str, ...] = (
     "serial_number",


### PR DESCRIPTION
## Summary
- Pin the remaining workflow actions by commit SHA.
- Add the config-entry-only schema expected by hassfest for this config-flow integration.

## Notes
- The old `.github/workflows/codeql-analysis.yaml` code-scanning warning is a stale GitHub configuration record from 2024, not an active workflow file.
- Current CodeQL workflow is `.github/workflows/codeql.yml`.

## Checks
- `python -m compileall -q custom_components tests`
- `git diff --check`
- `python -m pytest -q tests/test_release_metadata.py tests/test_platform_setup.py tests/test_sensor.py`
- Linux server: same compile/diff/pytest target set
