### PR TITLE
Release v1.4.18

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.17.6):
-  (e.g., 1.4.17.6)
+- **X-Sense-Integration Version** (z. B. 1.4.18):
+  (e.g., 1.4.18)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.18.md
+++ b/.github/release-notes/1.4.18.md
@@ -1,0 +1,17 @@
+## X-Sense Home Security v1.4.18
+
+This release brings the v1.4.17.1 through v1.4.17.6 pre-releases to the main release channel.
+
+### 📷 Recordings
+- Fixes browser playback of cached HLS recordings when the first segment has broken AAC metadata (#271), including the silent-AAC leading playback sidecar that matches the following segments' audio layout.
+- Upgrades existing HLS caches in place on integration load with a resumable background migration — no re-download required for already cached clips.
+- Fixes the recordings panel and playback HTTP 500 on Home Assistant 2026.8+ caused by synchronous ffprobe calls on the event loop (#275, thanks @Gren-95).
+- Keeps panel cached/ready state aligned with actual playback readiness without running migration or ffprobe during panel build.
+- Preserves X-Sense HLS recording segments as downloaded and clears stale caches from earlier pre-release generations when a safer replacement is ready.
+
+### 🔐 Authentication
+- Fixes `403 Forbidden` errors retrieving station data when the Home Assistant host clock is wrong, which commonly happens on a Raspberry Pi right after a reboot before NTP resyncs (#279).
+- The AWS SigV4 request signer now learns the clock-skew offset from the server `Date` response header and applies it to every subsequent signature, matching the AWS SDK behaviour in the X-Sense app.
+
+### 🧪 Devices
+- Restores the reported **Test Active** diagnostic entity when X-Sense provides the device test state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.18](.github/release-notes/1.4.18.md)
 - [1.4.17.6](.github/release-notes/1.4.17.6.md)
 - [1.4.17.5](.github/release-notes/1.4.17.5.md)
 - [1.4.17.4](.github/release-notes/1.4.17.4.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.17.6"
+PANEL_ASSET_VERSION = "1.4.18"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.17.6",
+  "version": "1.4.18",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- Rolls up v1.4.17.1 through v1.4.17.6 pre-releases into the main release channel as **v1.4.18**.
- HLS recording playback fixes (#271), panel HTTP 500 fix (#275), and AWS clock-skew 403 fix (#279) are now available as a normal HACS update without enabling pre-releases.

## Test plan
- [x] Code unchanged since v1.4.17.6 — version bump and release notes only
- [ ] Confirm GitHub Actions publishes v1.4.18 as **Latest** (not pre-release)
- [ ] HACS update path shows v1.4.18 without the pre-release switch
