### PR TITLE
Prepare v1.4.18.1 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.18):
-  (e.g., 1.4.18)
+- **X-Sense-Integration Version** (z. B. 1.4.18.1):
+  (e.g., 1.4.18.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.18.1.md
+++ b/.github/release-notes/1.4.18.1.md
@@ -1,0 +1,11 @@
+## X-Sense Home Security v1.4.18.1
+
+### Cameras
+- Improves camera access for accounts with more than one X-Sense Home by using the camera's own ADDX Home/node context when requesting camera data and WebRTC tickets.
+- Preserves exact ADDX camera serial metadata returned by X-Sense so camera requests use the same identity the app provides.
+- Keeps existing camera data available if one camera Home/node request fails while another succeeds.
+
+### Alarm Panel
+- Adds a force-arm confirmation path for SBS50 systems when X-Sense refuses a normal arm request because a sensor is open.
+- Uses the originally requested Home/Away mode for force-arm confirmation instead of falling back to the current alarm mode.
+- Clears the force-arm prompt after the request succeeds, is cancelled, or the system is disarmed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.18.1](.github/release-notes/1.4.18.1.md)
 - [1.4.18](.github/release-notes/1.4.18.md)
 - [1.4.17.6](.github/release-notes/1.4.17.6.md)
 - [1.4.17.5](.github/release-notes/1.4.17.5.md)

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import json
 import logging
+from urllib.parse import quote
 
+from homeassistant.components import persistent_notification
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
@@ -27,6 +28,7 @@ SAFEMODE_TO_STATE: dict[str, AlarmControlPanelState] = {
     "Home": AlarmControlPanelState.ARMED_HOME,
     "Away": AlarmControlPanelState.ARMED_AWAY,
 }
+FORCE_ARM_NOTIFICATION_ID_PREFIX = "xsense_force_arm_"
 
 
 async def async_setup_entry(
@@ -72,6 +74,19 @@ def station_supports_alarm_panel(station) -> bool:
     )
 
 
+def pending_force_arm_mode(station) -> str | None:
+    """Return the arm mode waiting for app-style force-arm confirmation."""
+    alarm_data = getattr(station, "alarm_data", {}) or {}
+    force_reason = alarm_data.get("forceReason")
+    if not force_reason:
+        return None
+
+    mode = alarm_data.get("safeModeAim") or alarm_data.get("safeMode")
+    if mode in ("Home", "Away"):
+        return mode
+    return None
+
+
 class XSenseAlarmControlPanel(
     CoordinatorEntity[XSenseDataUpdateCoordinator],
     AlarmControlPanelEntity,
@@ -98,6 +113,7 @@ class XSenseAlarmControlPanel(
         """Initialize the entity."""
         super().__init__(coordinator)
         self._station_id = station.entity_id
+        self._entry_id = getattr(getattr(coordinator, "entry", None), "entry_id", "")
         self._attr_unique_id = f"{station.sn}_alarm"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, station.entity_id)},
@@ -106,6 +122,7 @@ class XSenseAlarmControlPanel(
             "model": station.type,
         }
         self._safemode: str | None = None
+        self._pending_force_arm_mode: str | None = None
 
     @property
     def _station(self):
@@ -126,14 +143,44 @@ class XSenseAlarmControlPanel(
         """Return the current alarm state."""
         return SAFEMODE_TO_STATE.get(self._safemode)
 
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        """Return SBS50 bypass confirmation details."""
+        station = self._station
+        if station is None:
+            return None
+
+        mode = pending_force_arm_mode(station)
+        if mode is None:
+            return None
+
+        alarm_data = getattr(station, "alarm_data", {}) or {}
+        force_reason = alarm_data.get("forceReason")
+        return {
+            "force_arm_pending": True,
+            "force_arm_mode": mode,
+            "force_reason_count": len(force_reason)
+            if isinstance(force_reason, list)
+            else None,
+        }
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated coordinator data."""
         station = self._station
         if station is None:
             self._safemode = None
+            self._async_clear_force_arm_notification()
             self.async_write_ha_state()
             return
+
+        pending_mode = pending_force_arm_mode(station)
+        if pending_mode != self._pending_force_arm_mode:
+            self._pending_force_arm_mode = pending_mode
+            if pending_mode is None:
+                self._async_clear_force_arm_notification()
+            else:
+                self._async_create_force_arm_notification(station, pending_mode)
 
         safemode = getattr(station, "safe_mode", None)
         if safemode is None:
@@ -150,6 +197,49 @@ class XSenseAlarmControlPanel(
 
         self.async_write_ha_state()
 
+    @callback
+    def _async_create_force_arm_notification(self, station, safe_mode: str) -> None:
+        """Create/update the HA notification for an SBS50 bypass prompt."""
+        button_name = f"Force Arm {safe_mode}"
+        action_url = self._force_arm_url(safe_mode)
+        persistent_notification.async_create(
+            self.hass,
+            (
+                "One or more sensors are open.\n\n"
+                f"[**{button_name}**]({action_url})\n\n"
+                "This sends the guarded X-Sense force-arm command for the "
+                "pending arm request."
+            ),
+            title="X-Sense arm blocked",
+            notification_id=self._force_arm_notification_id,
+        )
+        LOGGER.debug(
+            "X-Sense SBS50 force-arm notification created: station=%s mode=%s",
+            station.sn,
+            safe_mode,
+        )
+
+    @callback
+    def _async_clear_force_arm_notification(self) -> None:
+        """Dismiss the HA notification for a cleared SBS50 bypass prompt."""
+        persistent_notification.async_dismiss(
+            self.hass, self._force_arm_notification_id
+        )
+
+    @property
+    def _force_arm_notification_id(self) -> str:
+        """Return the stable notification id for this SBS50 alarm panel."""
+        return f"{FORCE_ARM_NOTIFICATION_ID_PREFIX}{self._station_id}"
+
+    def _force_arm_url(self, safe_mode: str) -> str:
+        """Return the authenticated force-arm confirmation URL."""
+        return (
+            "/api/xsense/force-arm/"
+            f"{quote(str(self._entry_id), safe='')}/"
+            f"{quote(str(self._station_id), safe='')}/"
+            f"{safe_mode.lower()}"
+        )
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to coordinator updates and read initial state."""
         await super().async_added_to_hass()
@@ -157,74 +247,46 @@ class XSenseAlarmControlPanel(
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Disarm the alarm."""
-        await self._set_safe_mode("Disarmed")
+        await self._set_safe_mode("Disarmed", force_arm="0")
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Arm in home mode."""
-        await self._set_safe_mode("Home")
+        await self._set_safe_mode("Home", force_arm="0")
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Arm in away mode."""
-        await self._set_safe_mode("Away")
+        await self._set_safe_mode("Away", force_arm="0")
 
-    async def _set_safe_mode(self, safe_mode: str) -> None:
-        """Request a safeMode change through the X-Sense MQTT shadow."""
+    async def _set_safe_mode(self, safe_mode: str, *, force_arm: str) -> None:
+        """Request a safeMode change through the APK app-mode shadow."""
         station = self._station
         if station is None:
             raise xsense_error("station_unavailable")
 
         LOGGER.debug(
-            "Station %s requesting safeMode %s via MQTT appMode",
+            "Station %s requesting safeMode %s via appMode forceArm=%s",
             station.sn,
             safe_mode,
+            force_arm,
         )
 
         coordinator: XSenseDataUpdateCoordinator = self.coordinator
         api = coordinator.xsense
 
-        payload = {
-            "state": {
-                "desired": {
-                    "shadow": "appMode",
-                    "safeMode": safe_mode,
-                    "stationSN": station.sn,
-                    "source": "1",
-                    "forceArm": "0",
-                    "userId": api.userid,
-                    "userParam": "source=1",
-                }
-            }
-        }
-
-        topic = f"$aws/things/{station.shadow_name}/shadow/name/2nd_appmode/update"
-
-        mqtt = coordinator.mqtt_server(station.house.mqtt_server)
-
-        if mqtt is None or not mqtt.connected:
-            LOGGER.error(
-                "Station %s cannot set safeMode because MQTT is not connected",
-                station.sn,
-            )
-            raise xsense_error("mqtt_not_connected")
-
         try:
-            await mqtt.async_publish(
-                topic,
-                json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
-                qos=0,
-                retain=False,
-            )
+            await api.set_station_mode(station, safe_mode, force_arm=force_arm)
             LOGGER.debug(
-                "Station %s published appMode command %s on %s",
+                "Station %s sent appMode command %s forceArm=%s",
                 station.sn,
                 safe_mode,
-                topic,
+                force_arm,
             )
 
         except Exception as ex:  # noqa: BLE001
             LOGGER.exception(
-                "Could not set safeMode %s for station %s: %s",
+                "Could not set safeMode %s forceArm=%s for station %s: %s",
                 safe_mode,
+                force_arm,
                 station.sn,
                 ex,
             )

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from urllib.parse import quote
 
 from homeassistant.components import persistent_notification
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
@@ -81,7 +83,11 @@ def pending_force_arm_mode(station) -> str | None:
     if not force_reason:
         return None
 
-    mode = alarm_data.get("safeModeAim") or alarm_data.get("safeMode")
+    mode = (
+        alarm_data.get("safeModeAim")
+        or alarm_data.get("requestedSafeMode")
+        or alarm_data.get("safeMode")
+    )
     if mode in ("Home", "Away"):
         return mode
     return None
@@ -233,17 +239,28 @@ class XSenseAlarmControlPanel(
 
     def _force_arm_url(self, safe_mode: str) -> str:
         """Return the authenticated force-arm confirmation URL."""
-        return (
+        path = (
             "/api/xsense/force-arm/"
             f"{quote(str(self._entry_id), safe='')}/"
             f"{quote(str(self._station_id), safe='')}/"
             f"{safe_mode.lower()}"
+        )
+        return async_sign_path(
+            self.hass,
+            path,
+            timedelta(minutes=10),
+            use_content_user=True,
         )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to coordinator updates and read initial state."""
         await super().async_added_to_hass()
         self._handle_coordinator_update()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Dismiss entry-owned notifications when the entity unloads."""
+        self._async_clear_force_arm_notification()
+        await super().async_will_remove_from_hass()
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Disarm the alarm."""
@@ -273,6 +290,18 @@ class XSenseAlarmControlPanel(
         coordinator: XSenseDataUpdateCoordinator = self.coordinator
         api = coordinator.xsense
 
+        if safe_mode in ("Home", "Away") and force_arm == "0":
+            station.set_alarm_data({"requestedSafeMode": safe_mode})
+        elif safe_mode == "Disarmed":
+            station.set_alarm_data(
+                {
+                    "forceReason": None,
+                    "safeModeAim": None,
+                    "requestedSafeMode": None,
+                    "exitDelay": None,
+                }
+            )
+
         try:
             await api.set_station_mode(station, safe_mode, force_arm=force_arm)
             LOGGER.debug(
@@ -283,6 +312,8 @@ class XSenseAlarmControlPanel(
             )
 
         except Exception as ex:  # noqa: BLE001
+            if force_arm == "0":
+                station.set_alarm_data({"requestedSafeMode": None})
             LOGGER.exception(
                 "Could not set safeMode %s forceArm=%s for station %s: %s",
                 safe_mode,

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -15,7 +15,7 @@ FRONTEND_URL_PATH = "xsense-recordings"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.18"
+PANEL_ASSET_VERSION = "1.4.18.1"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -511,6 +511,14 @@ class XSenseForceArmView(http.HomeAssistantView):
             self.hass,
             f"{FORCE_ARM_NOTIFICATION_ID_PREFIX}{station_id}",
         )
+        station.set_alarm_data(
+            {
+                "forceReason": None,
+                "safeModeAim": None,
+                "requestedSafeMode": None,
+                "exitDelay": None,
+            }
+        )
         raise web.HTTPFound(location=_force_arm_redirect_url(self.hass, station))
 
 

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -11,9 +11,15 @@ from typing import Any
 from urllib.parse import quote
 
 from aiohttp import web
-from homeassistant.components import http
+from homeassistant.components import http, persistent_notification
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
+from .alarm_control_panel import (
+    FORCE_ARM_NOTIFICATION_ID_PREFIX,
+    pending_force_arm_mode,
+)
 from .const import (
     CONF_RECORDING_MEDIA_CLIPS_ORDER,
     CONF_RECORDING_MEDIA_DAYS_ORDER,
@@ -22,6 +28,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .entity import coordinator_stations
 from .recordings_media import (
     HLS_MIME_TYPE,
     XSenseRecordingsMediaSource,
@@ -59,6 +66,7 @@ async def async_register_recordings_http_views(hass: HomeAssistant) -> None:
     hass.http.register_view(XSenseRecordingsPanelPlaybackView(hass))
     hass.http.register_view(XSenseRecordingsPanelThumbnailView(hass))
     hass.http.register_view(XSenseRecordingsHlsSegmentView(hass))
+    hass.http.register_view(XSenseForceArmView(hass))
     domain_data["_recordings_http_views_registered"] = True
 
 
@@ -68,6 +76,23 @@ def _recordings_runtime_available(hass: HomeAssistant) -> bool:
     if not domain_data.get("_recordings_http_views_registered"):
         return False
     return has_any_camera_entities(hass)
+
+
+def _force_arm_redirect_url(hass: HomeAssistant, station) -> str:
+    """Return the HA frontend URL for the SBS50 alarm entity."""
+    entity_id = _alarm_panel_entity_id(hass, station)
+    if entity_id:
+        return f"/?more-info-entity-id={quote(entity_id, safe='')}"
+    return "/config/integrations/integration/xsense"
+
+
+def _alarm_panel_entity_id(hass: HomeAssistant, station) -> str | None:
+    """Return the HA entity id for the SBS50 alarm control panel."""
+    return er.async_get(hass).async_get_entity_id(
+        Platform.ALARM_CONTROL_PANEL,
+        DOMAIN,
+        f"{station.sn}_alarm",
+    )
 
 
 async def async_build_panel_data(hass: HomeAssistant) -> dict[str, Any]:
@@ -428,6 +453,65 @@ class XSenseRecordingsPanelDataView(http.HomeAssistantView):
             },
         )
         return web.json_response(data)
+
+
+class XSenseForceArmView(http.HomeAssistantView):
+    """Handle authenticated force-arm confirmation links."""
+
+    url = "/api/xsense/force-arm/{entry_id}/{station_id}/{mode}"
+    name = "api:xsense:force_arm"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the force-arm confirmation view."""
+        self.hass = hass
+
+    async def get(
+        self,
+        request: web.Request,
+        entry_id: str,
+        station_id: str,
+        mode: str,
+    ) -> web.Response:
+        """Confirm a pending SBS50 force-arm request."""
+        safe_mode = mode.title()
+        if safe_mode not in ("Home", "Away"):
+            raise web.HTTPBadRequest(reason="Invalid X-Sense arm mode")
+
+        coordinator = self.hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is None:
+            raise web.HTTPNotFound(reason="X-Sense account is not loaded")
+
+        station = coordinator_stations(coordinator).get(station_id)
+        if station is None:
+            raise web.HTTPNotFound(reason="X-Sense base station is not loaded")
+
+        if pending_force_arm_mode(station) != safe_mode:
+            raise web.HTTPConflict(
+                reason="X-Sense force arm is not pending for this mode"
+            )
+
+        try:
+            await coordinator.xsense.set_station_mode(
+                station,
+                safe_mode,
+                force_arm="1",
+            )
+        except Exception as err:  # noqa: BLE001
+            LOGGER.exception(
+                "X-Sense force-arm confirmation failed: station=%s mode=%s error=%s",
+                station.sn,
+                safe_mode,
+                err,
+            )
+            raise web.HTTPInternalServerError(
+                reason="X-Sense force-arm command failed"
+            ) from err
+
+        persistent_notification.async_dismiss(
+            self.hass,
+            f"{FORCE_ARM_NOTIFICATION_ID_PREFIX}{station_id}",
+        )
+        raise web.HTTPFound(location=_force_arm_redirect_url(self.hass, station))
 
 
 class XSenseRecordingsPanelDebugView(http.HomeAssistantView):

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.18",
+  "version": "1.4.18.1",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -591,7 +591,8 @@ class AsyncXSense(XSenseBase):
         self, camera: Entity, start_time: int, end_time: int
     ) -> dict:
         """Return APK SD-card video slices for a camera and time window."""
-        data = await self.addx_call(
+        data = await self._camera_addx_call(
+            camera,
             "/device/retrieveLocalVideos",
             serialNumber=camera.sn,
             startTime=start_time,
@@ -607,7 +608,8 @@ class AsyncXSense(XSenseBase):
         self, camera: Entity, start_time: int, end_time: int
     ) -> str | None:
         """Return the APK local-video playback URL/string for a camera window."""
-        data = await self.addx_call(
+        data = await self._camera_addx_call(
+            camera,
             "/device/playLocalVideo",
             serialNumber=camera.sn,
             startTime=start_time,
@@ -622,11 +624,16 @@ class AsyncXSense(XSenseBase):
 
     async def stop_camera_local_video(self, camera: Entity) -> None:
         """Stop APK local-video playback for a camera."""
-        await self.addx_call("/device/stopPlayLocalVideo", serialNumber=camera.sn)
+        await self._camera_addx_call(
+            camera,
+            "/device/stopPlayLocalVideo",
+            serialNumber=camera.sn,
+        )
 
     async def query_camera_sd_card_format(self, camera: Entity) -> dict:
         """Return the APK SD-card format status response for a camera."""
-        data = await self.addx_call(
+        data = await self._camera_addx_call(
+            camera,
             "/device/querySdCardFormat",
             serialNumber=camera.sn,
             queueId=str(camera.sn or ""),
@@ -639,7 +646,11 @@ class AsyncXSense(XSenseBase):
 
     async def get_camera_activity_zones(self, camera: Entity) -> dict:
         """Return APK activity zones configured for one camera."""
-        data = await self.addx_call("/device/getactivityzone", serialNumber=camera.sn)
+        data = await self._camera_addx_call(
+            camera,
+            "/device/getactivityzone",
+            serialNumber=camera.sn,
+        )
         LOGGER.debug(
             "X-Sense camera activity zone response: %s",
             _debug_data_shape(data),
@@ -847,12 +858,16 @@ class AsyncXSense(XSenseBase):
                 )
             return data.get("reData")
 
-    async def addx_call(self, endpoint: str, *, _retry: bool = True, **kwargs):
+    async def addx_call(
+        self,
+        endpoint: str,
+        *,
+        _retry: bool = True,
+        _house: House | None = None,
+        **kwargs,
+    ):
         """Call the ADDX camera API after the IPC endpoint has issued a token."""
-        if self._addx_session is None:
-            self._addx_session = await self.register_ipc()
-
-        addx_session = self._addx_session
+        addx_session = await self._get_addx_session(_house)
         node = addx_session.get("nodeType")
         base_url = self.ADDX_API_BY_NODE.get(node)
         if base_url is None:
@@ -881,9 +896,10 @@ class AsyncXSense(XSenseBase):
                     _debug_data_shape(result.get("data")),
                 )
                 if response.status in (401, 403) and _retry:
-                    self._addx_session = None
-                    self._addx_session = await self.register_ipc()
-                    return await self.addx_call(endpoint, _retry=False, **kwargs)
+                    self._clear_addx_session(_house, node)
+                    return await self.addx_call(
+                        endpoint, _retry=False, _house=_house, **kwargs
+                    )
                 message = result.get("msg") or result.get("message") or "unknown error"
                 raise APIFailure(f"ADDX API failure: {response.status}/{message}")
 
@@ -897,13 +913,45 @@ class AsyncXSense(XSenseBase):
                     _debug_data_shape(result.get("data")),
                 )
                 if result.get("result") == -1024 and _retry:
-                    self._addx_session = None
-                    self._addx_session = await self.register_ipc()
-                    return await self.addx_call(endpoint, _retry=False, **kwargs)
+                    self._clear_addx_session(_house, node)
+                    return await self.addx_call(
+                        endpoint, _retry=False, _house=_house, **kwargs
+                    )
                 raise APIFailure(
                     f"ADDX request for {endpoint} failed with error {result.get('result')}/{result.get('msg')}"
                 )
             return result.get("data")
+
+    async def _camera_addx_call(self, camera: Entity, endpoint: str, **kwargs):
+        """Call ADDX for one camera using its Home node when known."""
+        house = getattr(camera, "house", None)
+        if house is None:
+            return await self.addx_call(endpoint, **kwargs)
+        return await self.addx_call(endpoint, _house=house, **kwargs)
+
+    async def _get_addx_session(self, house: House | None = None) -> dict:
+        """Return an ADDX session for the requested APK Home node."""
+        if house is None:
+            if self._addx_session is None:
+                self._addx_session = await self.register_ipc()
+            return self._addx_session
+
+        node_type = _ipc_node_type(house.mqtt_region)
+        addx_sessions = getattr(self, "_addx_sessions_by_node", None)
+        if addx_sessions is None:
+            self._addx_sessions_by_node = addx_sessions = {}
+        if node_type not in addx_sessions:
+            addx_sessions[node_type] = await self.register_ipc(house)
+        return addx_sessions[node_type]
+
+    def _clear_addx_session(self, house: House | None, node: str | None) -> None:
+        """Clear a stale ADDX session without dropping unrelated Home nodes."""
+        if house is None:
+            self._addx_session = None
+            return
+        if node is None:
+            node = _ipc_node_type(house.mqtt_region)
+        getattr(self, "_addx_sessions_by_node", {}).pop(node, None)
 
     def _addx_body(self, addx_session: dict, data: Dict | None = None) -> Dict:
         """Return the ADDX request body shape used by the Android SDK."""
@@ -1040,11 +1088,12 @@ class AsyncXSense(XSenseBase):
 
         self.houses = result
 
-    async def register_ipc(self):
+    async def register_ipc(self, house: House | None = None):
         """Register with X-Sense IPC and receive the ADDX camera token."""
         if not self.houses:
             raise APIFailure("Cannot register IPC without an X-Sense house")
-        house = next(iter(self.houses.values()))
+        if house is None:
+            house = next(iter(self.houses.values()))
         node_type = _ipc_node_type(house.mqtt_region)
         return await self.ipc_call(
             "C10101",
@@ -1075,7 +1124,8 @@ class AsyncXSense(XSenseBase):
         for camera, addx_device in cameras:
             camera.set_data(_camera_data(addx_device))
             try:
-                config = await self.addx_call(
+                config = await self._camera_addx_call(
+                    camera,
                     "/device/getuserconfig",
                     serialNumber=camera.sn,
                     voiceReminder=False,
@@ -1086,7 +1136,8 @@ class AsyncXSense(XSenseBase):
                 camera.set_data(_camera_config_data(config))
 
             try:
-                setting_options = await self.addx_call(
+                setting_options = await self._camera_addx_call(
+                    camera,
                     "/user/getFormOptions",
                     serialNumber=camera.sn,
                 )
@@ -1111,7 +1162,8 @@ class AsyncXSense(XSenseBase):
                 or camera.data.get("supportMechanicalDingDong") is True
             ):
                 try:
-                    audio = await self.addx_call(
+                    audio = await self._camera_addx_call(
+                        camera,
                         "/device/config/querydeviceaudio",
                         serialNumber=camera.sn,
                     )
@@ -1122,7 +1174,8 @@ class AsyncXSense(XSenseBase):
 
             if camera.data.get("supportDoorBellAlarm"):
                 try:
-                    doorbell = await self.addx_call(
+                    doorbell = await self._camera_addx_call(
+                        camera,
                         "/device/config/querydoorbellconfig",
                         serialNumber=camera.sn,
                     )
@@ -1133,7 +1186,8 @@ class AsyncXSense(XSenseBase):
 
             if camera.data.get("supportPersonDetect") is not False:
                 try:
-                    notification_settings = await self.addx_call(
+                    notification_settings = await self._camera_addx_call(
+                        camera,
                         "/device/queryMessageNotification/v1",
                         serialNumber=camera.sn,
                         userId=self.userid,
@@ -1146,7 +1200,8 @@ class AsyncXSense(XSenseBase):
                     )
 
                 try:
-                    ai_event_settings = await self.addx_call(
+                    ai_event_settings = await self._camera_addx_call(
+                        camera,
                         "/aiAssist/queryEventObjectSwitch",
                         isAll=False,
                         serialNumbers=[camera.sn],
@@ -1233,7 +1288,11 @@ class AsyncXSense(XSenseBase):
             "X-Sense camera config update: %s",
             _camera_write_debug_context(camera, "/device/updateuserconfig", updates),
         )
-        await self.addx_call("/device/updateuserconfig", **payload)
+        await self._camera_addx_call(
+            camera,
+            "/device/updateuserconfig",
+            **payload,
+        )
         camera.set_data(updates)
 
     async def update_camera_audio(self, camera: Entity, **updates):
@@ -1257,7 +1316,8 @@ class AsyncXSense(XSenseBase):
                 camera, "/device/config/updatedeviceaudio", updates
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/config/updatedeviceaudio",
             serialNumber=camera.sn,
             deviceAudio=device_audio,
@@ -1274,7 +1334,8 @@ class AsyncXSense(XSenseBase):
                 camera, "/device/updaterecresolution", {"recResolution": resolution}
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/updaterecresolution",
             serialNumber=camera.sn,
             recResolution=resolution,
@@ -1289,7 +1350,8 @@ class AsyncXSense(XSenseBase):
                 camera, "/device/config/updatedefaultcodec", {"defaultCodec": codec}
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/config/updatedefaultcodec",
             serialNumber=camera.sn,
             defaultCodec=codec,
@@ -1308,7 +1370,8 @@ class AsyncXSense(XSenseBase):
                 {"cooldown.userEnable": user_enable, "cooldown.value": value},
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/updateCooldown",
             serialNumber=camera.sn,
             cooldown={"userEnable": user_enable, "value": value},
@@ -1327,7 +1390,8 @@ class AsyncXSense(XSenseBase):
         ):
             return cached
 
-        data = await self.addx_call(
+        data = await self._camera_addx_call(
+            camera,
             "/device/getWebrtcTicket",
             serialNumber=camera.sn,
             verifyDormancyStatus=True,
@@ -1339,7 +1403,11 @@ class AsyncXSense(XSenseBase):
 
     async def wake_camera(self, camera: Entity) -> None:
         """Wake a sleeping camera through the Android app endpoint."""
-        await self.addx_call("/device/wakeupDevice", serialNumber=camera.sn)
+        await self._camera_addx_call(
+            camera,
+            "/device/wakeupDevice",
+            serialNumber=camera.sn,
+        )
 
     async def update_camera_sleep(self, camera: Entity, enabled: bool) -> None:
         """Write camera dormancy through the Android app endpoint."""
@@ -1349,7 +1417,8 @@ class AsyncXSense(XSenseBase):
                 camera, "/device/dormancy/switch", {"dormancySwitch": enabled}
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/dormancy/switch",
             serialNumber=camera.sn,
             dormancySwitch=1 if enabled else 0,
@@ -1367,7 +1436,8 @@ class AsyncXSense(XSenseBase):
                 camera, "/device/config/updatedoorbellconfig", updates
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/config/updatedoorbellconfig",
             serialNumber=camera.sn,
             doorbellConfig=doorbell_config,
@@ -1392,7 +1462,8 @@ class AsyncXSense(XSenseBase):
                 {f"aiNotification.{event_object}": enabled},
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/device/updateMessageNotification/v1",
             serialNumber=camera.sn,
             eventObjectType=payload,
@@ -1411,7 +1482,8 @@ class AsyncXSense(XSenseBase):
                 {f"aiAssistant.{event_object}": enabled},
             ),
         )
-        await self.addx_call(
+        await self._camera_addx_call(
+            camera,
             "/aiAssist/updateEventObjectSwitch",
             serialNumber=camera.sn,
             list=[{"checked": enabled, "eventObject": event_object}],

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -199,6 +199,12 @@ def _normalized_camera_serial(value) -> str | None:
     return serial or None
 
 
+def _camera_addx_serial(camera: Entity) -> str:
+    """Return the exact serial supplied by the APK ADDX device record."""
+    data = getattr(camera, "data", {}) or {}
+    return str(data.get("addxSerialNumber") or camera.sn)
+
+
 def _camera_resolution(value) -> str | None:
     """Return an APK-style camera video resolution value."""
     if value is None:
@@ -594,7 +600,7 @@ class AsyncXSense(XSenseBase):
         data = await self._camera_addx_call(
             camera,
             "/device/retrieveLocalVideos",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             startTime=start_time,
             endTime=end_time,
         )
@@ -611,7 +617,7 @@ class AsyncXSense(XSenseBase):
         data = await self._camera_addx_call(
             camera,
             "/device/playLocalVideo",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             startTime=start_time,
             endTime=end_time,
         )
@@ -627,7 +633,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/stopPlayLocalVideo",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
         )
 
     async def query_camera_sd_card_format(self, camera: Entity) -> dict:
@@ -635,8 +641,8 @@ class AsyncXSense(XSenseBase):
         data = await self._camera_addx_call(
             camera,
             "/device/querySdCardFormat",
-            serialNumber=camera.sn,
-            queueId=str(camera.sn or ""),
+            serialNumber=_camera_addx_serial(camera),
+            queueId=_camera_addx_serial(camera),
         )
         LOGGER.debug(
             "X-Sense camera SD card format response: %s",
@@ -649,7 +655,7 @@ class AsyncXSense(XSenseBase):
         data = await self._camera_addx_call(
             camera,
             "/device/getactivityzone",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
         )
         LOGGER.debug(
             "X-Sense camera activity zone response: %s",
@@ -923,11 +929,21 @@ class AsyncXSense(XSenseBase):
             return result.get("data")
 
     async def _camera_addx_call(self, camera: Entity, endpoint: str, **kwargs):
-        """Call ADDX for one camera using its Home node when known."""
-        house = getattr(camera, "house", None)
+        """Call ADDX using the node that supplied the APK camera record."""
+        house = self._camera_addx_house(camera)
         if house is None:
             return await self.addx_call(endpoint, **kwargs)
         return await self.addx_call(endpoint, _house=house, **kwargs)
+
+    def _camera_addx_house(self, camera: Entity) -> House | None:
+        """Return a House on the ADDX node that discovered this camera."""
+        data = getattr(camera, "data", {}) or {}
+        node_type = data.get("addxNodeType")
+        if node_type:
+            for house in self.houses.values():
+                if _ipc_node_type(house.mqtt_region) == node_type:
+                    return house
+        return getattr(camera, "house", None)
 
     async def _get_addx_session(self, house: House | None = None) -> dict:
         """Return an ADDX session for the requested APK Home node."""
@@ -937,6 +953,11 @@ class AsyncXSense(XSenseBase):
             return self._addx_session
 
         node_type = _ipc_node_type(house.mqtt_region)
+        if (
+            self._addx_session is not None
+            and self._addx_session.get("nodeType") == node_type
+        ):
+            return self._addx_session
         addx_sessions = getattr(self, "_addx_sessions_by_node", None)
         if addx_sessions is None:
             self._addx_sessions_by_node = addx_sessions = {}
@@ -951,6 +972,11 @@ class AsyncXSense(XSenseBase):
             return
         if node is None:
             node = _ipc_node_type(house.mqtt_region)
+        if (
+            self._addx_session is not None
+            and self._addx_session.get("nodeType") == node
+        ):
+            self._addx_session = None
         getattr(self, "_addx_sessions_by_node", {}).pop(node, None)
 
     def _addx_body(self, addx_session: dict, data: Dict | None = None) -> Dict:
@@ -1104,12 +1130,7 @@ class AsyncXSense(XSenseBase):
 
     async def update_camera_data(self):
         """Merge camera metadata and config from the Android app ADDX API."""
-        data = await self.addx_call("/device/listuserdevices")
-        devices = [
-            device
-            for device in (data or {}).get("list") or []
-            if _normalized_camera_serial(device.get("serialNumber"))
-        ]
+        devices = await self._list_addx_camera_devices()
         if not devices:
             return
 
@@ -1127,7 +1148,7 @@ class AsyncXSense(XSenseBase):
                 config = await self._camera_addx_call(
                     camera,
                     "/device/getuserconfig",
-                    serialNumber=camera.sn,
+                    serialNumber=_camera_addx_serial(camera),
                     voiceReminder=False,
                 )
             except APIFailure:
@@ -1139,7 +1160,7 @@ class AsyncXSense(XSenseBase):
                 setting_options = await self._camera_addx_call(
                     camera,
                     "/user/getFormOptions",
-                    serialNumber=camera.sn,
+                    serialNumber=_camera_addx_serial(camera),
                 )
             except APIFailure:
                 setting_options = None
@@ -1165,7 +1186,7 @@ class AsyncXSense(XSenseBase):
                     audio = await self._camera_addx_call(
                         camera,
                         "/device/config/querydeviceaudio",
-                        serialNumber=camera.sn,
+                        serialNumber=_camera_addx_serial(camera),
                     )
                 except APIFailure:
                     audio = None
@@ -1177,7 +1198,7 @@ class AsyncXSense(XSenseBase):
                     doorbell = await self._camera_addx_call(
                         camera,
                         "/device/config/querydoorbellconfig",
-                        serialNumber=camera.sn,
+                        serialNumber=_camera_addx_serial(camera),
                     )
                 except APIFailure:
                     doorbell = None
@@ -1189,7 +1210,7 @@ class AsyncXSense(XSenseBase):
                     notification_settings = await self._camera_addx_call(
                         camera,
                         "/device/queryMessageNotification/v1",
-                        serialNumber=camera.sn,
+                        serialNumber=_camera_addx_serial(camera),
                         userId=self.userid,
                     )
                 except APIFailure:
@@ -1204,14 +1225,54 @@ class AsyncXSense(XSenseBase):
                         camera,
                         "/aiAssist/queryEventObjectSwitch",
                         isAll=False,
-                        serialNumbers=[camera.sn],
+                        serialNumbers=[_camera_addx_serial(camera)],
                     )
                 except APIFailure:
                     ai_event_settings = None
                 if ai_event_settings:
                     camera.set_data(
-                        _camera_ai_assistant_data(ai_event_settings, camera.sn)
+                        _camera_ai_assistant_data(
+                            ai_event_settings, _camera_addx_serial(camera)
+                        )
                     )
+
+    async def _list_addx_camera_devices(self) -> list[dict]:
+        """List cameras from every APK ADDX node represented by the account."""
+        houses_by_node: dict[str, House] = {}
+        for house in self.houses.values():
+            houses_by_node.setdefault(_ipc_node_type(house.mqtt_region), house)
+
+        devices_by_serial: dict[str, dict] = {}
+        first_error: APIFailure | None = None
+        successful_nodes = 0
+        for index, (node_type, house) in enumerate(houses_by_node.items()):
+            try:
+                data = await self.addx_call(
+                    "/device/listuserdevices",
+                    **({} if index == 0 else {"_house": house}),
+                )
+            except APIFailure as err:
+                if first_error is None:
+                    first_error = err
+                LOGGER.debug(
+                    "X-Sense camera list unavailable on ADDX node %s",
+                    node_type,
+                    exc_info=True,
+                )
+                continue
+
+            successful_nodes += 1
+            for raw_device in (data or {}).get("list") or []:
+                normalized = _normalized_camera_serial(raw_device.get("serialNumber"))
+                if normalized is None:
+                    continue
+                device = dict(raw_device)
+                device["addxNodeType"] = node_type
+                devices_by_serial.setdefault(normalized, device)
+
+        if successful_nodes == 0 and first_error is not None:
+            raise first_error
+        return list(devices_by_serial.values())
 
     async def get_camera_thumbnail(self, camera: Entity) -> bytes | None:
         """Return the latest camera thumbnail bytes from the APK thumbnail URL."""
@@ -1319,7 +1380,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/config/updatedeviceaudio",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             deviceAudio=device_audio,
         )
         camera.set_data(updates)
@@ -1337,7 +1398,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/updaterecresolution",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             recResolution=resolution,
         )
         camera.set_data({"recResolution": resolution})
@@ -1353,7 +1414,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/config/updatedefaultcodec",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             defaultCodec=codec,
         )
         camera.set_data({"defaultCodec": codec})
@@ -1373,7 +1434,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/updateCooldown",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             cooldown={"userEnable": user_enable, "value": value},
         )
         camera.set_data({"cooldownEnabled": user_enable, "cooldownValue": value})
@@ -1393,7 +1454,7 @@ class AsyncXSense(XSenseBase):
         data = await self._camera_addx_call(
             camera,
             "/device/getWebrtcTicket",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             verifyDormancyStatus=True,
         )
         if isinstance(data, dict):
@@ -1406,7 +1467,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/wakeupDevice",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
         )
 
     async def update_camera_sleep(self, camera: Entity, enabled: bool) -> None:
@@ -1420,7 +1481,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/dormancy/switch",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             dormancySwitch=1 if enabled else 0,
         )
 
@@ -1439,7 +1500,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/config/updatedoorbellconfig",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             doorbellConfig=doorbell_config,
         )
         camera.set_data(updates)
@@ -1465,7 +1526,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/device/updateMessageNotification/v1",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             eventObjectType=payload,
         )
         camera.set_data(_camera_ai_notification_state_data(current))
@@ -1485,7 +1546,7 @@ class AsyncXSense(XSenseBase):
         await self._camera_addx_call(
             camera,
             "/aiAssist/updateEventObjectSwitch",
-            serialNumber=camera.sn,
+            serialNumber=_camera_addx_serial(camera),
             list=[{"checked": enabled, "eventObject": event_object}],
         )
         camera.set_data({_camera_ai_assistant_key(event_object): enabled})
@@ -2563,6 +2624,9 @@ def _camera_data(data: Dict) -> Dict:
 
     return {
         "activatedTime": data.get("activatedTime"),
+        "addxLocationId": data.get("locationId"),
+        "addxNodeType": data.get("addxNodeType"),
+        "addxSerialNumber": data.get("serialNumber"),
         "antiflickerSupport": data.get("antiflickerSupport"),
         "awake": data.get("awake"),
         "batteryLevel": data.get("batteryLevel"),
@@ -2676,7 +2740,7 @@ _CAMERA_BOOLEAN_USER_CONFIG_KEYS = {"deviceCallToggleOn"}
 
 def _camera_user_config_payload(camera: Entity, updates: Dict) -> Dict:
     """Return the APK UserConfigBean-style camera config payload."""
-    payload = {"serialNumber": camera.sn}
+    payload = {"serialNumber": _camera_addx_serial(camera)}
     payload.update(
         {
             key: _camera_config_payload_value(key, value)

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -129,6 +129,7 @@ class XSenseBase:
     def __init__(self):
         self.houses: Dict[str, House] = {}
         self._addx_session = None
+        self._addx_sessions_by_node: dict[str, dict] = {}
 
     def _parse_client_error(self, e: ClientError):
         return e.response.get('Error', {}).get('Message') or str(e)

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -564,29 +564,44 @@ def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:
 
 def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
     """Track the APK bypass confirmation prompt for SBS50 arm requests."""
-    prompt = _sbs50_force_arm_prompt(station_data)
+    current_alarm_data = getattr(station, "alarm_data", {}) or {}
+    prompt = _sbs50_force_arm_prompt(
+        station_data,
+        requested_mode=current_alarm_data.get("requestedSafeMode"),
+    )
     if prompt is not None:
         station.set_alarm_data(prompt)
         return
 
-    if "safeMode" in station_data:
+    force_reason_reported = "forceReason" in station_data
+    reported_mode = station_data.get("safeMode")
+    requested_mode = current_alarm_data.get("requestedSafeMode")
+    request_completed = reported_mode in ("Home", "Away") and (
+        requested_mode is None or reported_mode == requested_mode
+    )
+    if force_reason_reported or request_completed:
         station.set_alarm_data(
             {
                 "forceReason": None,
                 "safeModeAim": None,
+                "requestedSafeMode": None,
                 "exitDelay": None,
             }
         )
 
 
-def _sbs50_force_arm_prompt(station_data: Dict) -> Dict | None:
+def _sbs50_force_arm_prompt(
+    station_data: Dict, *, requested_mode: str | None = None
+) -> Dict | None:
     if "forceReason" in station_data:
         force_reason = station_data.get("forceReason")
         if force_reason:
             return {
                 "forceReason": force_reason,
                 "safeModeAim": station_data.get("safeModeAim")
+                or requested_mode
                 or station_data.get("safeMode"),
+                "requestedSafeMode": requested_mode,
                 "exitDelay": station_data.get("exitDelay"),
             }
 
@@ -606,8 +621,10 @@ def _sbs50_force_arm_prompt(station_data: Dict) -> Dict | None:
         return {
             "forceReason": force_reason,
             "safeModeAim": event_param.get("safeModeAim")
+            or requested_mode
             or station_data.get("safeModeAim")
             or station_data.get("safeMode"),
+            "requestedSafeMode": requested_mode,
             "exitDelay": event_param.get("exitDelay"),
         }
 

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -380,6 +380,7 @@ class XSenseBase:
 
         _normalize_apk_alarm_status(station_data)
         has_alarm_status = 'alarmStatus' in station_data or 'a' in station_data
+        _apply_sbs50_force_arm_prompt(station, station_data)
         if station_data:
             station.set_data(station_data)
         if 'safeMode' in station_data:
@@ -558,6 +559,58 @@ def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:
             seen.add(text)
             result.append(text)
     return tuple(result)
+
+
+def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
+    """Track the APK bypass confirmation prompt for SBS50 arm requests."""
+    prompt = _sbs50_force_arm_prompt(station_data)
+    if prompt is not None:
+        station.set_alarm_data(prompt)
+        return
+
+    if "safeMode" in station_data:
+        station.set_alarm_data(
+            {
+                "forceReason": None,
+                "safeModeAim": None,
+                "exitDelay": None,
+            }
+        )
+
+
+def _sbs50_force_arm_prompt(station_data: Dict) -> Dict | None:
+    if "forceReason" in station_data:
+        force_reason = station_data.get("forceReason")
+        if force_reason:
+            return {
+                "forceReason": force_reason,
+                "safeModeAim": station_data.get("safeModeAim")
+                or station_data.get("safeMode"),
+                "exitDelay": station_data.get("exitDelay"),
+            }
+
+    notices = station_data.get("notices")
+    if not isinstance(notices, list):
+        return None
+
+    for notice in notices:
+        if not isinstance(notice, dict):
+            continue
+        event_param = notice.get("eventParam")
+        if not isinstance(event_param, dict):
+            continue
+        force_reason = event_param.get("forceReason")
+        if not force_reason:
+            continue
+        return {
+            "forceReason": force_reason,
+            "safeModeAim": event_param.get("safeModeAim")
+            or station_data.get("safeModeAim")
+            or station_data.get("safeMode"),
+            "exitDelay": event_param.get("exitDelay"),
+        }
+
+    return None
 
 
 def _apply_group_light_state(station: Station, station_data: Dict, children) -> bool:

--- a/custom_components/xsense/python_xsense/station.py
+++ b/custom_components/xsense/python_xsense/station.py
@@ -116,6 +116,8 @@ class Station(Entity):
             "deviceSn",
             "forceArm",
             "forceReason",
+            "safeModeAim",
+            "exitDelay",
         ]
 
         for k in keys:

--- a/custom_components/xsense/python_xsense/station.py
+++ b/custom_components/xsense/python_xsense/station.py
@@ -117,6 +117,7 @@ class Station(Entity):
             "forceArm",
             "forceReason",
             "safeModeAim",
+            "requestedSafeMode",
             "exitDelay",
         ]
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5035,7 +5035,7 @@ async def test_register_ipc_uses_mqtt_region_and_app_language_like_apk():
 
 
 @pytest.mark.asyncio
-async def test_camera_webrtc_ticket_uses_camera_home_ipc_node_in_multi_home_account():
+async def test_camera_webrtc_ticket_uses_exact_addx_identity_in_multi_home_account():
     client = async_xsense.AsyncXSense(language="en-US")
     client.username = "user@example.com"
     sensor_house = house.House(
@@ -5050,8 +5050,14 @@ async def test_camera_webrtc_ticket_uses_camera_home_ipc_node_in_multi_home_acco
     }
     camera = entity.Entity()
     camera.house = camera_house
-    camera.sn = "cam-sn"
+    camera.sn = "CAM-SN"
     camera.type = "SSC0A"
+    camera.set_data(
+        {
+            "addxNodeType": "US",
+            "addxSerialNumber": "camsn",
+        }
+    )
     registrations = []
 
     async def ipc_call(code, **kwargs):
@@ -5099,12 +5105,134 @@ async def test_camera_webrtc_ticket_uses_camera_home_ipc_node_in_multi_home_acco
     assert registrations == [
         (
             "C10101",
-            {"userName": "user@example.com", "nodeType": "EU", "language": "en"},
+            {"userName": "user@example.com", "nodeType": "US", "language": "en"},
         )
     ]
-    assert captured_posts[0][1]["headers"]["Authorization"] == "eu-token"
-    assert captured_posts[0][1]["json"]["serialNumber"] == "cam-sn"
+    assert captured_posts[0][1]["headers"]["Authorization"] == "us-token"
+    assert captured_posts[0][1]["json"]["serialNumber"] == "camsn"
     assert "houseId" not in captured_posts[0][1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_camera_discovery_lists_each_distinct_addx_node_once():
+    client = async_xsense.AsyncXSense()
+    us_house = house.House(
+        None, "us-house", "US Home", "US", "us-east-1", "mqtt-us"
+    )
+    second_us_house = house.House(
+        None, "second-us-house", "Second US Home", "US", "us-west-2", "mqtt-us-2"
+    )
+    eu_house = house.House(
+        None, "eu-house", "EU Home", "Germany", "eu-central-1", "mqtt-eu"
+    )
+    client.houses = {
+        "us-house": us_house,
+        "second-us-house": second_us_house,
+        "eu-house": eu_house,
+    }
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if kwargs.get("_house") is eu_house:
+            return {"list": [{"serialNumber": "EU-CAM", "modelNo": "SSC0A"}]}
+        return {"list": [{"serialNumber": "US-CAM", "modelNo": "SSC0A"}]}
+
+    client.addx_call = addx_call
+
+    devices = await client._list_addx_camera_devices()
+
+    assert calls == [
+        ("/device/listuserdevices", {}),
+        ("/device/listuserdevices", {"_house": eu_house}),
+    ]
+    assert [(item["serialNumber"], item["addxNodeType"]) for item in devices] == [
+        ("US-CAM", "US"),
+        ("EU-CAM", "EU"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_camera_discovery_continues_when_an_earlier_addx_node_fails():
+    client = async_xsense.AsyncXSense()
+    us_house = house.House(
+        None, "us-house", "US Home", "US", "us-east-1", "mqtt-us"
+    )
+    eu_house = house.House(
+        None, "eu-house", "EU Home", "Germany", "eu-central-1", "mqtt-eu"
+    )
+    client.houses = {"us-house": us_house, "eu-house": eu_house}
+
+    async def addx_call(endpoint, **kwargs):
+        if not kwargs:
+            raise exceptions.APIFailure("US camera node unavailable")
+        return {"list": [{"serialNumber": "EU-CAM", "modelNo": "SSC0A"}]}
+
+    client.addx_call = addx_call
+
+    assert await client._list_addx_camera_devices() == [
+        {
+            "serialNumber": "EU-CAM",
+            "modelNo": "SSC0A",
+            "addxNodeType": "EU",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_camera_data_preserves_exact_addx_serial_for_later_calls():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "cam-id",
+                    "ipcSn": "CAM-SN",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camsn",
+                        "deviceName": "Camera",
+                        "modelNo": "SSC0A",
+                        "online": 1,
+                    }
+                ]
+            }
+        if endpoint == "/device/getWebrtcTicket":
+            return {"signalServer": "https://signal.example"}
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+    camera = test_house.get_station_by_sn("CAM-SN")
+    assert camera.data["addxSerialNumber"] == "camsn"
+
+    await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+
+    assert (
+        "/device/getWebrtcTicket",
+        {
+            "_house": test_house,
+            "serialNumber": "camsn",
+            "verifyDormancyStatus": True,
+        },
+    ) in calls
 
 
 def test_ipc_language_uses_simple_apk_app_language_code():

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -4088,7 +4088,11 @@ async def test_update_camera_data_updates_known_camera_from_addx_device_list():
     assert ("/device/listuserdevices", {}) in calls
     assert (
         "/device/getuserconfig",
-        {"serialNumber": "cam-sn", "voiceReminder": False},
+        {
+            "_house": test_house,
+            "serialNumber": "cam-sn",
+            "voiceReminder": False,
+        },
     ) in calls
 
 
@@ -4227,7 +4231,10 @@ async def test_update_camera_data_loads_apk_form_options():
     assert camera.data["videoSecondsValues"] == [-1]
     assert camera.data["cooldownOptions"] == [10]
     assert "cameraWebrtcTicket" not in camera.data
-    assert ("/user/getFormOptions", {"serialNumber": "cam-sn"}) in calls
+    assert (
+        "/user/getFormOptions",
+        {"_house": test_house, "serialNumber": "cam-sn"},
+    ) in calls
     assert ("/device/getWebrtcTicket", {"serialNumber": "cam-sn"}) not in calls
 
 
@@ -4308,7 +4315,10 @@ async def test_update_camera_data_queries_audio_when_apk_support_is_unspecified(
     assert camera.data["liveAudioToggleOn"] is True
     assert camera.data["recordingAudioToggleOn"] is True
     assert camera.data["liveSpeakerVolume"] == 80
-    assert ("/device/config/querydeviceaudio", {"serialNumber": "cam-sn"}) in calls
+    assert (
+        "/device/config/querydeviceaudio",
+        {"_house": test_house, "serialNumber": "cam-sn"},
+    ) in calls
 
 
 @pytest.mark.asyncio
@@ -5022,6 +5032,79 @@ async def test_register_ipc_uses_mqtt_region_and_app_language_like_apk():
             {"userName": "user@example.com", "nodeType": "EU", "language": "de"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_camera_webrtc_ticket_uses_camera_home_ipc_node_in_multi_home_account():
+    client = async_xsense.AsyncXSense(language="en-US")
+    client.username = "user@example.com"
+    sensor_house = house.House(
+        None, "sensor-house", "Sensors", "US", "us-east-1", "mqtt-us"
+    )
+    camera_house = house.House(
+        None, "camera-house", "Cameras", "Germany", "eu-central-1", "mqtt-eu"
+    )
+    client.houses = {
+        "sensor-house": sensor_house,
+        "camera-house": camera_house,
+    }
+    camera = entity.Entity()
+    camera.house = camera_house
+    camera.sn = "cam-sn"
+    camera.type = "SSC0A"
+    registrations = []
+
+    async def ipc_call(code, **kwargs):
+        registrations.append((code, kwargs))
+        return {
+            "token": f"{kwargs['nodeType'].lower()}-token",
+            "nodeType": kwargs["nodeType"],
+            "countryNo": kwargs["nodeType"],
+            "language": kwargs["language"],
+        }
+
+    captured_posts = []
+
+    class CaptureSession:
+        closed = False
+
+        def post(self, url, **kwargs):
+            captured_posts.append((url, kwargs))
+            return CapturePostResponse(
+                {
+                    "result": 0,
+                    "data": {
+                        "signalServer": "https://signal.example",
+                        "groupId": "group",
+                        "role": "viewer",
+                        "id": "client123",
+                        "traceId": "trace",
+                        "sign": "sig",
+                        "time": 123456,
+                        "expirationTime": 4102444800000,
+                        "iceServer": [],
+                    },
+                }
+            )
+
+    async def get_session():
+        return CaptureSession()
+
+    client.ipc_call = ipc_call
+    client._get_session = get_session
+
+    ticket = await client.get_camera_webrtc_ticket(camera)
+
+    assert ticket["signalServer"] == "https://signal.example"
+    assert registrations == [
+        (
+            "C10101",
+            {"userName": "user@example.com", "nodeType": "EU", "language": "en"},
+        )
+    ]
+    assert captured_posts[0][1]["headers"]["Authorization"] == "eu-token"
+    assert captured_posts[0][1]["json"]["serialNumber"] == "cam-sn"
+    assert "houseId" not in captured_posts[0][1]["json"]
 
 
 def test_ipc_language_uses_simple_apk_app_language_code():

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -2,8 +2,10 @@ import pytest
 
 from custom_components.xsense.alarm_control_panel import (
     XSenseAlarmControlPanel,
+    pending_force_arm_mode,
     station_supports_alarm_panel,
 )
+from custom_components.xsense.python_xsense.base import XSenseBase
 from custom_components.xsense.python_xsense.station import Station
 from custom_components.xsense.binary_sensor import (
     SENSORS as BINARY_SENSORS,
@@ -502,3 +504,128 @@ def test_alarm_control_panel_requires_security_device_family():
             }
         )
         assert station_supports_alarm_panel(security_station)
+
+
+async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
+    class Api:
+        def __init__(self):
+            self.calls = []
+
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            self.calls.append((station.sn, safe_mode, force_arm))
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "door-id",
+                    "deviceName": "Door",
+                    "deviceSn": "door-sn",
+                    "deviceType": "SDS0A",
+                    "roomName": "Kitchen",
+                }
+            ]
+        }
+    )
+    api = Api()
+    coordinator = Coordinator(station)
+    coordinator.xsense = api
+    panel = XSenseAlarmControlPanel(coordinator, station)
+
+    await panel.async_alarm_arm_home()
+    await panel.async_alarm_arm_away()
+
+    assert api.calls == [
+        (station.sn, "Home", "0"),
+        (station.sn, "Away", "0"),
+    ]
+
+
+def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_notice():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "notices": [
+                {
+                    "type": "SKP0A",
+                    "eventParam": {
+                        "safeModeAim": "Home",
+                        "forceReason": [{"deviceSN": "door-sn"}],
+                        "exitDelay": "0",
+                    },
+                }
+            ],
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Home"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data["exitDelay"] == "0"
+
+    api.parse_get_state(station, {"safeMode": "Home"})
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data["forceReason"] is None
+
+
+def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    coordinator = Coordinator(station)
+    coordinator.entry = type("Entry", (), {"entry_id": "entry-id"})()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    created = []
+    dismissed = []
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
+        lambda hass, message, title=None, notification_id=None: created.append(
+            {
+                "hass": hass,
+                "message": message,
+                "title": title,
+                "notification_id": notification_id,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: dismissed.append((hass, notification_id)),
+    )
+
+    station.set_alarm_data(
+        {"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Away"}
+    )
+    panel._handle_coordinator_update()
+
+    assert created == [
+        {
+            "hass": panel.hass,
+            "message": (
+                "One or more sensors are open.\n\n"
+                "[**Force Arm Away**]"
+                f"(/api/xsense/force-arm/entry-id/{station.entity_id}/away)\n\n"
+                "This sends the guarded X-Sense force-arm command for the "
+                "pending arm request."
+            ),
+            "title": "X-Sense arm blocked",
+            "notification_id": f"xsense_force_arm_{station.entity_id}",
+        }
+    ]
+
+    panel._handle_coordinator_update()
+
+    assert len(created) == 1
+
+    station.set_alarm_data({"forceReason": None, "safeModeAim": None})
+    panel._handle_coordinator_update()
+
+    assert dismissed == [(panel.hass, f"xsense_force_arm_{station.entity_id}")]

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -541,6 +541,7 @@ async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
         (station.sn, "Home", "0"),
         (station.sn, "Away", "0"),
     ]
+    assert station.alarm_data["requestedSafeMode"] == "Away"
 
 
 def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_notice():
@@ -575,6 +576,43 @@ def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_notice():
     assert station.alarm_data["forceReason"] is None
 
 
+def test_force_arm_prompt_preserves_locally_requested_mode_from_apk_response():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Away"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Away"
+    assert station.alarm_data["requestedSafeMode"] == "Away"
+
+
+def test_empty_force_arm_reason_clears_pending_request_without_mode_change():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "safeModeAim": "Home",
+            "requestedSafeMode": "Home",
+        }
+    )
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(station, {"forceReason": []})
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data["requestedSafeMode"] is None
+
+
 def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch):
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
@@ -585,6 +623,15 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
     panel.async_write_ha_state = lambda: None
     created = []
     dismissed = []
+    monkeypatch.setitem(
+        panel._force_arm_url.__func__.__globals__,
+        "async_sign_path",
+        lambda hass, path, expiration, *, use_content_user=False: (
+            f"{path}?authSig=test"
+            if use_content_user
+            else pytest.fail("force-arm path must use the content user")
+        ),
+    )
     monkeypatch.setattr(
         "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
         lambda hass, message, title=None, notification_id=None: created.append(
@@ -612,7 +659,8 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
             "message": (
                 "One or more sensors are open.\n\n"
                 "[**Force Arm Away**]"
-                f"(/api/xsense/force-arm/entry-id/{station.entity_id}/away)\n\n"
+                f"(/api/xsense/force-arm/entry-id/{station.entity_id}/away"
+                "?authSig=test)\n\n"
                 "This sends the guarded X-Sense force-arm command for the "
                 "pending arm request."
             ),

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -2515,12 +2515,115 @@ def test_recordings_http_registration_adds_panel_views():
     asyncio.run(http.async_register_recordings_http_views(hass))
     asyncio.run(http.async_register_recordings_http_views(hass))
 
-    assert len(views) == 5
+    assert len(views) == 6
     assert isinstance(views[0], http.XSenseRecordingsPanelDataView)
     assert isinstance(views[1], http.XSenseRecordingsPanelDebugView)
     assert isinstance(views[2], http.XSenseRecordingsPanelPlaybackView)
     assert isinstance(views[3], http.XSenseRecordingsPanelThumbnailView)
     assert isinstance(views[4], http.XSenseRecordingsHlsSegmentView)
+    assert isinstance(views[5], http.XSenseForceArmView)
+
+
+def test_force_arm_view_sends_guarded_command_and_redirects(monkeypatch):
+    from aiohttp import web
+    from custom_components.xsense import http
+
+    class Api:
+        def __init__(self):
+            self.calls = []
+
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            self.calls.append((station.sn, safe_mode, force_arm))
+
+    class Registry:
+        def async_get_entity_id(self, domain, platform, unique_id):
+            assert domain == "alarm_control_panel"
+            assert platform == DOMAIN
+            assert unique_id == "station-sn_alarm"
+            return "alarm_control_panel.base_station_alarm"
+
+    station = SimpleNamespace(
+        alarm_data={"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Away"},
+        entity_id="station-id",
+        name="Base Station",
+        sn="station-sn",
+    )
+    api = Api()
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-id": SimpleNamespace(
+                    data={"stations": {"station-id": station}},
+                    xsense=api,
+                )
+            }
+        }
+    )
+    dismissed = []
+    monkeypatch.setattr(http.er, "async_get", lambda hass: Registry())
+    monkeypatch.setattr(
+        http.persistent_notification,
+        "async_dismiss",
+        lambda hass, notification_id: dismissed.append(notification_id),
+    )
+
+    with pytest.raises(web.HTTPFound) as exc:
+        asyncio.run(
+            http.XSenseForceArmView(hass).get(
+                SimpleNamespace(),
+                "entry-id",
+                "station-id",
+                "away",
+            )
+        )
+
+    assert api.calls == [("station-sn", "Away", "1")]
+    assert dismissed == ["xsense_force_arm_station-id"]
+    assert exc.value.location == (
+        "/?more-info-entity-id=alarm_control_panel.base_station_alarm"
+    )
+
+
+def test_force_arm_view_requires_matching_pending_prompt():
+    from aiohttp import web
+    from custom_components.xsense import http
+
+    class Api:
+        def __init__(self):
+            self.calls = []
+
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            self.calls.append((station.sn, safe_mode, force_arm))
+
+    station = SimpleNamespace(
+        alarm_data={"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Home"},
+        entity_id="station-id",
+        name="Base Station",
+        sn="station-sn",
+    )
+    api = Api()
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-id": SimpleNamespace(
+                    data={"stations": {"station-id": station}},
+                    xsense=api,
+                )
+            }
+        }
+    )
+
+    with pytest.raises(web.HTTPConflict):
+        asyncio.run(
+            http.XSenseForceArmView(hass).get(
+                SimpleNamespace(),
+                "entry-id",
+                "station-id",
+                "away",
+            )
+        )
+
+    assert api.calls == []
 
 
 def test_recordings_hls_playlist_rewrites_segments_to_token_route(tmp_path):

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -2548,6 +2548,7 @@ def test_force_arm_view_sends_guarded_command_and_redirects(monkeypatch):
         name="Base Station",
         sn="station-sn",
     )
+    station.set_alarm_data = station.alarm_data.update
     api = Api()
     hass = SimpleNamespace(
         data={
@@ -2579,6 +2580,8 @@ def test_force_arm_view_sends_guarded_command_and_redirects(monkeypatch):
 
     assert api.calls == [("station-sn", "Away", "1")]
     assert dismissed == ["xsense_force_arm_station-id"]
+    assert station.alarm_data["forceReason"] is None
+    assert station.alarm_data["safeModeAim"] is None
     assert exc.value.location == (
         "/?more-info-entity-id=alarm_control_panel.base_station_alarm"
     )


### PR DESCRIPTION
## Summary
- add SBS50 force-arm bypass confirmation after a refused arm request
- route camera ADDX calls through the camera Home/node context for multi-Home accounts
- prepare v1.4.18.1 pre-release metadata and notes

## Tests
- pytest tests/test_release_metadata.py tests/api/test_async_xsense.py tests/test_entity_availability.py tests/test_platform_setup.py -q
- pytest -q
- python -m compileall -q custom_components tests
- node --check custom_components/xsense/frontend/recordings-panel.js
- git diff --check
