### PR TITLE
Fix HTTP 500 on the recordings panel: don't run ffprobe on the event loop

### DIFF
--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -2376,6 +2376,12 @@ def _categorize_hls_leading_segment(
             segment_path
         ).name
         profile["playback_mode"] = HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
+        # The sidecar was just built and verified here, where blocking work is
+        # allowed. Record that so the readiness check never has to re-probe it:
+        # _hls_playback_profile_ready() runs on the event loop via the panel and
+        # play handlers, and an ffprobe there raises
+        # "Caught blocking call to sleep ... inside the event loop".
+        profile["leading_playback_verified"] = True
         LOGGER.debug(
             "X-Sense HLS leading segment categorized for silent-AAC playback: %s",
             {
@@ -2583,6 +2589,13 @@ def _finalize_hls_playback_profile(cache_dir: Path, state: dict[str, Any]) -> No
 
 
 def _hls_playback_profile_ready(cache_dir: Path) -> bool:
+    """Return whether a cached clip is ready to play.
+
+    This is reached from the event loop (panel build and play handler), so it must
+    not run ffprobe: HA raises "Caught blocking call ... inside the event loop" and
+    the request fails with HTTP 500. The sidecar is verified once at creation time
+    and recorded as leading_playback_verified, so a file check is sufficient here.
+    """
     profile = _read_hls_playback_profile(cache_dir)
     if not profile:
         return False
@@ -2594,8 +2607,11 @@ def _hls_playback_profile_ready(cache_dir: Path) -> bool:
     playback_path = cache_dir / playback_segment
     if not _path_ready(playback_path):
         return False
-    sidecar_aac, _probe = _probe_hls_ts_aac(playback_path)
-    return sidecar_aac == HLS_LEADING_AAC_OK
+    if profile.get("leading_playback_verified"):
+        return True
+    # Profile written by an older version: no verification flag. Accept the sidecar
+    # on presence rather than probing, and let the next regeneration stamp it.
+    return playback_path.stat().st_size > 0
 
 
 def _hls_playback_fields_for_clip(clip: dict[str, Any]) -> dict[str, str]:


### PR DESCRIPTION
## Problem

On v1.4.17.4 every request to `/api/xsense/recordings/panel` returns **HTTP 500**, so
the recordings panel cannot load at all. Playback requests fail the same way.

```
RuntimeError: Caught blocking call to sleep with args (0.001,) inside the event loop
by custom integration 'xsense' at custom_components/xsense/recordings_media.py, line 2123
```

Call chain:

```
http.py:419  get
  -> http.py:77   async_build_panel_data
    -> http.py:184  _async_build_panel_data_from_index
      -> recordings_media.py:2603  _hls_playback_fields_for_clip
        -> :2644  _hls_ready
          -> :2655  _hls_cache_ready_at
            -> :2597  _hls_playback_profile_ready
              -> :2123  _probe_hls_ts_aac  ->  subprocess.run(...)
```

`_hls_playback_profile_ready()` re-probes the playback sidecar with `ffprobe` to confirm
it has a valid AAC track. That function is reached from the event loop — both from the
panel handler and the play handler — and Home Assistant raises on blocking calls there,
so the request dies before returning anything.

`async_build_panel_data` calls `_hls_playback_fields_for_clip` once per clip, so building
the panel attempts one synchronous `ffprobe` per cached clip. On this install that is 85
clips, and the handler raised 130+ times in three minutes as the frontend retried.

The `ffprobe` itself is fast (~0.05 s) — this is the blocking-in-event-loop rule, not a
timeout.

## Fix

The sidecar is already built and validated in `_ensure_hls_playback_profile()`, which runs
where blocking work is allowed. Record that result in the profile and have the readiness
check read the flag instead of re-probing.

1. On successful sidecar creation, set `profile["leading_playback_verified"] = True`.
2. In `_hls_playback_profile_ready()`, return `True` when that flag is present.
3. For profiles written by earlier versions (no flag), accept the sidecar on presence and
   non-zero size rather than probing. The next regeneration stamps the flag.

No `subprocess` remains on the event-loop path.

## Testing

Home Assistant 2026.8.0, 85 cached clips, 70 with a broken leading AAC header.

Before the patch:

```
/api/xsense/recordings/panel                -> HTTP 500
/api/xsense/recordings/play/<...>           -> HTTP 500
RuntimeError: Caught blocking call ...      -> 130 occurrences in 3 min
```

After the patch:

```
/api/xsense/recordings/panel                -> HTTP 200
/api/xsense/recordings/play/<...>           -> HTTP 200
blocking-call errors added by both requests -> 0
```

Playback verified in Firefox 152: the previously failing clip now plays with no
`bufferAppendError`. The silent-AAC sidecar introduced in v1.4.17.4 is correct — the
regenerated segment probes as `aac 16000/1` + `h264`, matching the following segments
including stream order, and the playlist points at it.

## Notes

- Endpoint status alone is not a reliable success signal for this feature. Earlier
  versions returned HTTP 200 for clips that still threw `bufferAppendError` in the
  browser, so playback needs checking in a browser rather than with curl.
- One unrelated issue remains on this install: a 180-second clip
  (`<serial>_1786547428_1786547608`) returns `404 "X-Sense recording is not ready"`
  despite a valid sidecar, a correct `.xsense-hls-playback-profile.json` and a playlist
  that points at the sidecar. Not addressed here.
- Two clips have no playlist at all (7 s and 1 s durations) — truncated caches left over
  from v1.4.17.1 with a single segment and no profile. They just need clearing.
