### PR TITLE
Prepare v1.4.17.6 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17.5):
-  (e.g., 1.4.17.5)
+- **X-Sense-Integration Version** (z. B. 1.4.17.6):
+  (e.g., 1.4.17.6)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.17.6.md
+++ b/.github/release-notes/1.4.17.6.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.17.6
+
+### 🔐 Authentication
+- Fixes `403 Forbidden` errors retrieving station data (`Unable to retrieve station data: 403/...`) when the Home Assistant host clock is wrong, which commonly happens on a Raspberry Pi right after a reboot before NTP resyncs.
+- The AWS SigV4 request signer now learns the clock-skew offset from the server `Date` response header and applies it to every subsequent signature, matching the AWS SDK behaviour in the X-Sense app. A skewed host clock no longer permanently breaks station data; the integration self-corrects and retries.
+- Logs a warning pointing at host NTP time sync when a large skew is detected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.17.6](.github/release-notes/1.4.17.6.md)
 - [1.4.17.5](.github/release-notes/1.4.17.5.md)
 - [1.4.17.4](.github/release-notes/1.4.17.4.md)
 - [1.4.17.3](.github/release-notes/1.4.17.3.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17.5"
+PANEL_ASSET_VERSION = "1.4.17.6"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17.5",
+  "version": "1.4.17.6",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -938,6 +938,7 @@ class AsyncXSense(XSenseBase):
         async with session.get(url, headers=headers) as response:
             self._lastres = response
             if response.status in (401, 403) and _retry:
+                self._apply_clock_skew_from_response(response)
                 await self.load_aws()
                 return await self.get_house(house, page, _retry=False)
             return await response.json()
@@ -952,6 +953,7 @@ class AsyncXSense(XSenseBase):
         async with session.get(url, headers=headers) as response:
             self._lastres = response
             if response.status in (401, 403) and _retry:
+                self._apply_clock_skew_from_response(response)
                 await self.load_aws()
                 return await self.get_thing(station, page, _retry=False)
             return await response.json()
@@ -974,6 +976,7 @@ class AsyncXSense(XSenseBase):
                 and self.signer is not None
                 and self.aws_access_expiry is not None
             ):
+                self._apply_clock_skew_from_response(response)
                 await self.load_aws()
                 return await self.do_thing(station, page, data, _retry=False)
             if response.status >= 400:

--- a/custom_components/xsense/python_xsense/aws_signer.py
+++ b/custom_components/xsense/python_xsense/aws_signer.py
@@ -7,6 +7,33 @@ from typing import Dict
 from urllib.parse import parse_qsl, quote, urlencode, urlsplit
 
 
+# Seconds to subtract from the local clock when stamping AWS SigV4 requests.
+# Mirrors the AWS Android SDK's SDKGlobalConfiguration.getGlobalTimeOffset():
+# when AWS IoT rejects a signature because the host clock is skewed (a common
+# situation right after a Raspberry Pi reboots before NTP resyncs), the offset
+# between the local clock and the server "Date" header is learned once and
+# applied to every subsequent signature so requests stop failing with 403.
+_GLOBAL_TIME_OFFSET_SECONDS = 0.0
+
+
+def get_global_time_offset() -> float:
+    """Return the learned clock-skew offset in seconds (local minus server)."""
+    return _GLOBAL_TIME_OFFSET_SECONDS
+
+
+def set_global_time_offset(seconds: float) -> None:
+    """Store the learned clock-skew offset applied to future signatures."""
+    global _GLOBAL_TIME_OFFSET_SECONDS
+    _GLOBAL_TIME_OFFSET_SECONDS = seconds
+
+
+def signing_now() -> datetime.datetime:
+    """Return the current UTC time corrected by the learned clock-skew offset."""
+    return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=_GLOBAL_TIME_OFFSET_SECONDS
+    )
+
+
 class AWSSigner:
     algorithm = 'AWS4-HMAC-SHA256'
     service = 'iotdata'
@@ -79,7 +106,7 @@ class AWSSigner:
         parsed_url = urlsplit(url)
 
         result = {'host': parsed_url.netloc}
-        t = datetime.datetime.now(datetime.timezone.utc)
+        t = signing_now()
         amz_date = t.strftime('%Y%m%dT%H%M%SZ')
         date_stamp = t.strftime('%Y%m%d')
 
@@ -113,7 +140,7 @@ class AWSSigner:
         return result
 
     def presign_url(self, url, region):
-        t = datetime.datetime.now(datetime.timezone.utc)
+        t = signing_now()
         date_time = t.strftime('%Y%m%dT%H%M%SZ')
         date_stamp = t.strftime('%Y%m%d')
         credential_scope = f'{date_stamp}/{region}/{self.service}/aws4_request'

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -3,7 +3,9 @@ import binascii
 import hashlib
 import hmac
 import json
+import logging
 from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from typing import Dict
 
 import boto3
@@ -11,11 +13,19 @@ from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 from pycognito import AWSSRP
 
+from .aws_signer import get_global_time_offset, set_global_time_offset
 from .entity import Entity
 from .entity_map import entities
 from .exceptions import APIFailure, AuthFailed
 from .station import Station
 from .house import House
+
+LOGGER = logging.getLogger(__name__)
+
+# Ignore sub-minute differences: AWS SigV4 tolerates a few minutes of skew, so
+# only a genuinely wrong host clock (post-reboot, NTP not yet synced) needs the
+# correction. This keeps a normal 403 (e.g. bad credentials) on the same path.
+_CLOCK_SKEW_THRESHOLD_SECONDS = 60
 
 
 def _mac_json(value) -> str:
@@ -203,6 +213,43 @@ class XSenseBase:
 
     def _aws_token_expiring(self):
         return datetime.now(timezone.utc) > self.aws_access_expiry - timedelta(seconds=60)
+
+    def _apply_clock_skew_from_response(self, response) -> bool:
+        """Learn the host clock-skew offset from an AWS response Date header.
+
+        AWS IoT returns 403 when the SigV4 X-Amz-Date is outside its tolerance,
+        which happens when the Home Assistant host clock is wrong (commonly right
+        after a reboot before NTP resyncs). The server tells us the real time in
+        the Date header; we store the offset so every later signature is stamped
+        with the corrected time, matching the AWS Android SDK behaviour in the
+        X-Sense app. Returns True when a meaningful correction was applied.
+        """
+        headers = getattr(response, 'headers', None)
+        if not headers:
+            return False
+        server_date_raw = headers.get('Date')
+        if not server_date_raw:
+            return False
+        try:
+            server_date = parsedate_to_datetime(server_date_raw)
+        except (TypeError, ValueError):
+            return False
+        if server_date is None:
+            return False
+        if server_date.tzinfo is None:
+            server_date = server_date.replace(tzinfo=timezone.utc)
+        offset = (datetime.now(timezone.utc) - server_date).total_seconds()
+        if abs(offset) < _CLOCK_SKEW_THRESHOLD_SECONDS:
+            return False
+        if abs(offset - get_global_time_offset()) < 1:
+            return False
+        set_global_time_offset(offset)
+        LOGGER.warning(
+            'Corrected AWS request signing clock skew of %d seconds from server '
+            'Date header; check NTP time sync on the Home Assistant host.',
+            int(offset),
+        )
+        return True
 
     def _decode_secret(self, encoded):
         value = base64.b64decode(encoded)

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1,5 +1,6 @@
 import base64
 from collections import defaultdict
+from datetime import timedelta
 import hashlib
 import importlib
 import json
@@ -18,6 +19,7 @@ def load_api_module(module_name: str):
 
 async_xsense = load_api_module("async_xsense")
 base = importlib.import_module("custom_components.xsense.python_xsense.base")
+aws_signer = load_api_module("aws_signer")
 entity = load_api_module("entity")
 device_module = load_api_module("device")
 entity_map = load_api_module("entity_map")
@@ -2674,6 +2676,135 @@ async def test_do_thing_raises_on_shadow_update_failure():
             "2nd_selftest_device-sn",
             {"state": {"desired": {"a": 1}}},
         )
+
+
+class FakeGetResponse:
+    def __init__(self, status: int, headers: dict, payload: dict) -> None:
+        self.status = status
+        self.headers = headers
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+class FakeGetSession:
+    def __init__(self, responses) -> None:
+        self._responses = list(responses)
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append({"url": url, "headers": headers})
+        return self._responses.pop(0)
+
+
+def test_aws_signer_applies_global_time_offset():
+    signer = aws_signer.AWSSigner("client-id", "client-secret", "token")
+    try:
+        aws_signer.set_global_time_offset(0)
+        baseline = signer.sign_headers(
+            "GET", "https://example.invalid/things/x/shadow", "us-east-1", {}, None
+        )["X-Amz-Date"]
+
+        aws_signer.set_global_time_offset(-7200)
+        shifted = signer.sign_headers(
+            "GET", "https://example.invalid/things/x/shadow", "us-east-1", {}, None
+        )["X-Amz-Date"]
+    finally:
+        aws_signer.set_global_time_offset(0)
+
+    baseline_dt = async_xsense.datetime.strptime(baseline, "%Y%m%dT%H%M%SZ")
+    shifted_dt = async_xsense.datetime.strptime(shifted, "%Y%m%dT%H%M%SZ")
+    # A -7200s offset means the signer stamps two hours ahead of the raw clock.
+    assert 7100 <= (shifted_dt - baseline_dt).total_seconds() <= 7300
+
+
+def test_apply_clock_skew_from_response_learns_offset():
+    from email.utils import format_datetime
+
+    client = async_xsense.AsyncXSense()
+    server_date = async_xsense.datetime.now(async_xsense.timezone.utc) - timedelta(
+        hours=2
+    )
+    response = FakeGetResponse(403, {"Date": format_datetime(server_date)}, {})
+    try:
+        aws_signer.set_global_time_offset(0)
+        applied = client._apply_clock_skew_from_response(response)
+        offset = aws_signer.get_global_time_offset()
+    finally:
+        aws_signer.set_global_time_offset(0)
+
+    assert applied is True
+    assert 7100 <= offset <= 7300
+
+
+def test_apply_clock_skew_ignores_small_offset():
+    from email.utils import format_datetime
+
+    client = async_xsense.AsyncXSense()
+    server_date = async_xsense.datetime.now(async_xsense.timezone.utc)
+    response = FakeGetResponse(403, {"Date": format_datetime(server_date)}, {})
+    try:
+        aws_signer.set_global_time_offset(0)
+        applied = client._apply_clock_skew_from_response(response)
+        offset = aws_signer.get_global_time_offset()
+    finally:
+        aws_signer.set_global_time_offset(0)
+
+    assert applied is False
+    assert offset == 0
+
+
+@pytest.mark.asyncio
+async def test_get_thing_corrects_clock_skew_and_retries():
+    from email.utils import format_datetime
+
+    client = async_xsense.AsyncXSense()
+    client._aws_token_expiring = lambda: False
+
+    server_date = async_xsense.datetime.now(async_xsense.timezone.utc) - timedelta(
+        hours=2
+    )
+    session = FakeGetSession(
+        [
+            FakeGetResponse(403, {"Date": format_datetime(server_date)}, {}),
+            FakeGetResponse(200, {}, {"state": {"reported": {"ok": True}}}),
+        ]
+    )
+
+    async def get_session():
+        return session
+
+    client._get_session = get_session
+    client._thing_request = lambda station, page: ("https://example.invalid", {})
+
+    load_aws_calls = []
+
+    async def load_aws():
+        load_aws_calls.append(True)
+
+    client.load_aws = load_aws
+
+    try:
+        aws_signer.set_global_time_offset(0)
+        result = await client.get_thing(FakeXSenseStation("SBS50"), "2nd_mainpage")
+        offset = aws_signer.get_global_time_offset()
+    finally:
+        aws_signer.set_global_time_offset(0)
+
+    assert result == {"state": {"reported": {"ok": True}}}
+    assert len(session.calls) == 2
+    assert len(load_aws_calls) == 1
+    assert 7100 <= offset <= 7300
 
 
 async def _capture_volume_update(client, target, volume_key, volume):


### PR DESCRIPTION
## Summary
- Fixes `403 Forbidden` on station data retrieval (`Unable to retrieve station data: 403/...`) caused by AWS SigV4 clock skew when the Home Assistant host clock is wrong — commonly a Raspberry Pi right after reboot before NTP resyncs.
- The signer now learns the clock-skew offset from the server `Date` response header on a 401/403 and applies it to every subsequent signature, then retries. This mirrors the AWS Android SDK behaviour in the X-Sense app (verified against APK 1.4.0 / app code `1400`: `AbstractAWSSigner.getTimeOffset`, `AWS4Signer.getDateFromRequest`, `AmazonHttpClient.parseClockSkewOffset`, `SDKGlobalConfiguration` global offset).
- Sub-minute differences are ignored so a genuine 403 (bad credentials, correct clock) is unaffected. Logs a warning pointing at host NTP time sync.

## Test plan
- [x] `pytest` — 731 passed (4 new: signer offset, skew learning, small-offset ignore, get_thing correct-and-retry)
- [ ] On a host with a deliberately skewed clock, confirm station data loads (self-corrects) instead of a permanent 403
- [ ] Confirm normal operation with a correct clock is unchanged
