### PR TITLE
Prepare v1.4.17.4 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17.3):
-  (e.g., 1.4.17.3)
+- **X-Sense-Integration Version** (z. B. 1.4.17.4):
+  (e.g., 1.4.17.4)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.17.4.md
+++ b/.github/release-notes/1.4.17.4.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.17.4
+
+### 📷 Recordings
+- Fixes browser playback of cached HLS recordings when the first segment has broken AAC metadata (#271) by substituting a leading playback sidecar with silent AAC that matches the following segments' audio layout, instead of a video-only sidecar that breaks hls.js/MSE track setup.
+- Reads AAC sample rate and channel count from the first good following segment when building the sidecar, with a 16 kHz mono fallback when no reference segment is available yet.
+- Regenerates existing video-only playback sidecars from v1.4.17.3 automatically on reload or during background cache migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.17.4](.github/release-notes/1.4.17.4.md)
 - [1.4.17.3](.github/release-notes/1.4.17.3.md)
 - [1.4.17.2](.github/release-notes/1.4.17.2.md)
 - [1.4.17.1](.github/release-notes/1.4.17.1.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17.3"
+PANEL_ASSET_VERSION = "1.4.17.4"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17.3",
+  "version": "1.4.17.4",
   "zeroconf": []
 }

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -2172,12 +2172,97 @@ def _probe_hls_ts_aac(path: Path) -> tuple[str, dict[str, Any]]:
     return HLS_LEADING_AAC_OK, details
 
 
-def _create_hls_leading_playback_segment(path: Path) -> tuple[bool, dict[str, Any]]:
-    """Create a video-only playback sidecar for one leading HLS segment."""
+def _ffmpeg_channel_layout(channels: int) -> str:
+    """Return a lavfi channel_layout value for one AAC stream."""
+    if channels == 1:
+        return "mono"
+    if channels == 2:
+        return "stereo"
+    return f"{channels}c"
+
+
+def _audio_params_from_probe(probe: dict[str, Any]) -> tuple[int, int]:
+    """Return sample rate and channel count from one ffprobe payload."""
+    stream = probe.get("stream")
+    if not isinstance(stream, dict):
+        return 16000, 1
+    try:
+        sample_rate = int(stream.get("sample_rate") or 0)
+    except (TypeError, ValueError):
+        sample_rate = 0
+    try:
+        channels = int(stream.get("channels") or 0)
+    except (TypeError, ValueError):
+        channels = 0
+    if sample_rate <= 0:
+        sample_rate = 16000
+    if channels <= 0:
+        channels = 1
+    return sample_rate, channels
+
+
+def _iter_playlist_media_segment_paths(
+    cache_dir: Path,
+    playlist_path: Path,
+) -> list[Path]:
+    """Return original cached media segment paths referenced by one playlist."""
+    if not _path_ready(playlist_path):
+        return []
+    try:
+        lines = playlist_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    segment_paths: list[Path] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _is_hls_playlist_uri(stripped):
+            nested = _iter_playlist_media_segment_paths(
+                cache_dir,
+                playlist_path.parent / stripped,
+            )
+            segment_paths.extend(nested)
+            continue
+        if ".playback." in stripped:
+            original_name = stripped.replace(".playback.", ".", 1)
+            segment_paths.append(cache_dir / original_name)
+            continue
+        segment_paths.append(cache_dir / stripped)
+    return segment_paths
+
+
+def _hls_reference_audio_segment_path(
+    cache_dir: Path,
+    playlist_path: Path,
+    leading_path: Path,
+) -> Path | None:
+    """Return the first following segment with probeable AAC parameters."""
+    past_leading = False
+    for segment_path in _iter_playlist_media_segment_paths(cache_dir, playlist_path):
+        if segment_path.resolve() == leading_path.resolve():
+            past_leading = True
+            continue
+        if not past_leading:
+            continue
+        leading_aac, _probe = _probe_hls_ts_aac(segment_path)
+        if leading_aac == HLS_LEADING_AAC_OK:
+            return segment_path
+    return None
+
+
+def _create_hls_leading_playback_segment(
+    path: Path,
+    *,
+    sample_rate: int,
+    channels: int,
+) -> tuple[bool, dict[str, Any]]:
+    """Create a silent-AAC playback sidecar for one leading HLS segment."""
     ffmpeg = shutil.which("ffmpeg")
     output_path = _hls_leading_playback_segment_path(path)
     if not ffmpeg or not _path_ready(path):
         return False, {"reason": "ffmpeg_unavailable"}
+    channel_layout = _ffmpeg_channel_layout(channels)
     command = [
         ffmpeg,
         "-hide_banner",
@@ -2186,15 +2271,35 @@ def _create_hls_leading_playback_segment(path: Path) -> tuple[bool, dict[str, An
         "-y",
         "-i",
         str(path),
+        "-f",
+        "lavfi",
+        "-i",
+        f"anullsrc=channel_layout={channel_layout}:sample_rate={sample_rate}",
+        "-map",
+        "1:a:0",
         "-map",
         "0:v:0",
-        "-c",
+        "-shortest",
+        "-c:v",
         "copy",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "32k",
+        "-ar",
+        str(sample_rate),
+        "-ac",
+        str(channels),
         "-f",
         "mpegts",
         str(output_path),
     ]
-    details: dict[str, Any] = {"command": command}
+    details: dict[str, Any] = {
+        "command": command,
+        "sample_rate": sample_rate,
+        "channels": channels,
+        "channel_layout": channel_layout,
+    }
     try:
         result = subprocess.run(
             command,
@@ -2217,8 +2322,15 @@ def _create_hls_leading_playback_segment(path: Path) -> tuple[bool, dict[str, An
     return True, details
 
 
-def _categorize_hls_leading_segment(segment_path: Path) -> dict[str, Any]:
+def _categorize_hls_leading_segment(
+    segment_path: Path,
+    *,
+    playlist_path: Path | None = None,
+) -> dict[str, Any]:
     """Probe one leading segment and prepare playback metadata."""
+    if playlist_path is None:
+        playlist_path = segment_path.parent / "index.m3u8"
+    cache_dir = segment_path.parent
     leading_aac, probe = _probe_hls_ts_aac(segment_path)
     profile: dict[str, Any] = {
         "leading_aac": leading_aac,
@@ -2226,7 +2338,35 @@ def _categorize_hls_leading_segment(segment_path: Path) -> dict[str, Any]:
         "probe": probe,
     }
     if leading_aac == HLS_LEADING_AAC_BROKEN:
-        created, repair = _create_hls_leading_playback_segment(segment_path)
+        reference_path = _hls_reference_audio_segment_path(
+            cache_dir,
+            playlist_path,
+            segment_path,
+        )
+        if reference_path is not None:
+            _reference_aac, reference_probe = _probe_hls_ts_aac(reference_path)
+            sample_rate, channels = _audio_params_from_probe(reference_probe)
+            profile["reference_audio_segment"] = reference_path.name
+            profile["reference_audio"] = {
+                "sample_rate": sample_rate,
+                "channels": channels,
+            }
+        else:
+            sample_rate, channels = 16000, 1
+            profile["reference_audio"] = {
+                "sample_rate": sample_rate,
+                "channels": channels,
+                "fallback": True,
+            }
+            LOGGER.debug(
+                "X-Sense HLS leading segment sidecar uses fallback AAC params: %s",
+                {"segment": segment_path.name},
+            )
+        created, repair = _create_hls_leading_playback_segment(
+            segment_path,
+            sample_rate=sample_rate,
+            channels=channels,
+        )
         profile["repair"] = repair
         if not created:
             raise Unresolvable(
@@ -2237,10 +2377,11 @@ def _categorize_hls_leading_segment(segment_path: Path) -> dict[str, Any]:
         ).name
         profile["playback_mode"] = HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
         LOGGER.debug(
-            "X-Sense HLS leading segment categorized for ignore-AAC playback: %s",
+            "X-Sense HLS leading segment categorized for silent-AAC playback: %s",
             {
                 "segment": segment_path.name,
                 "playback_segment": profile["leading_playback_segment"],
+                "reference_audio": profile.get("reference_audio"),
             },
         )
     else:
@@ -2394,7 +2535,10 @@ def _ensure_hls_playback_profile(cache_dir: Path, playlist_path: Path) -> bool:
     if not _path_ready(leading_path):
         return False
     try:
-        playback_profile = _categorize_hls_leading_segment(leading_path)
+        playback_profile = _categorize_hls_leading_segment(
+            leading_path,
+            playlist_path=leading_playlist,
+        )
     except Unresolvable:
         LOGGER.debug(
             "X-Sense HLS playback profile migration failed: %s",
@@ -2427,11 +2571,14 @@ def _finalize_hls_playback_profile(cache_dir: Path, state: dict[str, Any]) -> No
             },
         )
         return
-    profile = _categorize_hls_leading_segment(leading_path)
-    _write_hls_playback_profile(cache_dir, profile)
     playlist_path = state.get("leading_playlist_path")
     if not isinstance(playlist_path, Path):
         playlist_path = cache_dir / "index.m3u8"
+    profile = _categorize_hls_leading_segment(
+        leading_path,
+        playlist_path=playlist_path,
+    )
+    _write_hls_playback_profile(cache_dir, profile)
     _apply_hls_playback_profile_to_playlist(playlist_path, profile)
 
 
@@ -2444,7 +2591,11 @@ def _hls_playback_profile_ready(cache_dir: Path) -> bool:
     playback_segment = str(profile.get("leading_playback_segment") or "")
     if not playback_segment:
         return False
-    return _path_ready(cache_dir / playback_segment)
+    playback_path = cache_dir / playback_segment
+    if not _path_ready(playback_path):
+        return False
+    sidecar_aac, _probe = _probe_hls_ts_aac(playback_path)
+    return sidecar_aac == HLS_LEADING_AAC_OK
 
 
 def _hls_playback_fields_for_clip(clip: dict[str, Any]) -> dict[str, str]:
@@ -2502,7 +2653,7 @@ def _hls_cache_ready_at(cache_dir: Path, playlist_path: Path) -> bool:
     if not _read_hls_playback_profile(cache_dir):
         return _ensure_hls_playback_profile(cache_dir, playlist_path)
     if not _hls_playback_profile_ready(cache_dir):
-        return False
+        return _ensure_hls_playback_profile(cache_dir, playlist_path)
     return True
 
 

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -2302,7 +2302,7 @@ def test_recording_media_source_caches_hd_hls_without_sd_fallback(
     monkeypatch.setattr(
         media_source,
         "_categorize_hls_leading_segment",
-        lambda path: {
+        lambda path, **kwargs: {
             "leading_aac": media_source.HLS_LEADING_AAC_OK,
             "leading_segment": path.name,
             "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
@@ -2411,7 +2411,7 @@ def test_recording_media_source_preserves_original_leading_hls_ts_segment(
     monkeypatch.setattr(
         media_source,
         "_categorize_hls_leading_segment",
-        lambda path: {
+        lambda path, **kwargs: {
             "leading_aac": media_source.HLS_LEADING_AAC_OK,
             "leading_segment": path.name,
             "playback_mode": media_source.HLS_PLAYBACK_MODE_NORMAL,
@@ -2520,9 +2520,9 @@ def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback
 ):
     from custom_components.xsense import recordings_media as media_source
 
-    def _broken_leading_profile(path):
+    def _broken_leading_profile(path, **kwargs):
         sidecar = media_source._hls_leading_playback_segment_path(path)
-        sidecar.write_bytes(b"video-only-sidecar")
+        sidecar.write_bytes(b"silent-aac-sidecar")
         return {
             "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
             "leading_segment": path.name,
@@ -2530,6 +2530,23 @@ def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback
             "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
         }
 
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (
+            media_source.HLS_LEADING_AAC_OK,
+            {
+                "stream": {
+                    "codec_name": "aac",
+                    "profile": "lc",
+                    "sample_rate": "16000",
+                    "channels": 1,
+                }
+            },
+        )
+        if ".playback." in path.name
+        else (media_source.HLS_LEADING_AAC_BROKEN, {}),
+    )
     monkeypatch.setattr(
         media_source,
         "_categorize_hls_leading_segment",
@@ -2618,7 +2635,7 @@ def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback
     assert profile["leading_aac"] == media_source.HLS_LEADING_AAC_BROKEN
     assert profile["playback_mode"] == media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
     assert (playlist.parent / "segment_0002.ts").read_bytes() == b"bad-leading-audio"
-    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"video-only-sidecar"
+    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"silent-aac-sidecar"
     assert playlist.read_text(encoding="utf-8") == (
         "#EXTM3U\n"
         "#EXT-X-TARGETDURATION:4\n"
@@ -2639,9 +2656,9 @@ def test_recording_media_source_migrates_v2_hls_cache_in_place(
 ):
     from custom_components.xsense import recordings_media as media_source
 
-    def _broken_leading_profile(path):
+    def _broken_leading_profile(path, **kwargs):
         sidecar = media_source._hls_leading_playback_segment_path(path)
-        sidecar.write_bytes(b"video-only-sidecar")
+        sidecar.write_bytes(b"silent-aac-sidecar")
         return {
             "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
             "leading_segment": path.name,
@@ -2649,6 +2666,23 @@ def test_recording_media_source_migrates_v2_hls_cache_in_place(
             "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
         }
 
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (
+            media_source.HLS_LEADING_AAC_OK,
+            {
+                "stream": {
+                    "codec_name": "aac",
+                    "profile": "lc",
+                    "sample_rate": "16000",
+                    "channels": 1,
+                }
+            },
+        )
+        if ".playback." in path.name
+        else (media_source.HLS_LEADING_AAC_BROKEN, {}),
+    )
     monkeypatch.setattr(
         media_source,
         "_categorize_hls_leading_segment",
@@ -2680,7 +2714,7 @@ def test_recording_media_source_migrates_v2_hls_cache_in_place(
         playlist.parent / media_source.HLS_CACHE_VERSION_FILE
     ).read_text(encoding="utf-8").strip() == "3"
     assert (playlist.parent / "segment_0002.ts").read_bytes() == b"bad-leading-audio"
-    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"video-only-sidecar"
+    assert (playlist.parent / "segment_0002.playback.ts").read_bytes() == b"silent-aac-sidecar"
     assert "segment_0002.playback.ts" in playlist.read_text(encoding="utf-8")
 
 
@@ -2761,7 +2795,7 @@ def test_hls_playback_profile_migration_skips_completed_cache_dirs(
 ):
     from custom_components.xsense import recordings_media as media_source
 
-    def _ok_profile(path):
+    def _ok_profile(path, **kwargs):
         return {
             "leading_aac": media_source.HLS_LEADING_AAC_OK,
             "leading_segment": path.name,
@@ -2810,6 +2844,98 @@ def test_hls_playback_profile_migration_skips_completed_cache_dirs(
     assert (
         pending_dir / media_source.HLS_CACHE_VERSION_FILE
     ).read_text(encoding="utf-8").strip() == "3"
+
+
+def test_hls_leading_playback_segment_uses_silent_aac_from_reference(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    leading = tmp_path / "segment_0007.ts"
+    reference = tmp_path / "segment_0009.ts"
+    leading.write_bytes(b"broken-leading")
+    reference.write_bytes(b"good-audio-video")
+    playlist = tmp_path / "index.m3u8"
+    playlist.write_text(
+        "#EXTM3U\n#EXT-X-TARGETDURATION:4\n"
+        "segment_0007.ts\nsegment_0009.ts\n#EXT-X-ENDLIST\n"
+    )
+
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (
+            (
+                media_source.HLS_LEADING_AAC_BROKEN,
+                {"stream": {"codec_name": "aac", "profile": "unknown"}},
+            )
+            if path == leading
+            else (
+                media_source.HLS_LEADING_AAC_OK,
+                {
+                    "stream": {
+                        "codec_name": "aac",
+                        "profile": "lc",
+                        "sample_rate": "16000",
+                        "channels": 1,
+                    }
+                },
+            )
+        ),
+    )
+    commands = []
+
+    def _run(command, **kwargs):
+        commands.append(command)
+        sidecar = media_source._hls_leading_playback_segment_path(leading)
+        sidecar.write_bytes(b"silent-aac-sidecar")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(media_source.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(media_source.subprocess, "run", _run)
+
+    profile = media_source._categorize_hls_leading_segment(
+        leading,
+        playlist_path=playlist,
+    )
+
+    assert profile["reference_audio_segment"] == "segment_0009.ts"
+    assert profile["reference_audio"] == {
+        "sample_rate": 16000,
+        "channels": 1,
+    }
+    assert profile["leading_playback_segment"] == "segment_0007.playback.ts"
+    assert commands
+    command = commands[0]
+    assert "anullsrc=channel_layout=mono:sample_rate=16000" in command
+    assert command.count("-map") == 2
+    assert "-map" in command and "1:a:0" in command and "0:v:0" in command
+    assert "-c:a" in command and "aac" in command
+
+
+def test_hls_playback_profile_ready_rejects_video_only_sidecar(monkeypatch, tmp_path):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    sidecar = cache_dir / "segment_0007.playback.ts"
+    sidecar.write_bytes(b"video-only")
+    media_source._write_hls_playback_profile(
+        cache_dir,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+        },
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (media_source.HLS_LEADING_AAC_BROKEN, {}),
+    )
+
+    assert media_source._hls_playback_profile_ready(cache_dir) is False
 
 
 def test_recording_media_source_rejects_unversioned_hls_cache(


### PR DESCRIPTION
## Summary
- Fixes HLS browser playback for broken leading AAC segments (#271) by using a silent-AAC playback sidecar that matches the following segments audio layout, instead of the video-only sidecar in v1.4.17.3 that breaks hls.js/MSE.
- Reads AAC parameters from the first good following segment; regenerates existing v1.4.17.3 video-only sidecars on reload or migration.

## Test plan
- [x] 720 tests passed locally with `-p no:homeassistant`
- [x] Silent-AAC sidecar generation and v1.4.17.3 sidecar regeneration tests passed
- [x] Release metadata aligned for `1.4.17.4`
