### PR TITLE
Gate WebRTC ICE until SDP answer

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.16):
-  (e.g., 1.4.16)
+- **X-Sense-Integration Version** (z. B. 1.4.16.1):
+  (e.g., 1.4.16.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.16.1.md
+++ b/.github/release-notes/1.4.16.1.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.16.1
+
+### 📷 Cameras
+- Restores the WebRTC signal timing used by the previously working camera live-view path.
+- Queues Home Assistant ICE candidates until the X-Sense camera returns an SDP answer, then forwards them.
+
+### 🧪 Pre-release
+- This build is for confirming the SSC0A live-view repair before rolling it into the next regular release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.16.1](.github/release-notes/1.4.16.1.md)
 - [1.4.16](.github/release-notes/1.4.16.md)
 - [1.4.15](.github/release-notes/1.4.15.md)
 - [1.4.14.5](.github/release-notes/1.4.14.5.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.16"
+PANEL_ASSET_VERSION = "1.4.16.1"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -24,6 +24,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.16",
+  "version": "1.4.16.1",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -231,7 +231,12 @@ class XSenseWebRTCSignalSession:
                 self._debug_context(candidate_type=type(candidate).__name__),
             )
             return
-        if self._ws is None or self._ws.closed or not self._offer_sent:
+        if (
+            self._ws is None
+            or self._ws.closed
+            or not self._offer_sent
+            or not _future_has_result(self._answer)
+        ):
             self._pending_remote_candidates.append(payload)
             pending = len(self._pending_remote_candidates)
             if pending <= 3 or pending in {5, 10, 25, 50, 100}:
@@ -414,6 +419,7 @@ class XSenseWebRTCSignalSession:
                 )
                 if not self._answer.done():
                     self._answer.set_result(answer)
+                await self._flush_pending_remote_candidates()
             else:
                 LOGGER.debug(
                     "X-Sense WebRTC signal relay ignored SDP answer: %s",
@@ -489,11 +495,15 @@ class XSenseWebRTCSignalSession:
         )
         for candidate in candidates:
             await self._send_candidate(candidate)
-        await self._flush_pending_remote_candidates()
 
     async def _flush_pending_remote_candidates(self) -> None:
-        """Send any HA candidates that arrived before the X-Sense offer was sent."""
-        if self._ws is None or self._ws.closed or not self._offer_sent:
+        """Send any HA candidates that arrived before the X-Sense answer."""
+        if (
+            self._ws is None
+            or self._ws.closed
+            or not self._offer_sent
+            or not _future_has_result(self._answer)
+        ):
             return
         pending = len(self._pending_remote_candidates)
         if pending:
@@ -1187,6 +1197,8 @@ def _candidate_queue_reason(session: XSenseWebRTCSignalSession) -> str:
         return "signal_closed"
     if not session._offer_sent:
         return "waiting_for_peer_offer"
+    if not _future_has_result(session._answer):
+        return "waiting_for_sdp_answer"
     return "unknown"
 
 

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -184,7 +184,7 @@ async def test_webrtc_signal_session_constructs_without_local_media_stack():
     assert session is not None
 
 
-async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
+async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -216,6 +216,12 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
     await session._send_offer()
 
     assert not session._answer.done()
+    assert len(session._pending_remote_candidates) == 1
+    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
+
+    session._answer.set_result("v=0\r\nanswer")
+    await session._flush_pending_remote_candidates()
+
     assert len(session._pending_remote_candidates) == 0
     assert [message["messageType"] for message in fake_ws.messages] == [
         "SDP_OFFER",
@@ -231,7 +237,7 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
     }
 
 
-async def test_webrtc_signal_sends_ha_candidates_immediately_after_offer():
+async def test_webrtc_signal_queues_ha_candidates_until_answer():
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -261,8 +267,14 @@ async def test_webrtc_signal_sends_ha_candidates_immediately_after_offer():
 
     await session.add_candidate(candidate)
 
-    assert len(session._pending_remote_candidates) == 0
+    assert len(session._pending_remote_candidates) == 1
     assert not session._answer.done()
+    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
+
+    session._answer.set_result("v=0\r\nanswer")
+    await session._flush_pending_remote_candidates()
+
+    assert len(session._pending_remote_candidates) == 0
     assert [message["messageType"] for message in fake_ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",


### PR DESCRIPTION
## Summary
- restores the known camera signal timing by queuing Home Assistant ICE until X-Sense returns an SDP answer
- updates WebRTC regression tests so the camera path cannot drift back to pre-answer ICE forwarding
- prepares pre-release metadata for v1.4.16.1

## Tests
- pytest -q tests/test_webrtc_signal.py tests/test_camera_entity_guards.py tests/test_release_metadata.py
- pytest -q
- python -m compileall -q custom_components tests
- node --check custom_components/xsense/frontend/recordings-panel.js
- git diff --check