### PR TITLE
Prepare v1.4.17.3 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17.2):
-  (e.g., 1.4.17.2)
+- **X-Sense-Integration Version** (z. B. 1.4.17.3):
+  (e.g., 1.4.17.3)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.17.3.md
+++ b/.github/release-notes/1.4.17.3.md
@@ -1,0 +1,7 @@
+## X-Sense Home Security v1.4.17.3
+
+### 📷 Recordings
+- Fixes browser playback of cached HLS recordings when the first segment has broken AAC metadata (`bufferAppendError` / #271) by mirroring the X-Sense app: keep the original segment on disk and serve a video-only playback sidecar for the leading segment only.
+- Upgrades existing HLS caches in place on integration load with a resumable background migration — no re-download required for already cached clips.
+- Restarts or resumes migration safely when Home Assistant or the integration reloads during the upgrade.
+- Exposes HLS playback profile metadata to the recordings panel for clearer debug logging during playback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.17.3](.github/release-notes/1.4.17.3.md)
 - [1.4.17.2](.github/release-notes/1.4.17.2.md)
 - [1.4.17.1](.github/release-notes/1.4.17.1.md)
 - [1.4.17](.github/release-notes/1.4.17.md)

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -38,7 +38,9 @@ from .recordings_media import (
     async_register_recording_services,
     async_register_recordings_media_source,
     async_remove_recording_index,
+    async_schedule_hls_playback_profile_migration,
     async_start_recording_media_sync,
+    async_stop_hls_playback_profile_migration,
     async_stop_recording_media_sync,
     async_unregister_recording_services,
     async_unregister_recordings_media_source,
@@ -296,6 +298,7 @@ def _cleanup_recordings_runtime(hass: HomeAssistant, entry_id: str | None = None
     if entry_id:
         _cleanup_recordings_entry(hass, entry_id)
     if not _has_any_camera_entities(hass):
+        async_stop_hls_playback_profile_migration(hass)
         async_unregister_recordings_panel(hass)
         async_unregister_recording_services(hass)
         async_unregister_recordings_media_source(hass)
@@ -310,6 +313,7 @@ async def _async_register_recordings_runtime(
     await async_register_recording_services(hass)
     async_register_recordings_media_source(hass)
     async_start_recording_media_sync(hass, entry)
+    async_schedule_hls_playback_profile_migration(hass, entry)
 
 
 def _sensor_unique_id(entity_id: str, key: str) -> str:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17.2"
+PANEL_ASSET_VERSION = "1.4.17.3"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/frontend/recordings-panel.js
+++ b/custom_components/xsense/frontend/recordings-panel.js
@@ -1662,6 +1662,7 @@ class XSenseRecordingsPanel extends HTMLElement {
     this.signedPaths = new Map();
     this.playbackUrls = new Map();
     this.playbackTypes = new Map();
+    this.playbackProfiles = new Map();
     this.playbackErrors = new Map();
     this.playbackLoadingKey = "";
     this.hlsInstances = new Map();
@@ -2287,11 +2288,18 @@ class XSenseRecordingsPanel extends HTMLElement {
       }
       const contentType = response.headers.get("content-type") || "";
       if (this.isHlsResponse(contentType, response.url || signedPath)) {
-        this.setPlaybackUrl(key, signedPath, "hls");
+        const leadingAac = response.headers.get("X-XSense-HLS-Leading-AAC") || clip.hls_leading_aac || "";
+        const playbackMode = response.headers.get("X-XSense-HLS-Playback-Mode") || clip.hls_playback_mode || "";
+        this.setPlaybackUrl(key, signedPath, "hls", {
+          leadingAac,
+          playbackMode,
+        });
         this.logPanelEvent("playback_hls_ready", this.clipDebugPayload(clip, {
           playback_url: playbackPath,
           content_type: contentType,
           message: this.hlsSupportMessage(),
+          hls_leading_aac: leadingAac,
+          hls_playback_mode: playbackMode,
           elapsed_ms: Math.round(performance.now() - startedAt),
         }));
         return;
@@ -2321,7 +2329,7 @@ class XSenseRecordingsPanel extends HTMLElement {
     }
   }
 
-  setPlaybackUrl(key, url, type) {
+  setPlaybackUrl(key, url, type, options = {}) {
     const previousUrl = this.playbackUrls.get(key);
     const previousType = this.playbackTypes.get(key);
     if (previousType === "blob" && previousUrl && previousUrl !== url) {
@@ -2333,6 +2341,10 @@ class XSenseRecordingsPanel extends HTMLElement {
     }
     this.playbackUrls.set(key, url);
     this.playbackTypes.set(key, type);
+    this.playbackProfiles.set(key, {
+      leadingAac: options.leadingAac || "",
+      playbackMode: options.playbackMode || "",
+    });
   }
 
   clearPlaybackUrl(key) {
@@ -2345,6 +2357,7 @@ class XSenseRecordingsPanel extends HTMLElement {
     this.hlsInstances.delete(key);
     this.playbackUrls.delete(key);
     this.playbackTypes.delete(key);
+    this.playbackProfiles.delete(key);
   }
 
   disposePlaybackResources() {
@@ -2359,6 +2372,7 @@ class XSenseRecordingsPanel extends HTMLElement {
     }
     this.playbackUrls.clear();
     this.playbackTypes.clear();
+    this.playbackProfiles.clear();
   }
 
   isHlsResponse(contentType, url) {
@@ -2399,6 +2413,7 @@ class XSenseRecordingsPanel extends HTMLElement {
       }
     }
     this.hlsInstances.get(key)?.destroy?.();
+    const profile = this.playbackProfiles.get(key) || {};
     const hls = new Hls({
       enableWorker: false,
       lowLatencyMode: false,
@@ -2410,6 +2425,8 @@ class XSenseRecordingsPanel extends HTMLElement {
         type: data?.type || "",
         details: data?.details || "",
         fatal: Boolean(data?.fatal),
+        hls_leading_aac: profile.leadingAac || "",
+        hls_playback_mode: profile.playbackMode || "",
       }));
       if (data?.fatal) {
         this.clearPlaybackUrl(key);
@@ -2422,6 +2439,8 @@ class XSenseRecordingsPanel extends HTMLElement {
     hls.loadSource(hlsUrl);
     this.logPanelEvent("playback_hls_js_attached", this.clipDebugPayload(this.selectedClip, {
       playback_url: hlsUrl,
+      hls_leading_aac: profile.leadingAac || "",
+      hls_playback_mode: profile.playbackMode || "",
     }));
   }
 

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -30,6 +30,7 @@ from .recordings_media import (
     _clip_start_for_sort,
     _clip_thumbnail_cache_path,
     _hls_playlist_cache_path,
+    _hls_playback_fields_for_clip,
     _hls_ready,
     _hls_attribute_uri,
     _local_media_url,
@@ -180,6 +181,7 @@ async def _async_build_panel_data_from_index(
                     "thumbnail_cached": thumb_cached,
                     "playable": playable,
                     "sync_enabled": sync_enabled,
+                    **_hls_playback_fields_for_clip(clip),
                     "playback_url": _playback_api_url(entry_id, serial, start, end)
                     if hls_cached
                     else _local_media_url(clip_path)
@@ -332,6 +334,7 @@ def build_panel_data(hass: HomeAssistant, index: dict[str, Any]) -> dict[str, An
                     "thumbnail_cached": thumb_cached,
                     "playable": playable,
                     "sync_enabled": sync_enabled,
+                    **_hls_playback_fields_for_clip(clip),
                     "playback_url": _playback_api_url(entry_id, serial, start, end)
                     if hls_cached
                     else _local_media_url(clip_path)
@@ -519,12 +522,17 @@ class XSenseRecordingsPanelPlaybackView(http.HomeAssistantView):
                     **context,
                     "elapsed_ms": int((monotonic() - started_at) * 1000),
                     "content_type": HLS_MIME_TYPE,
+                    **_hls_playback_fields_for_clip(clip),
                 },
             )
+            headers = {
+                "Cache-Control": "private, max-age=300",
+                **_hls_playback_response_headers(clip),
+            }
             return web.Response(
                 text=playlist,
                 content_type=HLS_MIME_TYPE,
-                headers={"Cache-Control": "private, max-age=300"},
+                headers=headers,
             )
         if await source._async_mp4_ready(output_path):
             output_bytes = await source._async_file_size(output_path)
@@ -863,6 +871,19 @@ def _hls_playlist_for_response(playlist_path: Path, segment_base_url: str) -> st
             continue
         rewritten.append(f"{base}/{quote(stripped, safe='/')}")
     return "\n".join(rewritten) + "\n"
+
+
+def _hls_playback_response_headers(clip: dict[str, Any]) -> dict[str, str]:
+    """Return playback profile headers for one cached HLS clip."""
+    fields = _hls_playback_fields_for_clip(clip)
+    headers: dict[str, str] = {}
+    leading_aac = fields.get("hls_leading_aac")
+    playback_mode = fields.get("hls_playback_mode")
+    if leading_aac:
+        headers["X-XSense-HLS-Leading-AAC"] = leading_aac
+    if playback_mode:
+        headers["X-XSense-HLS-Playback-Mode"] = playback_mode
+    return headers
 
 
 def _clip_debug_context(

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17.2",
+  "version": "1.4.17.3",
   "zeroconf": []
 }

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import shutil
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import monotonic
@@ -20,7 +23,8 @@ from homeassistant.components.media_source import (
     PlayMedia,
 )
 from homeassistant.components.media_source.error import Unresolvable
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.storage import Store
@@ -54,13 +58,21 @@ RECORDING_CACHE_TTL = timedelta(minutes=5)
 RECORDING_LOOKBACK_DAYS = 7
 RECORDING_PAGE_LIMIT = 100
 RECORDING_MEDIA_SYNC_STARTUP_DELAY = 30
+HLS_PLAYBACK_PROFILE_MIGRATION_STARTUP_DELAY = 30
 RECORDING_MEDIA_RECENT_SYNC_INTERVAL = timedelta(minutes=2)
 RECORDING_MEDIA_RECENT_LOOKBACK = timedelta(minutes=10)
 THUMBNAIL_WARMUP_LIMIT = 10
 EVENT_RECORDING_CLIP_LIMIT = 50
 HLS_INITIAL_SEGMENT_COUNT = 2
-HLS_CACHE_VERSION = 2
+HLS_CACHE_VERSION = 3
 HLS_CACHE_VERSION_FILE = ".xsense-hls-cache-version"
+HLS_CACHE_SUPPORTED_LEGACY_VERSIONS = frozenset({"2"})
+HLS_PLAYBACK_PROFILE_FILE = ".xsense-hls-playback-profile.json"
+HLS_LEADING_AAC_OK = "ok"
+HLS_LEADING_AAC_BROKEN = "broken"
+HLS_LEADING_AAC_UNKNOWN = "unknown"
+HLS_PLAYBACK_MODE_NORMAL = "normal"
+HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC = "ignore_leading_aac"
 SERVICE_REFRESH_RECORDINGS = "refresh_recordings"
 SERVICE_CACHE_RECORDINGS = "cache_recordings"
 SERVICE_CLEAR_RECORDINGS_CACHE = "clear_recordings_cache"
@@ -492,6 +504,116 @@ def async_stop_recording_media_sync(
         domain_data.pop("_recording_media_sync_unsubs", None)
 
 
+def async_stop_hls_playback_profile_migration(hass: HomeAssistant) -> None:
+    """Cancel a pending or running HLS playback profile migration."""
+    domain_data = hass.data.get(DOMAIN, {})
+    state = domain_data.get("_hls_playback_profile_migration")
+    if not isinstance(state, dict):
+        return
+    pending_unsub = state.pop("pending_unsub", None)
+    if callable(pending_unsub):
+        pending_unsub()
+    start_listener_unsub = state.pop("start_listener_unsub", None)
+    if callable(start_listener_unsub):
+        start_listener_unsub()
+    task = state.get("task")
+    if task is not None and not task.done():
+        task.cancel()
+
+
+def async_schedule_hls_playback_profile_migration(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> None:
+    """Upgrade cached HLS playback profiles in the background after startup."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    state = domain_data.setdefault("_hls_playback_profile_migration", {})
+    async_stop_hls_playback_profile_migration(hass)
+
+    generation = int(state.get("generation") or 0) + 1
+    state["generation"] = generation
+
+    async def _async_run_migration(_now=None) -> None:
+        if state.get("generation") != generation:
+            return
+        stats = {"migrated": 0, "skipped": 0, "failed": 0}
+        try:
+            roots = _configured_recording_media_roots(hass)
+            cache_dirs = await hass.async_add_executor_job(
+                _list_hls_cache_dirs,
+                roots,
+            )
+            for cache_dir in cache_dirs:
+                if state.get("generation") != generation:
+                    stats["interrupted"] = True
+                    break
+                result = await hass.async_add_executor_job(
+                    _migrate_hls_cache_dir,
+                    cache_dir,
+                )
+                stats[result] = int(stats.get(result) or 0) + 1
+        except asyncio.CancelledError:
+            stats["interrupted"] = True
+            raise
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug(
+                "X-Sense HLS playback profile migration failed: %s",
+                exc,
+            )
+            return
+        finally:
+            if state.get("task_generation") == generation:
+                state.pop("task", None)
+                state.pop("task_generation", None)
+
+        if state.get("generation") != generation:
+            return
+        if stats.get("migrated") or stats.get("failed") or stats.get("interrupted"):
+            LOGGER.debug(
+                "X-Sense HLS playback profile migration finished: %s",
+                stats,
+            )
+
+    @callback
+    def _start_migration_task(_now=None) -> None:
+        if state.get("generation") != generation:
+            return
+        state.pop("pending_unsub", None)
+        task = hass.async_create_task(_async_run_migration())
+        state["task"] = task
+        state["task_generation"] = generation
+
+    @callback
+    def _schedule_migration(_event=None) -> None:
+        if state.get("generation") != generation:
+            return
+        pending_unsub = state.get("pending_unsub")
+        if callable(pending_unsub):
+            pending_unsub()
+        state["pending_unsub"] = async_call_later(
+            hass,
+            HLS_PLAYBACK_PROFILE_MIGRATION_STARTUP_DELAY,
+            _start_migration_task,
+        )
+
+    if getattr(hass, "is_running", False):
+        _schedule_migration()
+    else:
+        start_listener_unsub = hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STARTED,
+            _schedule_migration,
+        )
+        state["start_listener_unsub"] = start_listener_unsub
+
+    @callback
+    def _stop_scheduled_migration() -> None:
+        if state.get("generation") != generation:
+            return
+        async_stop_hls_playback_profile_migration(hass)
+
+    entry.async_on_unload(_stop_scheduled_migration)
+
+
 def build_identifier(params: dict[str, str] | None = None) -> str:
     """Return a stable X-Sense media-source identifier."""
     if params is None:
@@ -860,6 +982,7 @@ class XSenseRecordingsMediaSource(MediaSource):
                 depth=0,
                 state=state,
             )
+            await self._async_file_job(_finalize_hls_playback_profile, staging_dir, state)
             await self._async_file_job(_write_hls_cache_version, staging_dir)
             if not await self._async_file_job(
                 _hls_cache_ready_at,
@@ -968,6 +1091,12 @@ class XSenseRecordingsMediaSource(MediaSource):
             segment_name = f"{prefix}_{index:04d}{suffix}"
             segment_count += 1
             segment_path = cache_dir / segment_name
+            if (
+                suffix.lower().endswith(".ts")
+                and not state.get("leading_segment_path")
+            ):
+                state["leading_segment_path"] = segment_path
+                state["leading_playlist_path"] = playlist_path
             if int(state.get("remaining_initial_segments") or 0) > 0:
                 payload = await self._async_download_hls_part(media_url)
                 await self._async_file_job(
@@ -1968,6 +2097,371 @@ def _write_cache_file(path: Path, payload: bytes) -> None:
     temp_path.replace(path)
 
 
+def _hls_leading_playback_segment_path(path: Path) -> Path:
+    """Return the playback-only sidecar path for one cached HLS segment."""
+    return path.with_name(f"{path.stem}.playback{path.suffix}")
+
+
+def _probe_hls_ts_aac(path: Path) -> tuple[str, dict[str, Any]]:
+    """Return the leading AAC category and ffprobe details for one TS segment."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe or not _path_ready(path):
+        return HLS_LEADING_AAC_UNKNOWN, {"reason": "ffprobe_unavailable"}
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=codec_name,profile,sample_rate,channels",
+        "-of",
+        "json",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=30,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return HLS_LEADING_AAC_UNKNOWN, {
+            "reason": "ffprobe_failed",
+            "error": str(exc),
+            "command": command,
+        }
+    details: dict[str, Any] = {
+        "command": command,
+        "returncode": result.returncode,
+    }
+    if result.stdout.strip():
+        details["stdout"] = result.stdout.strip()[:1000]
+    if result.stderr.strip():
+        details["stderr"] = result.stderr.strip()[:1000]
+    if result.returncode != 0:
+        return HLS_LEADING_AAC_UNKNOWN, details
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return HLS_LEADING_AAC_UNKNOWN, details
+    streams = payload.get("streams")
+    if not isinstance(streams, list) or not streams:
+        return HLS_LEADING_AAC_BROKEN, details
+    stream = streams[0] if isinstance(streams[0], dict) else {}
+    details["stream"] = stream
+    try:
+        sample_rate = int(stream.get("sample_rate") or 0)
+    except (TypeError, ValueError):
+        sample_rate = 0
+    try:
+        channels = int(stream.get("channels") or 0)
+    except (TypeError, ValueError):
+        channels = 0
+    profile = str(stream.get("profile") or "").strip().lower()
+    codec_name = str(stream.get("codec_name") or "").strip().lower()
+    if (
+        sample_rate <= 0
+        or channels <= 0
+        or not codec_name
+        or profile in {"", "unknown"}
+    ):
+        return HLS_LEADING_AAC_BROKEN, details
+    return HLS_LEADING_AAC_OK, details
+
+
+def _create_hls_leading_playback_segment(path: Path) -> tuple[bool, dict[str, Any]]:
+    """Create a video-only playback sidecar for one leading HLS segment."""
+    ffmpeg = shutil.which("ffmpeg")
+    output_path = _hls_leading_playback_segment_path(path)
+    if not ffmpeg or not _path_ready(path):
+        return False, {"reason": "ffmpeg_unavailable"}
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(path),
+        "-map",
+        "0:v:0",
+        "-c",
+        "copy",
+        "-f",
+        "mpegts",
+        str(output_path),
+    ]
+    details: dict[str, Any] = {"command": command}
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=30,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        details["error"] = str(exc)
+        return False, details
+    details["returncode"] = result.returncode
+    if result.stdout.strip():
+        details["stdout"] = result.stdout.strip()[:1000]
+    if result.stderr.strip():
+        details["stderr"] = result.stderr.strip()[:1000]
+    if result.returncode != 0 or not _path_ready(output_path):
+        output_path.unlink(missing_ok=True)
+        return False, details
+    return True, details
+
+
+def _categorize_hls_leading_segment(segment_path: Path) -> dict[str, Any]:
+    """Probe one leading segment and prepare playback metadata."""
+    leading_aac, probe = _probe_hls_ts_aac(segment_path)
+    profile: dict[str, Any] = {
+        "leading_aac": leading_aac,
+        "leading_segment": segment_path.name,
+        "probe": probe,
+    }
+    if leading_aac == HLS_LEADING_AAC_BROKEN:
+        created, repair = _create_hls_leading_playback_segment(segment_path)
+        profile["repair"] = repair
+        if not created:
+            raise Unresolvable(
+                "X-Sense HLS recording leading segment could not be prepared for playback"
+            )
+        profile["leading_playback_segment"] = _hls_leading_playback_segment_path(
+            segment_path
+        ).name
+        profile["playback_mode"] = HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
+        LOGGER.debug(
+            "X-Sense HLS leading segment categorized for ignore-AAC playback: %s",
+            {
+                "segment": segment_path.name,
+                "playback_segment": profile["leading_playback_segment"],
+            },
+        )
+    else:
+        profile["playback_mode"] = HLS_PLAYBACK_MODE_NORMAL
+        if leading_aac == HLS_LEADING_AAC_UNKNOWN:
+            LOGGER.debug(
+                "X-Sense HLS leading segment AAC probe was inconclusive: %s",
+                {"segment": segment_path.name, "probe": probe},
+            )
+    return profile
+
+
+def _write_hls_playback_profile(cache_dir: Path, profile: dict[str, Any]) -> None:
+    _write_cache_file(
+        cache_dir / HLS_PLAYBACK_PROFILE_FILE,
+        (json.dumps(profile, sort_keys=True) + "\n").encode(),
+    )
+
+
+def _read_hls_playback_profile(cache_dir: Path) -> dict[str, Any]:
+    profile_path = cache_dir / HLS_PLAYBACK_PROFILE_FILE
+    try:
+        payload = json.loads(profile_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _apply_hls_playback_profile_to_playlist(
+    playlist_path: Path,
+    profile: dict[str, Any],
+) -> None:
+    """Rewrite one cached playlist for broken leading AAC playback."""
+    if profile.get("leading_aac") != HLS_LEADING_AAC_BROKEN:
+        return
+    leading_segment = str(profile.get("leading_segment") or "")
+    playback_segment = str(profile.get("leading_playback_segment") or "")
+    if not leading_segment or not playback_segment:
+        return
+    lines = playlist_path.read_text(encoding="utf-8").splitlines()
+    rewritten: list[str] = []
+    replaced = False
+    insert_discontinuity = False
+    for line in lines:
+        stripped = line.strip()
+        if insert_discontinuity and stripped and not stripped.startswith("#"):
+            rewritten.append("#EXT-X-DISCONTINUITY")
+            insert_discontinuity = False
+        if (
+            not replaced
+            and stripped
+            and not stripped.startswith("#")
+            and stripped == leading_segment
+        ):
+            rewritten.append(playback_segment)
+            replaced = True
+            insert_discontinuity = True
+            continue
+        rewritten.append(line)
+    if replaced:
+        playlist_path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
+
+
+def _hls_first_media_segment_path(
+    playlist_path: Path,
+) -> tuple[Path, Path] | None:
+    """Return the first TS segment path and the playlist that references it."""
+    if not _path_ready(playlist_path):
+        return None
+    try:
+        lines = playlist_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _is_hls_playlist_uri(stripped):
+            nested = _hls_first_media_segment_path(playlist_path.parent / stripped)
+            if nested is not None:
+                return nested
+            continue
+        segment_path = playlist_path.parent / stripped
+        if ".playback." in stripped:
+            original_name = stripped.replace(".playback.", ".", 1)
+            original_path = playlist_path.parent / original_name
+            if _path_ready(original_path):
+                return original_path, playlist_path
+        return segment_path, playlist_path
+    return None
+
+
+def _list_hls_cache_dirs(roots: list[Path]) -> list[Path]:
+    """Return cached HLS clip directories under the configured media roots."""
+    cache_dirs: list[Path] = []
+    for root in roots:
+        hls_root = root / "hls"
+        if not hls_root.is_dir():
+            continue
+        for path in sorted(hls_root.iterdir()):
+            if path.is_dir() and not path.name.startswith("."):
+                cache_dirs.append(path)
+    return cache_dirs
+
+
+def _hls_cache_dir_needs_playback_profile_migration(
+    cache_dir: Path,
+    playlist_path: Path,
+) -> bool:
+    """Return whether one cached HLS clip still needs playback profile work."""
+    if not _path_ready(playlist_path) or not _hls_playlist_ready(playlist_path):
+        return False
+    version = _hls_cache_version_value(cache_dir)
+    if (
+        version
+        and version not in HLS_CACHE_SUPPORTED_LEGACY_VERSIONS
+        and version != str(HLS_CACHE_VERSION)
+    ):
+        return False
+    profile = _read_hls_playback_profile(cache_dir)
+    if (
+        profile
+        and _hls_playback_profile_ready(cache_dir)
+        and version == str(HLS_CACHE_VERSION)
+    ):
+        return False
+    return True
+
+
+def _migrate_hls_cache_dir(cache_dir: Path) -> str:
+    """Upgrade one cached HLS clip directory in place."""
+    playlist_path = cache_dir / "index.m3u8"
+    if not _hls_cache_dir_needs_playback_profile_migration(cache_dir, playlist_path):
+        return "skipped"
+    if _ensure_hls_playback_profile(cache_dir, playlist_path):
+        return "migrated"
+    return "failed"
+
+
+def _ensure_hls_playback_profile(cache_dir: Path, playlist_path: Path) -> bool:
+    """Probe a cached clip in place and add playback metadata when missing."""
+    profile = _read_hls_playback_profile(cache_dir)
+    if profile and _hls_playback_profile_ready(cache_dir):
+        if _hls_cache_version_value(cache_dir) != str(HLS_CACHE_VERSION):
+            _write_hls_cache_version(cache_dir)
+        return True
+    located = _hls_first_media_segment_path(playlist_path)
+    if located is None:
+        return False
+    leading_path, leading_playlist = located
+    if not _path_ready(leading_path):
+        return False
+    try:
+        playback_profile = _categorize_hls_leading_segment(leading_path)
+    except Unresolvable:
+        LOGGER.debug(
+            "X-Sense HLS playback profile migration failed: %s",
+            {"segment": leading_path.name},
+        )
+        return False
+    _write_hls_playback_profile(cache_dir, playback_profile)
+    _apply_hls_playback_profile_to_playlist(leading_playlist, playback_profile)
+    _write_hls_cache_version(cache_dir)
+    LOGGER.debug(
+        "X-Sense HLS playback profile migrated in place: %s",
+        {
+            "leading_aac": playback_profile.get("leading_aac"),
+            "playback_mode": playback_profile.get("playback_mode"),
+            "leading_segment": playback_profile.get("leading_segment"),
+        },
+    )
+    return _hls_playback_profile_ready(cache_dir)
+
+
+def _finalize_hls_playback_profile(cache_dir: Path, state: dict[str, Any]) -> None:
+    """Probe the leading segment and store playback handling metadata."""
+    leading_path = state.get("leading_segment_path")
+    if not isinstance(leading_path, Path) or not _path_ready(leading_path):
+        _write_hls_playback_profile(
+            cache_dir,
+            {
+                "leading_aac": HLS_LEADING_AAC_UNKNOWN,
+                "playback_mode": HLS_PLAYBACK_MODE_NORMAL,
+            },
+        )
+        return
+    profile = _categorize_hls_leading_segment(leading_path)
+    _write_hls_playback_profile(cache_dir, profile)
+    playlist_path = state.get("leading_playlist_path")
+    if not isinstance(playlist_path, Path):
+        playlist_path = cache_dir / "index.m3u8"
+    _apply_hls_playback_profile_to_playlist(playlist_path, profile)
+
+
+def _hls_playback_profile_ready(cache_dir: Path) -> bool:
+    profile = _read_hls_playback_profile(cache_dir)
+    if not profile:
+        return False
+    if profile.get("leading_aac") != HLS_LEADING_AAC_BROKEN:
+        return True
+    playback_segment = str(profile.get("leading_playback_segment") or "")
+    if not playback_segment:
+        return False
+    return _path_ready(cache_dir / playback_segment)
+
+
+def _hls_playback_fields_for_clip(clip: dict[str, Any]) -> dict[str, str]:
+    """Return playback profile fields exposed to the recordings panel."""
+    if not _hls_ready(clip):
+        return {}
+    profile = _read_hls_playback_profile(_hls_playlist_cache_path(clip).parent)
+    leading_aac = str(profile.get("leading_aac") or "")
+    playback_mode = str(profile.get("playback_mode") or "")
+    if not leading_aac:
+        return {}
+    fields = {"hls_leading_aac": leading_aac}
+    if playback_mode:
+        fields["hls_playback_mode"] = playback_mode
+    return fields
+
+
 def _replace_cache_file(source: Path, target: Path) -> None:
     """Replace one cached recording file."""
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -2000,10 +2494,30 @@ def _hls_ready(clip: dict[str, Any]) -> bool:
 
 
 def _hls_cache_ready_at(cache_dir: Path, playlist_path: Path) -> bool:
-    if not _hls_cache_version_ready(cache_dir):
+    if not _hls_cache_version_supported(cache_dir):
         _remove_directory(cache_dir)
         return False
-    return _hls_playlist_ready(playlist_path)
+    if not _hls_playlist_ready(playlist_path):
+        return False
+    if not _read_hls_playback_profile(cache_dir):
+        return _ensure_hls_playback_profile(cache_dir, playlist_path)
+    if not _hls_playback_profile_ready(cache_dir):
+        return False
+    return True
+
+
+def _hls_cache_version_value(cache_dir: Path) -> str:
+    try:
+        return (cache_dir / HLS_CACHE_VERSION_FILE).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _hls_cache_version_supported(cache_dir: Path) -> bool:
+    version = _hls_cache_version_value(cache_dir)
+    if version == str(HLS_CACHE_VERSION):
+        return True
+    return version in HLS_CACHE_SUPPORTED_LEGACY_VERSIONS
 
 
 def _write_hls_cache_version(cache_dir: Path) -> None:
@@ -2014,13 +2528,7 @@ def _write_hls_cache_version(cache_dir: Path) -> None:
 
 
 def _hls_cache_version_ready(cache_dir: Path) -> bool:
-    try:
-        version = (cache_dir / HLS_CACHE_VERSION_FILE).read_text(
-            encoding="utf-8"
-        ).strip()
-    except OSError:
-        return False
-    return version == str(HLS_CACHE_VERSION)
+    return _hls_cache_version_supported(cache_dir)
 
 
 def _hls_playlist_ready(playlist_path: Path) -> bool:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -2299,6 +2299,15 @@ def test_recording_media_source_caches_hd_hls_without_sd_fallback(
 ):
     from custom_components.xsense import recordings_media as media_source
 
+    monkeypatch.setattr(
+        media_source,
+        "_categorize_hls_leading_segment",
+        lambda path: {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": path.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        },
+    )
     source = media_source.XSenseRecordingsMediaSource(_recordings_media_source_hass())
     output_path = tmp_path / "clip.mp4"
     clip = {
@@ -2399,6 +2408,15 @@ def test_recording_media_source_preserves_original_leading_hls_ts_segment(
 ):
     from custom_components.xsense import recordings_media as media_source
 
+    monkeypatch.setattr(
+        media_source,
+        "_categorize_hls_leading_segment",
+        lambda path: {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": path.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        },
+    )
     source = media_source.XSenseRecordingsMediaSource(_recordings_media_source_hass())
     output_path = tmp_path / "clip.mp4"
     clip = {
@@ -2491,6 +2509,307 @@ def test_recording_media_source_preserves_original_leading_hls_ts_segment(
     )
     assert (playlist.parent / "segment_0002.ts").read_bytes() == b"bad-leading-audio"
     assert (playlist.parent / "segment_0003.ts").read_bytes() == b"good-audio-video"
+    profile = media_source._read_hls_playback_profile(playlist.parent)
+    assert profile["leading_aac"] == media_source.HLS_LEADING_AAC_OK
+    assert profile["playback_mode"] == media_source.HLS_PLAYBACK_MODE_NORMAL
+
+
+def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    def _broken_leading_profile(path):
+        sidecar = media_source._hls_leading_playback_segment_path(path)
+        sidecar.write_bytes(b"video-only-sidecar")
+        return {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_segment": path.name,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+        }
+
+    monkeypatch.setattr(
+        media_source,
+        "_categorize_hls_leading_segment",
+        _broken_leading_profile,
+    )
+    source = media_source.XSenseRecordingsMediaSource(_recordings_media_source_hass())
+    output_path = tmp_path / "clip.mp4"
+    clip = {
+        "source": "video_url",
+        "quality": "HD",
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "playback_url": "https://example.invalid/index.m3u8",
+        "media_root": tmp_path.as_posix(),
+    }
+    responses = {
+        "https://example.invalid/index.m3u8": (
+            "application/vnd.apple.mpegurl;charset=utf-8",
+            b"#EXTM3U\n#EXT-X-TARGETDURATION:4\nseg-1.ts\nseg-2.ts\n#EXT-X-ENDLIST\n",
+        ),
+        "https://example.invalid/seg-1.ts": ("video/mp2t", b"bad-leading-audio"),
+        "https://example.invalid/seg-2.ts": ("video/mp2t", b"good-audio-video"),
+    }
+
+    class Response:
+        def __init__(self, url):
+            self.content_type, self.payload = responses[url]
+            self.headers = {"content-type": self.content_type}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        async def read(self):
+            return self.payload
+
+        async def text(self):
+            return self.payload.decode()
+
+    class Session:
+        def get(self, url):
+            return Response(url)
+
+    class Hass:
+        async def async_add_executor_job(self, func, *args):
+            return func(*args)
+
+    source.hass = Hass()
+    monkeypatch.setattr(
+        media_source,
+        "_hls_cache_dir",
+        lambda current_clip: tmp_path / "hls",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: tmp_path / "hls" / "index.m3u8",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_local_media_url",
+        lambda path: f"/media/local/test/{path.name}",
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_clip_cache_path",
+        lambda current_clip: output_path,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "async_get_clientsession",
+        lambda hass: Session(),
+    )
+
+    asyncio.run(source._async_cached_playback_url(clip))
+
+    playlist = media_source._hls_playlist_cache_path(clip)
+    profile = media_source._read_hls_playback_profile(playlist.parent)
+    assert profile["leading_aac"] == media_source.HLS_LEADING_AAC_BROKEN
+    assert profile["playback_mode"] == media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
+    assert (playlist.parent / "segment_0002.ts").read_bytes() == b"bad-leading-audio"
+    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"video-only-sidecar"
+    assert playlist.read_text(encoding="utf-8") == (
+        "#EXTM3U\n"
+        "#EXT-X-TARGETDURATION:4\n"
+        "segment_0002.playback.ts\n"
+        "#EXT-X-DISCONTINUITY\n"
+        "segment_0003.ts\n"
+        "#EXT-X-ENDLIST\n"
+    )
+    assert media_source._hls_playback_fields_for_clip(clip) == {
+        "hls_leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+        "hls_playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+    }
+
+
+def test_recording_media_source_migrates_v2_hls_cache_in_place(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    def _broken_leading_profile(path):
+        sidecar = media_source._hls_leading_playback_segment_path(path)
+        sidecar.write_bytes(b"video-only-sidecar")
+        return {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_segment": path.name,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+        }
+
+    monkeypatch.setattr(
+        media_source,
+        "_categorize_hls_leading_segment",
+        _broken_leading_profile,
+    )
+    playlist = tmp_path / "hls" / "index.m3u8"
+    playlist.parent.mkdir(parents=True)
+    playlist.write_text(
+        "#EXTM3U\n#EXT-X-TARGETDURATION:4\nsegment_0002.ts\nsegment_0003.ts\n#EXT-X-ENDLIST\n"
+    )
+    (playlist.parent / "segment_0002.ts").write_bytes(b"bad-leading-audio")
+    (playlist.parent / "segment_0003.ts").write_bytes(b"good-audio-video")
+    (playlist.parent / media_source.HLS_CACHE_VERSION_FILE).write_text("2\n")
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+
+    assert media_source._hls_ready(clip)
+    assert (
+        playlist.parent / media_source.HLS_CACHE_VERSION_FILE
+    ).read_text(encoding="utf-8").strip() == "3"
+    assert (playlist.parent / "segment_0002.ts").read_bytes() == b"bad-leading-audio"
+    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"video-only-sidecar"
+    assert "segment_0002.playback.ts" in playlist.read_text(encoding="utf-8")
+
+
+def test_hls_playback_profile_migration_reschedules_on_reload(monkeypatch):
+    from custom_components.xsense import recordings_media as media_source
+    from custom_components.xsense.const import DOMAIN
+
+    scheduled = []
+    cancelled = []
+
+    def async_call_later(hass, delay, action):
+        scheduled.append(action)
+        return lambda: cancelled.append("pending")
+
+    class Task:
+        def __init__(self, coro):
+            self._coro = coro
+            self.done = MagicMock(return_value=False)
+            self.cancel = MagicMock()
+
+        def __await__(self):
+            return self._coro.__await__()
+
+    created_tasks = []
+
+    def async_create_task(coro):
+        task = Task(coro)
+        created_tasks.append(task)
+        return task
+
+    async def noop_migration(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(media_source, "async_call_later", async_call_later)
+    monkeypatch.setattr(
+        media_source,
+        "_configured_recording_media_roots",
+        lambda hass: [],
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_list_hls_cache_dirs",
+        lambda roots: [],
+    )
+
+    unloads = []
+    entry = SimpleNamespace(
+        entry_id="entry-id",
+        async_on_unload=unloads.append,
+    )
+    hass = SimpleNamespace(
+        data={DOMAIN: {}},
+        is_running=True,
+        bus=SimpleNamespace(
+            async_listen_once=lambda event, callback: lambda: cancelled.append(
+                "start-listener"
+            )
+        ),
+        async_add_executor_job=noop_migration,
+        async_create_task=async_create_task,
+    )
+
+    media_source.async_schedule_hls_playback_profile_migration(hass, entry)
+    first_generation = hass.data[DOMAIN]["_hls_playback_profile_migration"]["generation"]
+    assert len(scheduled) == 1
+
+    media_source.async_schedule_hls_playback_profile_migration(hass, entry)
+    second_generation = hass.data[DOMAIN]["_hls_playback_profile_migration"]["generation"]
+    assert second_generation == first_generation + 1
+    assert cancelled == ["pending"]
+    assert len(scheduled) == 2
+    assert len(unloads) == 2
+
+
+def test_hls_playback_profile_migration_skips_completed_cache_dirs(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    def _ok_profile(path):
+        return {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": path.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        }
+
+    monkeypatch.setattr(
+        media_source,
+        "_categorize_hls_leading_segment",
+        _ok_profile,
+    )
+
+    ready_dir = tmp_path / "hls" / "ready_clip"
+    ready_dir.mkdir(parents=True)
+    ready_playlist = ready_dir / "index.m3u8"
+    ready_playlist.write_text(
+        "#EXTM3U\n#EXT-X-TARGETDURATION:4\nsegment_0001.ts\n#EXT-X-ENDLIST\n"
+    )
+    (ready_dir / "segment_0001.ts").write_bytes(b"good-audio-video")
+    (ready_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    media_source._write_hls_playback_profile(ready_dir, _ok_profile(ready_dir / "segment_0001.ts"))
+
+    pending_dir = tmp_path / "hls" / "pending_clip"
+    pending_dir.mkdir(parents=True)
+    pending_playlist = pending_dir / "index.m3u8"
+    pending_playlist.write_text(
+        "#EXTM3U\n#EXT-X-TARGETDURATION:4\nsegment_0002.ts\n#EXT-X-ENDLIST\n"
+    )
+    (pending_dir / "segment_0002.ts").write_bytes(b"bad-leading-audio")
+    (pending_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("2\n")
+
+    cache_dirs = media_source._list_hls_cache_dirs([tmp_path])
+    assert cache_dirs == [pending_dir, ready_dir]
+
+    assert media_source._hls_cache_dir_needs_playback_profile_migration(
+        ready_dir,
+        ready_playlist,
+    ) is False
+    assert media_source._hls_cache_dir_needs_playback_profile_migration(
+        pending_dir,
+        pending_playlist,
+    ) is True
+
+    assert media_source._migrate_hls_cache_dir(ready_dir) == "skipped"
+    assert media_source._migrate_hls_cache_dir(pending_dir) == "migrated"
+    assert (
+        pending_dir / media_source.HLS_CACHE_VERSION_FILE
+    ).read_text(encoding="utf-8").strip() == "3"
 
 
 def test_recording_media_source_rejects_unversioned_hls_cache(
@@ -2550,6 +2869,14 @@ def test_recording_media_source_prefers_hls_cache_over_legacy_mp4(
     playlist.write_text("#EXTM3U\n#EXT-X-TARGETDURATION:4\nsegment_0001.ts\n")
     (playlist.parent / "segment_0001.ts").write_bytes(b"segment")
     media_source._write_hls_cache_version(playlist.parent)
+    media_source._write_hls_playback_profile(
+        playlist.parent,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": "segment_0001.ts",
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        },
+    )
     clip = {
         "source": "video_url",
         "quality": "HD",
@@ -2623,6 +2950,14 @@ def test_recording_media_source_hls_master_ready_with_one_buffered_variant(
         encoding="utf-8",
     )
     media_source._write_hls_cache_version(root)
+    media_source._write_hls_playback_profile(
+        root,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": "segment_0002.ts",
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        },
+    )
     monkeypatch.setattr(
         media_source,
         "_hls_playlist_cache_path",

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -30,6 +30,29 @@ from custom_components.xsense import (
 from custom_components.xsense.const import CONF_RECORDING_MEDIA_SYNC_ENABLED, DOMAIN
 
 
+def _mock_hls_playback_profile_migration(monkeypatch, calls=None):
+    """Stub HLS playback profile migration so setup tests avoid HA event loop deps."""
+
+    def _schedule(hass, entry):
+        if calls is not None:
+            calls.append("hls_playback_profile_migration")
+
+    def _stop(hass):
+        if calls is not None:
+            calls.append("hls_playback_profile_migration_stop")
+
+    monkeypatch.setattr(
+        xsense_module,
+        "async_schedule_hls_playback_profile_migration",
+        _schedule,
+    )
+    monkeypatch.setattr(
+        xsense_module,
+        "async_stop_hls_playback_profile_migration",
+        _stop,
+    )
+
+
 ROOT = Path(__file__).parents[1]
 
 
@@ -1733,6 +1756,7 @@ def test_recordings_runtime_cleanup_removes_stale_non_camera_runtime(monkeypatch
         "async_clear_recording_event_clips",
         lambda hass, entry_id=None: calls.append(("event_clips", entry_id)),
     )
+    _mock_hls_playback_profile_migration(monkeypatch, calls)
 
     xsense_module._cleanup_recordings_runtime(SimpleNamespace(), "xcom-entry")
 
@@ -1740,6 +1764,7 @@ def test_recordings_runtime_cleanup_removes_stale_non_camera_runtime(monkeypatch
         ("stop_sync", "xcom-entry"),
         ("remove_index", "xcom-entry"),
         ("event_clips", "xcom-entry"),
+        "hls_playback_profile_migration_stop",
         "recordings_panel",
         "recording_services",
         "recording_media_source",
@@ -2022,6 +2047,7 @@ def test_setup_entry_registers_recordings_runtime_with_cameras(monkeypatch):
         "async_start_recording_media_sync",
         lambda hass, entry: calls.append("recording_media_sync"),
     )
+    _mock_hls_playback_profile_migration(monkeypatch, calls)
     monkeypatch.setattr(
         xsense_module,
         "_schedule_startup_maintenance",
@@ -2042,6 +2068,7 @@ def test_setup_entry_registers_recordings_runtime_with_cameras(monkeypatch):
     assert "recordings_http_views" not in calls
     assert "recording_services" in calls
     assert "recording_media_sync" in calls
+    assert "hls_playback_profile_migration" in calls
 
 
 def test_setup_entry_registers_recordings_runtime_when_camera_appears_later(
@@ -2141,6 +2168,7 @@ def test_setup_entry_registers_recordings_runtime_when_camera_appears_later(
         "async_start_recording_media_sync",
         lambda hass, entry: calls.append("recording_media_sync"),
     )
+    _mock_hls_playback_profile_migration(monkeypatch, calls)
     monkeypatch.setattr(
         xsense_module,
         "_schedule_startup_maintenance",
@@ -2312,9 +2340,12 @@ def test_recordings_panel_video_uses_authenticated_blob_playback():
     assert "new Hls({" in panel
     assert "enableWorker: false" in panel
     assert 'defaultAudioCodec: "mp4a.40.2"' in panel
-    assert "setPlaybackUrl(key, url, type)" in panel
+    assert "setPlaybackUrl(key, url, type, options = {})" in panel
     assert "clearPlaybackUrl(key)" in panel
     assert "disposePlaybackResources()" in panel
+    assert "this.playbackProfiles = new Map()" in panel
+    assert 'response.headers.get("X-XSense-HLS-Leading-AAC")' in panel
+    assert 'response.headers.get("X-XSense-HLS-Playback-Mode")' in panel
     assert 'this.logPanelEvent("playback_hls_js_attached"' in panel
     assert 'this.logPanelEvent("playback_hls_js_error"' in panel
     assert 'this.logPanelEvent("playback_hls_native_attached"' in panel
@@ -2435,6 +2466,7 @@ def test_recordings_entry_reload_reregisters_panel_without_duplicate_assets(monk
         "async_start_recording_media_sync",
         lambda hass, entry: calls.append("recording_media_sync"),
     )
+    _mock_hls_playback_profile_migration(monkeypatch, calls)
     monkeypatch.setattr(
         xsense_module,
         "_schedule_startup_maintenance",
@@ -2881,6 +2913,14 @@ def test_recordings_panel_playback_serves_hls_before_legacy_mp4(
     playlist.write_text("#EXTM3U\n#EXT-X-TARGETDURATION:4\nsegment_0001.ts\n")
     (playlist.parent / "segment_0001.ts").write_bytes(b"segment")
     media_source._write_hls_cache_version(playlist.parent)
+    media_source._write_hls_playback_profile(
+        playlist.parent,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_OK,
+            "leading_segment": "segment_0001.ts",
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
+        },
+    )
     clip = {
         "entry_id": "entry-id",
         "serial": "CAMERA-SN",


### PR DESCRIPTION
## Summary
- Fixes HLS recording playback when the first segment has broken AAC metadata (#271) by serving a video-only playback sidecar for the leading segment only, matching the X-Sense app behavior.
- Upgrades existing HLS caches in place with a resumable background migration on integration load — no re-download required.
- Restarts or resumes migration safely when Home Assistant or the integration reloads during the upgrade.

## Test plan
- [x] 718 tests passed locally with \-p no:homeassistant\
- [x] HLS playback profile migration and in-place cache upgrade tests passed
- [x] Release metadata aligned for \1.4.17.3\

Made with [Cursor](https://cursor.com)