### PR TITLE
docs: document HACS pre-release switch-entity steps

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -18,6 +18,21 @@ If Home Assistant does not show an update immediately:
 4. Update or redownload the integration.
 5. Restart Home Assistant.
 
+## Installing a Pre-release
+
+Pre-release (beta) builds are published as GitHub pre-releases. HACS 2.0 removed
+the old "Show beta versions" toggle from the download dialog. To receive a
+pre-release you must enable the repository's pre-release **switch entity**:
+
+1. In Home Assistant, go to **Settings → Devices & Services → Entities**.
+2. Search for the X-Sense HACS **pre-release** switch. It is disabled by
+   default, so enable the entity first, then wait ~30 seconds for it to appear.
+3. Turn the switch **on** so HACS includes pre-releases in update checks.
+4. Open HACS, select the X-Sense repository, and use the three-dot menu to run
+   **Update information**.
+5. **Redownload** (or Update) and select the pre-release version, then restart
+   Home Assistant.
+
 ## Entity Changes
 
 Entity changes that can affect dashboards or automations are tracked in [X-Sense Entity Changes](ENTITY_CHANGES.md).


### PR DESCRIPTION
Documents the HACS 2.0 pre-release switch-entity method in UPDATING.md (the old download-dialog beta toggle was removed). Docs-only, no version bump.

Made with [Cursor](https://cursor.com)