### PR TITLE
Prepare v1.4.17.1 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17):
-  (e.g., 1.4.17)
+- **X-Sense-Integration Version** (z. B. 1.4.17.1):
+  (e.g., 1.4.17.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.17.1.md
+++ b/.github/release-notes/1.4.17.1.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.17.1
+
+### 📷 Recordings
+- Repairs cached HLS recordings whose first transport-stream segment needs a clean remux before browser playback.
+- Preserves the original audio track during HLS repair; clips are not served as ready if the leading segment cannot be repaired with its streams intact.
+
+### 🧪 Devices
+- Restores the reported **Test Active** diagnostic entity when X-Sense provides the device test state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.17.1](.github/release-notes/1.4.17.1.md)
 - [1.4.17](.github/release-notes/1.4.17.md)
 - [1.4.16.1](.github/release-notes/1.4.16.1.md)
 - [1.4.16](.github/release-notes/1.4.16.md)

--- a/custom_components/xsense/const.py
+++ b/custom_components/xsense/const.py
@@ -79,7 +79,6 @@ NON_ENTITY_DIAGNOSTIC_BINARY_SENSOR_KEYS = frozenset(
         "alarm_sound_enabled",
         "app_tip_enabled",
         "schedule_tip_enabled",
-        "test_active",
         "timezone_enabled",
         "timezone_valid",
     }

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17"
+PANEL_ASSET_VERSION = "1.4.17.1"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17",
+  "version": "1.4.17.1",
   "zeroconf": []
 }

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import monotonic
@@ -894,6 +896,7 @@ class XSenseRecordingsMediaSource(MediaSource):
         segment_count = 0
         key_count = 0
         child_playlist_count = 0
+        direct_media_segment_count = 0
         for index, line in enumerate(playlist_text.splitlines()):
             stripped = line.strip()
             if not stripped:
@@ -954,6 +957,23 @@ class XSenseRecordingsMediaSource(MediaSource):
                     segment_path,
                     payload,
                 )
+                if direct_media_segment_count == 0 and suffix.lower().endswith(".ts"):
+                    repair = await self._async_file_job(
+                        _repair_hls_leading_segment,
+                        segment_path,
+                    )
+                    if not repair:
+                        raise Unresolvable(
+                            "X-Sense HLS recording leading segment could not be repaired"
+                        )
+                    LOGGER.debug(
+                        "X-Sense HLS leading segment repaired: %s",
+                        {
+                            "depth": depth,
+                            "segment": segment_name,
+                            "repair": repair,
+                        },
+                    )
                 total_bytes += len(payload)
                 state["remaining_initial_segments"] = (
                     int(state.get("remaining_initial_segments") or 0) - 1
@@ -964,6 +984,7 @@ class XSenseRecordingsMediaSource(MediaSource):
             else:
                 state.setdefault("deferred", []).append((media_url, segment_path))
             rewritten.append(segment_name)
+            direct_media_segment_count += 1
 
         LOGGER.debug(
             "X-Sense HLS playlist cached: %s",
@@ -1940,6 +1961,51 @@ def _write_cache_file(path: Path, payload: bytes) -> None:
     temp_path = path.with_name(f"{path.stem}.tmp{path.suffix}")
     temp_path.write_bytes(payload)
     temp_path.replace(path)
+
+
+def _repair_hls_leading_segment(path: Path) -> str:
+    """Remux the first HLS TS segment so hls.js sees stable stream metadata."""
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg or not _path_ready(path):
+        return ""
+    if _ffmpeg_remux_hls_segment(ffmpeg, path):
+        return "copy"
+    return ""
+
+
+def _ffmpeg_remux_hls_segment(ffmpeg: str, path: Path) -> bool:
+    output_path = path.with_name(f"{path.stem}.copy.tmp{path.suffix}")
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(path),
+        "-map",
+        "0",
+        "-c",
+        "copy",
+        "-f",
+        "mpegts",
+        str(output_path),
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0 or not _path_ready(output_path):
+            return False
+        output_path.replace(path)
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+    finally:
+        output_path.unlink(missing_ok=True)
 
 
 def _replace_cache_file(source: Path, target: Path) -> None:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -2372,6 +2372,11 @@ def test_recording_media_source_caches_hd_hls_without_sd_fallback(
     )
     monkeypatch.setattr(
         media_source,
+        "_repair_hls_leading_segment",
+        lambda path: "copy",
+    )
+    monkeypatch.setattr(
+        media_source,
         "async_get_clientsession",
         lambda hass: Session(),
     )
@@ -2391,6 +2396,195 @@ def test_recording_media_source_caches_hd_hls_without_sd_fallback(
     assert (playlist.parent / "segment_0002.ts").read_bytes() == b"segment-one"
     assert (playlist.parent / "segment_0003.ts").read_bytes() == b"segment-two"
     assert not (playlist.parent / "segment_0004.ts").exists()
+
+
+def test_recording_media_source_repairs_leading_hls_ts_segment(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    source = media_source.XSenseRecordingsMediaSource(_recordings_media_source_hass())
+    output_path = tmp_path / "clip.mp4"
+    clip = {
+        "source": "video_url",
+        "quality": "HD",
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "playback_url": "https://example.invalid/index.m3u8",
+        "media_root": tmp_path.as_posix(),
+    }
+    responses = {
+        "https://example.invalid/index.m3u8": (
+            "application/vnd.apple.mpegurl;charset=utf-8",
+            b"#EXTM3U\n#EXT-X-TARGETDURATION:4\nseg-1.ts\nseg-2.ts\n#EXT-X-ENDLIST\n",
+        ),
+        "https://example.invalid/seg-1.ts": ("video/mp2t", b"bad-leading-audio"),
+        "https://example.invalid/seg-2.ts": ("video/mp2t", b"good-audio-video"),
+    }
+    repaired = []
+
+    class Response:
+        def __init__(self, url):
+            self.content_type, self.payload = responses[url]
+            self.headers = {"content-type": self.content_type}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        async def read(self):
+            return self.payload
+
+        async def text(self):
+            return self.payload.decode()
+
+    class Session:
+        def get(self, url):
+            return Response(url)
+
+    class Hass:
+        async def async_add_executor_job(self, func, *args):
+            return func(*args)
+
+    def repair(path):
+        repaired.append(path.name)
+        return "copy"
+
+    source.hass = Hass()
+    monkeypatch.setattr(
+        media_source,
+        "_hls_cache_dir",
+        lambda current_clip: tmp_path / "hls",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: tmp_path / "hls" / "index.m3u8",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_local_media_url",
+        lambda path: f"/media/local/test/{path.name}",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_clip_cache_path",
+        lambda current_clip: output_path,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_repair_hls_leading_segment",
+        repair,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "async_get_clientsession",
+        lambda hass: Session(),
+    )
+
+    result = asyncio.run(source._async_cached_playback_url(clip))
+
+    playlist = media_source._hls_playlist_cache_path(clip)
+    assert result == "/media/local/test/index.m3u8"
+    assert repaired == ["segment_0002.ts"]
+    assert playlist.read_text(encoding="utf-8") == (
+        "#EXTM3U\n"
+        "#EXT-X-TARGETDURATION:4\n"
+        "segment_0002.ts\n"
+        "segment_0003.ts\n"
+        "#EXT-X-ENDLIST\n"
+    )
+
+
+def test_recording_media_source_rejects_unrepaired_leading_hls_ts_segment(
+    monkeypatch,
+    tmp_path,
+):
+    from homeassistant.components.media_source.error import Unresolvable
+
+    from custom_components.xsense import recordings_media as media_source
+
+    source = media_source.XSenseRecordingsMediaSource(_recordings_media_source_hass())
+    clip = {
+        "source": "video_url",
+        "quality": "HD",
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "playback_url": "https://example.invalid/index.m3u8",
+        "media_root": tmp_path.as_posix(),
+    }
+    responses = {
+        "https://example.invalid/index.m3u8": (
+            "application/vnd.apple.mpegurl;charset=utf-8",
+            b"#EXTM3U\n#EXT-X-TARGETDURATION:4\nseg-1.ts\nseg-2.ts\n#EXT-X-ENDLIST\n",
+        ),
+        "https://example.invalid/seg-1.ts": ("video/mp2t", b"bad-leading-audio"),
+    }
+
+    class Response:
+        def __init__(self, url):
+            self.content_type, self.payload = responses[url]
+            self.headers = {"content-type": self.content_type}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        async def read(self):
+            return self.payload
+
+        async def text(self):
+            return self.payload.decode()
+
+    class Session:
+        def get(self, url):
+            return Response(url)
+
+    class Hass:
+        async def async_add_executor_job(self, func, *args):
+            return func(*args)
+
+    source.hass = Hass()
+    monkeypatch.setattr(
+        media_source,
+        "_hls_cache_dir",
+        lambda current_clip: tmp_path / "hls",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: tmp_path / "hls" / "index.m3u8",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_repair_hls_leading_segment",
+        lambda path: "",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "async_get_clientsession",
+        lambda hass: Session(),
+    )
+
+    with pytest.raises(Unresolvable):
+        asyncio.run(source._async_cached_playback_url(clip))
+
+    assert not media_source._hls_playlist_cache_path(clip).exists()
 
 
 def test_recording_media_source_prefers_hls_cache_over_legacy_mp4(

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -6,6 +6,7 @@ from custom_components.xsense.alarm_control_panel import (
 )
 from custom_components.xsense.python_xsense.station import Station
 from custom_components.xsense.binary_sensor import (
+    SENSORS as BINARY_SENSORS,
     XSenseBinarySensorEntity,
     XSenseBinarySensorEntityDescription,
     XSenseMQTTConnectedEntity,
@@ -119,6 +120,23 @@ def test_xs01_wx_shadow_data_entities_stay_available():
     assert binary_sensor.is_on is False
     assert connected.available
     assert connected.is_on is True
+
+
+def test_reported_test_active_state_is_exposed_from_device_data():
+    station = _xs01_wx_from_real_shadow()
+    description = next(item for item in BINARY_SENSORS if item.key == "test_active")
+
+    assert not description.exists_fn(station)
+
+    station.set_data({"test": "1"})
+
+    assert description.exists_fn(station)
+    assert description.value_fn(station) is True
+
+    station.set_data({"test": "0"})
+
+    assert description.exists_fn(station)
+    assert description.value_fn(station) is False
 
 
 def test_station_sensor_stays_available_when_station_id_alias_changes():

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -463,7 +463,6 @@ def test_obsolete_binary_sensor_keys_only_remove_removed_binary_sensors():
         "alarm_sound_enabled",
         "app_tip_enabled",
         "schedule_tip_enabled",
-        "test_active",
         "timezone_enabled",
         "timezone_valid",
     } <= set(OBSOLETE_BINARY_SENSOR_KEYS)
@@ -517,6 +516,15 @@ def test_raw_diagnostic_metadata_is_not_exposed_as_entities():
     assert NON_ENTITY_DIAGNOSTIC_BINARY_SENSOR_KEYS <= set(
         OBSOLETE_BINARY_SENSOR_KEYS
     )
+
+
+def test_reported_test_active_state_remains_available():
+    from custom_components.xsense.binary_sensor import SENSORS as BINARY_SENSORS
+
+    binary_sensor_keys = {description.key for description in BINARY_SENSORS}
+
+    assert "test_active" in binary_sensor_keys
+    assert "test_active" not in OBSOLETE_BINARY_SENSOR_KEYS
 
 
 def test_obsolete_sensor_cleanup_removes_stale_registry_entries(monkeypatch):


### PR DESCRIPTION
## Summary
- repair cached HLS recordings by copy-remuxing the leading TS segment while preserving audio
- reject the HLS cache if the leading segment cannot be repaired with streams intact
- restore the reported Test Active diagnostic entity when X-Sense provides test state

## Tests
- python -m compileall -q custom_components tests
- node --check custom_components/xsense/frontend/recordings-panel.js
- git diff --check
- pytest -q