### PR TITLE
Prepare v1.4.17.5 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17.4):
-  (e.g., 1.4.17.4)
+- **X-Sense-Integration Version** (z. B. 1.4.17.5):
+  (e.g., 1.4.17.5)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.17.5.md
+++ b/.github/release-notes/1.4.17.5.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.17.5
+
+### 📷 Recordings
+- Fixes the recordings panel and playback HTTP 500 on Home Assistant 2026.8+ caused by synchronous ffprobe calls on the event loop (#271, #275, thanks @Gren-95).
+- Stores `leading_playback_verified` in the HLS playback profile when the silent-AAC sidecar is built, so readiness checks never re-probe on panel load.
+- Keeps panel cached/ready state aligned with actual playback readiness without running migration or ffprobe during panel build.
+- Stops `_hls_playback_fields_for_clip()` from calling `_hls_ready()` on the event loop.
+- Accepts legacy v1.4.17.4 silent-AAC profiles via `reference_audio` metadata instead of treating any non-zero sidecar as ready, so v1.4.17.3 video-only sidecars stay pending until regeneration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.17.5](.github/release-notes/1.4.17.5.md)
 - [1.4.17.4](.github/release-notes/1.4.17.4.md)
 - [1.4.17.3](.github/release-notes/1.4.17.3.md)
 - [1.4.17.2](.github/release-notes/1.4.17.2.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17.4"
+PANEL_ASSET_VERSION = "1.4.17.5"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -31,7 +31,7 @@ from .recordings_media import (
     _clip_thumbnail_cache_path,
     _hls_playlist_cache_path,
     _hls_playback_fields_for_clip,
-    _hls_ready,
+    _hls_cache_playback_ready,
     _hls_attribute_uri,
     _local_media_url,
     _mp4_ready,
@@ -124,7 +124,7 @@ async def _async_build_panel_data_from_index(
             clip_path = _clip_cache_path(clip)
             thumb_path = _clip_thumbnail_cache_path(clip)
             mp4_cached = await source._async_mp4_ready(clip_path)
-            hls_cached = await source._async_hls_ready(clip)
+            hls_cached = await source._async_hls_cache_playback_ready(clip)
             if hls_cached and mp4_cached:
                 await source._async_cleanup_legacy_mp4_cache(clip)
                 mp4_cached = False
@@ -292,7 +292,7 @@ def build_panel_data(hass: HomeAssistant, index: dict[str, Any]) -> dict[str, An
             clip_path = _clip_cache_path(clip)
             thumb_path = _clip_thumbnail_cache_path(clip)
             mp4_cached = _mp4_ready(clip_path)
-            hls_cached = _hls_ready(clip)
+            hls_cached = _hls_cache_playback_ready(clip)
             clip_cached = mp4_cached or hls_cached
             thumb_cached = _path_ready(thumb_path)
             if clip_cached:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17.4",
+  "version": "1.4.17.5",
   "zeroconf": []
 }

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -1249,6 +1249,14 @@ class XSenseRecordingsMediaSource(MediaSource):
         """Return whether a cached HLS playlist and its media files are present."""
         return await self._async_file_job(_hls_ready, clip)
 
+    async def _async_hls_cache_present(self, clip: dict[str, Any]) -> bool:
+        """Return whether cached HLS files exist without upgrading them."""
+        return await self._async_file_job(_hls_cache_present, clip)
+
+    async def _async_hls_cache_playback_ready(self, clip: dict[str, Any]) -> bool:
+        """Return whether cached HLS is playback-ready without upgrading it."""
+        return await self._async_file_job(_hls_cache_playback_ready, clip)
+
     async def _async_cached_media_ready(self, clip: dict[str, Any]) -> bool:
         """Return whether cached MP4 or HLS media exists for a clip."""
         return await self._async_hls_ready(clip) or await self._async_mp4_ready(
@@ -2376,12 +2384,14 @@ def _categorize_hls_leading_segment(
             segment_path
         ).name
         profile["playback_mode"] = HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC
-        # The sidecar was just built and verified here, where blocking work is
-        # allowed. Record that so the readiness check never has to re-probe it:
-        # _hls_playback_profile_ready() runs on the event loop via the panel and
-        # play handlers, and an ffprobe there raises
-        # "Caught blocking call to sleep ... inside the event loop".
-        profile["leading_playback_verified"] = True
+        # The sidecar was just built here, where blocking work is allowed. Probe it
+        # once and record leading_playback_verified so _hls_playback_profile_ready()
+        # never re-probes on the event loop (panel/play handlers).
+        sidecar_path = _hls_leading_playback_segment_path(segment_path)
+        sidecar_aac, sidecar_probe = _probe_hls_ts_aac(sidecar_path)
+        profile["leading_playback_verified"] = sidecar_aac == HLS_LEADING_AAC_OK
+        if sidecar_probe:
+            profile["sidecar_probe"] = sidecar_probe
         LOGGER.debug(
             "X-Sense HLS leading segment categorized for silent-AAC playback: %s",
             {
@@ -2530,6 +2540,20 @@ def _migrate_hls_cache_dir(cache_dir: Path) -> str:
 def _ensure_hls_playback_profile(cache_dir: Path, playlist_path: Path) -> bool:
     """Probe a cached clip in place and add playback metadata when missing."""
     profile = _read_hls_playback_profile(cache_dir)
+    if profile and profile.get("leading_aac") == HLS_LEADING_AAC_BROKEN:
+        playback_segment = str(profile.get("leading_playback_segment") or "")
+        playback_path = cache_dir / playback_segment if playback_segment else None
+        if (
+            playback_path is not None
+            and _path_ready(playback_path)
+            and not profile.get("leading_playback_verified")
+        ):
+            sidecar_aac, sidecar_probe = _probe_hls_ts_aac(playback_path)
+            if sidecar_aac == HLS_LEADING_AAC_OK:
+                profile["leading_playback_verified"] = True
+                if sidecar_probe:
+                    profile["sidecar_probe"] = sidecar_probe
+                _write_hls_playback_profile(cache_dir, profile)
     if profile and _hls_playback_profile_ready(cache_dir):
         if _hls_cache_version_value(cache_dir) != str(HLS_CACHE_VERSION):
             _write_hls_cache_version(cache_dir)
@@ -2609,16 +2633,17 @@ def _hls_playback_profile_ready(cache_dir: Path) -> bool:
         return False
     if profile.get("leading_playback_verified"):
         return True
-    # Profile written by an older version: no verification flag. Accept the sidecar
-    # on presence rather than probing, and let the next regeneration stamp it.
-    return playback_path.stat().st_size > 0
+    # 1.4.17.4 silent-AAC profiles written before the verification flag existed.
+    # reference_audio distinguishes them from 1.4.17.3 video-only sidecars.
+    return bool(profile.get("reference_audio"))
 
 
 def _hls_playback_fields_for_clip(clip: dict[str, Any]) -> dict[str, str]:
     """Return playback profile fields exposed to the recordings panel."""
-    if not _hls_ready(clip):
+    playlist_path = _hls_playlist_cache_path(clip)
+    if not _path_ready(playlist_path):
         return {}
-    profile = _read_hls_playback_profile(_hls_playlist_cache_path(clip).parent)
+    profile = _read_hls_playback_profile(playlist_path.parent)
     leading_aac = str(profile.get("leading_aac") or "")
     playback_mode = str(profile.get("playback_mode") or "")
     if not leading_aac:
@@ -2658,6 +2683,33 @@ def _mp4_ready(path: Path) -> bool:
 def _hls_ready(clip: dict[str, Any]) -> bool:
     playlist_path = _hls_playlist_cache_path(clip)
     return _hls_cache_ready_at(playlist_path.parent, playlist_path)
+
+
+def _hls_cache_present(clip: dict[str, Any]) -> bool:
+    playlist_path = _hls_playlist_cache_path(clip)
+    return _hls_cache_present_at(playlist_path.parent, playlist_path)
+
+
+def _hls_cache_present_at(cache_dir: Path, playlist_path: Path) -> bool:
+    """Return whether cached HLS files exist without running probes or migration."""
+    if not _hls_cache_version_supported(cache_dir):
+        return False
+    return _hls_playlist_ready(playlist_path)
+
+
+def _hls_cache_playback_ready(clip: dict[str, Any]) -> bool:
+    playlist_path = _hls_playlist_cache_path(clip)
+    return _hls_cache_playback_ready_at(playlist_path.parent, playlist_path)
+
+
+def _hls_cache_playback_ready_at(cache_dir: Path, playlist_path: Path) -> bool:
+    """Return whether cached HLS is playback-ready without probes or migration."""
+    if not _hls_cache_present_at(cache_dir, playlist_path):
+        return False
+    profile = _read_hls_playback_profile(cache_dir)
+    if not profile:
+        return False
+    return _hls_playback_profile_ready(cache_dir)
 
 
 def _hls_cache_ready_at(cache_dir: Path, playlist_path: Path) -> bool:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -2528,6 +2528,7 @@ def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback
             "leading_segment": path.name,
             "leading_playback_segment": sidecar.name,
             "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "leading_playback_verified": True,
         }
 
     monkeypatch.setattr(
@@ -2650,6 +2651,270 @@ def test_recording_media_source_prepares_broken_leading_hls_segment_for_playback
     }
 
 
+def test_ensure_hls_playback_profile_backfills_leading_playback_verified(monkeypatch, tmp_path):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    sidecar = cache_dir / "segment_0007.playback.ts"
+    sidecar.write_bytes(b"silent-aac")
+    playlist.write_text(
+        "#EXTM3U\nsegment_0007.playback.ts\n#EXT-X-DISCONTINUITY\nsegment_0009.ts\n"
+    )
+    (cache_dir / "segment_0009.ts").write_bytes(b"good")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    media_source._write_hls_playback_profile(
+        cache_dir,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_segment": "segment_0007.ts",
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "reference_audio": {"sample_rate": 16000, "channels": 1},
+        },
+    )
+    ffmpeg_calls = []
+
+    def _fail_ffmpeg(*args, **kwargs):
+        ffmpeg_calls.append(args)
+        raise AssertionError("ffmpeg must not run when sidecar already probes OK")
+
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (
+            media_source.HLS_LEADING_AAC_OK,
+            {
+                "stream": {
+                    "codec_name": "aac",
+                    "profile": "lc",
+                    "sample_rate": "16000",
+                    "channels": 1,
+                }
+            },
+        ),
+    )
+    monkeypatch.setattr(media_source.subprocess, "run", _fail_ffmpeg)
+
+    assert media_source._ensure_hls_playback_profile(cache_dir, playlist)
+    profile = media_source._read_hls_playback_profile(cache_dir)
+    assert profile["leading_playback_verified"] is True
+    assert ffmpeg_calls == []
+
+
+def test_hls_cache_present_does_not_run_migration(monkeypatch, tmp_path):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    playlist.write_text("#EXTM3U\nsegment_0001.ts\n")
+    (cache_dir / "segment_0001.ts").write_bytes(b"segment")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_ensure_hls_playback_profile",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("_ensure_hls_playback_profile must not run")
+        ),
+    )
+
+    assert media_source._hls_cache_present(clip)
+
+
+def test_hls_cache_playback_ready_requires_persisted_profile(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    playlist.write_text("#EXTM3U\nsegment_0001.ts\n")
+    (cache_dir / "segment_0001.ts").write_bytes(b"segment")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_ensure_hls_playback_profile",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("_ensure_hls_playback_profile must not run")
+        ),
+    )
+
+    assert media_source._hls_cache_present(clip)
+    assert not media_source._hls_cache_playback_ready(clip)
+
+
+def test_hls_cache_playback_ready_rejects_incomplete_sidecar_profile(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    sidecar = cache_dir / "segment_0007.playback.ts"
+    sidecar.write_bytes(b"video-only")
+    playlist.write_text(
+        "#EXTM3U\nsegment_0007.playback.ts\n#EXT-X-DISCONTINUITY\nsegment_0009.ts\n"
+    )
+    (cache_dir / "segment_0009.ts").write_bytes(b"good")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    media_source._write_hls_playback_profile(
+        cache_dir,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+        },
+    )
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (_ for _ in ()).throw(
+            AssertionError("_probe_hls_ts_aac must not run on panel readiness checks")
+        ),
+    )
+
+    assert media_source._hls_cache_present(clip)
+    assert not media_source._hls_cache_playback_ready(clip)
+
+
+def test_hls_cache_playback_ready_accepts_legacy_silent_aac_profile(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    sidecar = cache_dir / "segment_0007.playback.ts"
+    sidecar.write_bytes(b"silent-aac")
+    playlist.write_text(
+        "#EXTM3U\nsegment_0007.playback.ts\n#EXT-X-DISCONTINUITY\nsegment_0009.ts\n"
+    )
+    (cache_dir / "segment_0009.ts").write_bytes(b"good")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    media_source._write_hls_playback_profile(
+        cache_dir,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "reference_audio": {"sample_rate": 16000, "channels": 1},
+        },
+    )
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (_ for _ in ()).throw(
+            AssertionError("_probe_hls_ts_aac must not run on panel readiness checks")
+        ),
+    )
+
+    assert media_source._hls_cache_playback_ready(clip)
+
+
+def test_hls_cache_playback_ready_accepts_persisted_verification_flag(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    cache_dir = tmp_path / "clip"
+    cache_dir.mkdir()
+    playlist = cache_dir / "index.m3u8"
+    sidecar = cache_dir / "segment_0007.playback.ts"
+    sidecar.write_bytes(b"silent-aac")
+    playlist.write_text(
+        "#EXTM3U\nsegment_0007.playback.ts\n#EXT-X-DISCONTINUITY\nsegment_0009.ts\n"
+    )
+    (cache_dir / "segment_0009.ts").write_bytes(b"good")
+    (cache_dir / media_source.HLS_CACHE_VERSION_FILE).write_text("3\n")
+    media_source._write_hls_playback_profile(
+        cache_dir,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_playback_segment": sidecar.name,
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "leading_playback_verified": True,
+        },
+    )
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+    monkeypatch.setattr(
+        media_source,
+        "_probe_hls_ts_aac",
+        lambda path: (_ for _ in ()).throw(
+            AssertionError("_probe_hls_ts_aac must not run on panel readiness checks")
+        ),
+    )
+
+    assert media_source._hls_cache_playback_ready(clip)
+
+
 def test_recording_media_source_migrates_v2_hls_cache_in_place(
     monkeypatch,
     tmp_path,
@@ -2664,6 +2929,7 @@ def test_recording_media_source_migrates_v2_hls_cache_in_place(
             "leading_segment": path.name,
             "leading_playback_segment": sidecar.name,
             "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "leading_playback_verified": True,
         }
 
     monkeypatch.setattr(
@@ -2914,7 +3180,7 @@ def test_hls_leading_playback_segment_uses_silent_aac_from_reference(
     assert "-c:a" in command and "aac" in command
 
 
-def test_hls_playback_profile_ready_rejects_video_only_sidecar(monkeypatch, tmp_path):
+def test_hls_playback_profile_ready_rejects_video_only_sidecar(tmp_path):
     from custom_components.xsense import recordings_media as media_source
 
     cache_dir = tmp_path / "clip"
@@ -2929,13 +3195,58 @@ def test_hls_playback_profile_ready_rejects_video_only_sidecar(monkeypatch, tmp_
             "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
         },
     )
-    monkeypatch.setattr(
-        media_source,
-        "_probe_hls_ts_aac",
-        lambda path: (media_source.HLS_LEADING_AAC_BROKEN, {}),
-    )
 
     assert media_source._hls_playback_profile_ready(cache_dir) is False
+
+
+def test_hls_playback_fields_for_clip_reads_profile_without_subprocess(
+    monkeypatch,
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    def _fail_subprocess(*args, **kwargs):
+        raise AssertionError("subprocess must not run on panel profile reads")
+
+    monkeypatch.setattr(media_source.subprocess, "run", _fail_subprocess)
+    monkeypatch.setattr(
+        media_source,
+        "_hls_ready",
+        lambda clip: (_ for _ in ()).throw(
+            AssertionError("_hls_ready must not run on panel profile reads")
+        ),
+    )
+
+    playlist = tmp_path / "hls" / "index.m3u8"
+    playlist.parent.mkdir(parents=True)
+    playlist.write_text("#EXTM3U\nsegment_0001.ts\n")
+    (playlist.parent / "segment_0001.ts").write_bytes(b"segment")
+    media_source._write_hls_playback_profile(
+        playlist.parent,
+        {
+            "leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+            "leading_playback_segment": "segment_0001.playback.ts",
+            "playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+            "leading_playback_verified": True,
+        },
+    )
+    clip = {
+        "entry_id": "entry-id",
+        "serial": "CAMERA-SN",
+        "start": 1782049304,
+        "end": 1782049334,
+        "media_root": tmp_path.as_posix(),
+    }
+    monkeypatch.setattr(
+        media_source,
+        "_hls_playlist_cache_path",
+        lambda current_clip: playlist,
+    )
+
+    assert media_source._hls_playback_fields_for_clip(clip) == {
+        "hls_leading_aac": media_source.HLS_LEADING_AAC_BROKEN,
+        "hls_playback_mode": media_source.HLS_PLAYBACK_MODE_IGNORE_LEADING_AAC,
+    }
 
 
 def test_recording_media_source_rejects_unversioned_hls_cache(

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -2674,7 +2674,7 @@ def test_recordings_panel_data_prefers_hls_over_legacy_mp4(monkeypatch):
 
     monkeypatch.setattr(http, "_path_ready", lambda path: False)
     monkeypatch.setattr(http, "_mp4_ready", lambda path: True)
-    monkeypatch.setattr(http, "_hls_ready", lambda clip: True)
+    monkeypatch.setattr(http, "_hls_cache_playback_ready", lambda clip: True)
     monkeypatch.setattr(http, "_file_size", lambda path: 123)
     monkeypatch.setattr(http, "_directory_size", lambda path: 777)
     hass = _recordings_panel_test_hass(


### PR DESCRIPTION
## Summary
- Builds on merged #275 (@Gren-95): stops synchronous ffprobe on the event loop that caused HTTP 500 on the recordings panel and playback endpoints.
- Hardens the panel path: cached/ready state uses read-only playback readiness checks without migration or ffprobe during panel build.
- Stops `_hls_playback_fields_for_clip()` from calling `_hls_ready()` on the event loop.
- Probes and stores `leading_playback_verified` when sidecars are created; legacy v1.4.17.4 silent-AAC profiles are accepted via `reference_audio` metadata.

## Test plan
- [x] `pytest` — 727 passed
- [ ] Update to v1.4.17.5 on HA 2026.8+ and confirm `/api/xsense/recordings/panel` returns HTTP 200
- [ ] Confirm playback works in browser for clips with broken leading AAC (#271)
- [ ] Confirm panel only marks clips cached/ready when playback profile is complete
