### PR TITLE
Prepare v1.4.18.2 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.18.1):
-  (e.g., 1.4.18.1)
+- **X-Sense-Integration Version** (z. B. 1.4.18.2):
+  (e.g., 1.4.18.2)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.18.2.md
+++ b/.github/release-notes/1.4.18.2.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.4.18.2
+
+### Cameras
+- Adds another camera ticket fallback for accounts where X-Sense rejects the normal ADDX camera identity but accepts the APK camera device identity.
+- Keeps the camera's ADDX Home/node context in place when retrying the WebRTC ticket request.
+
+### Alarm Panel
+- Reworks force-arm confirmation so SBS50 Home/Away failures open an authenticated Home Assistant panel instead of using a state-changing URL.
+- Keeps the force-arm path independent from the recordings sidebar, so it can work for alarm systems without cameras.
+- Adds the same force-arm prompt behavior for Home mode as Away mode when X-Sense reports open sensors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.18.2](.github/release-notes/1.4.18.2.md)
 - [1.4.18.1](.github/release-notes/1.4.18.1.md)
 - [1.4.18](.github/release-notes/1.4.18.md)
 - [1.4.17.6](.github/release-notes/1.4.17.6.md)

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from urllib.parse import quote
+from urllib.parse import urlencode
 
+import voluptuous as vol
 from homeassistant.components import persistent_notification
-from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
@@ -15,6 +14,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -22,6 +22,11 @@ from .const import DOMAIN, MANUFACTURER
 from .coordinator import XSenseDataUpdateCoordinator
 from .entity import coordinator_stations
 from .errors import xsense_error
+from .frontend import (
+    FORCE_ARM_FRONTEND_URL_PATH,
+    async_register_force_arm_panel,
+    async_unregister_force_arm_panel,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +36,8 @@ SAFEMODE_TO_STATE: dict[str, AlarmControlPanelState] = {
     "Away": AlarmControlPanelState.ARMED_AWAY,
 }
 FORCE_ARM_NOTIFICATION_ID_PREFIX = "xsense_force_arm_"
+FORCE_ARM_SERVICE = "force_arm"
+FORCE_ARM_SCHEMA = {vol.Required("mode"): vol.In(("Home", "Away"))}
 
 
 async def async_setup_entry(
@@ -55,6 +62,17 @@ async def async_setup_entry(
                 entities.append(XSenseAlarmControlPanel(coordinator, station))
 
     if entities:
+        platform = entity_platform.current_platform.get()
+        if platform is not None:
+            platform.async_register_entity_service(
+                FORCE_ARM_SERVICE,
+                FORCE_ARM_SCHEMA,
+                "async_force_arm",
+            )
+        await async_register_force_arm_panel(hass, entry.entry_id)
+        entry.async_on_unload(
+            lambda: async_unregister_force_arm_panel(hass, entry.entry_id)
+        )
         async_add_entities(entities)
     else:
         LOGGER.debug(
@@ -84,8 +102,8 @@ def pending_force_arm_mode(station) -> str | None:
         return None
 
     mode = (
-        alarm_data.get("safeModeAim")
-        or alarm_data.get("requestedSafeMode")
+        alarm_data.get("requestedSafeMode")
+        or alarm_data.get("safeModeAim")
         or alarm_data.get("safeMode")
     )
     if mode in ("Home", "Away"):
@@ -213,8 +231,7 @@ class XSenseAlarmControlPanel(
             (
                 "One or more sensors are open.\n\n"
                 f"[**{button_name}**]({action_url})\n\n"
-                "This sends the guarded X-Sense force-arm command for the "
-                "pending arm request."
+                "Select the link to confirm the pending X-Sense arm request."
             ),
             title="X-Sense arm blocked",
             notification_id=self._force_arm_notification_id,
@@ -238,19 +255,14 @@ class XSenseAlarmControlPanel(
         return f"{FORCE_ARM_NOTIFICATION_ID_PREFIX}{self._station_id}"
 
     def _force_arm_url(self, safe_mode: str) -> str:
-        """Return the authenticated force-arm confirmation URL."""
-        path = (
-            "/api/xsense/force-arm/"
-            f"{quote(str(self._entry_id), safe='')}/"
-            f"{quote(str(self._station_id), safe='')}/"
-            f"{safe_mode.lower()}"
+        """Return the hidden HA action-panel URL for force-arm confirmation."""
+        params = urlencode(
+            {
+                "entity_id": self.entity_id,
+                "mode": safe_mode,
+            }
         )
-        return async_sign_path(
-            self.hass,
-            path,
-            timedelta(minutes=10),
-            use_content_user=True,
-        )
+        return f"/{FORCE_ARM_FRONTEND_URL_PATH}#{params}"
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to coordinator updates and read initial state."""
@@ -273,6 +285,29 @@ class XSenseAlarmControlPanel(
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Arm in away mode."""
         await self._set_safe_mode("Away", force_arm="0")
+
+    async def async_force_arm(self, mode: str) -> None:
+        """Confirm the exact Home or Away request currently awaiting bypass."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
+
+        pending_mode = pending_force_arm_mode(station)
+        if pending_mode != mode:
+            raise xsense_error("force_arm_not_pending", mode=mode)
+
+        await self._set_safe_mode(mode, force_arm="1")
+        station.set_alarm_data(
+            {
+                "forceReason": None,
+                "safeModeAim": None,
+                "requestedSafeMode": None,
+                "exitDelay": None,
+            }
+        )
+        self._pending_force_arm_mode = None
+        self._async_clear_force_arm_notification()
+        self.async_write_ha_state()
 
     async def _set_safe_mode(self, safe_mode: str, *, force_arm: str) -> None:
         """Request a safeMode change through the APK app-mode shadow."""

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -318,7 +318,9 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
             import_module, __package__ + ".python_xsense.webrtc_signal"
         )
         try:
-            ticket = webrtc_signal.XSenseWebRTCTicket.from_api(entity.sn, ticket_data)
+            ticket = webrtc_signal.XSenseWebRTCTicket.from_api(
+                _camera_webrtc_ticket_serial(entity, ticket_data), ticket_data
+            )
         except (KeyError, TypeError, ValueError) as err:
             LOGGER.debug(
                 "X-Sense camera WebRTC ticket parse failed: %s",
@@ -547,6 +549,15 @@ def _ticket_data_debug_context(ticket_data):
         "ticket_id": _short_id(ticket_data.get("id")),
         "real_camera": _short_id(ticket_data.get("realCxSerialNumber")),
     }
+
+
+def _camera_webrtc_ticket_serial(entity, ticket_data) -> str:
+    """Return the camera identifier used for the accepted WebRTC ticket."""
+    if isinstance(ticket_data, dict):
+        serial = ticket_data.get("serialNumber")
+        if serial not in (None, ""):
+            return str(serial)
+    return str(entity.sn)
 
 
 def _send_remote_candidate(send_message, entity, session_id, candidate) -> None:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from homeassistant.components import frontend
@@ -12,10 +13,12 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 
 FRONTEND_URL_PATH = "xsense-recordings"
+FORCE_ARM_FRONTEND_URL_PATH = "xsense-force-arm"
 STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
+FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.18.1"
+PANEL_ASSET_VERSION = "1.4.18.2"
 
 
 def _recordings_panel_module_url() -> str:
@@ -23,42 +26,89 @@ def _recordings_panel_module_url() -> str:
     return f"{STATIC_URL_PATH}/recordings-panel.js?v={PANEL_ASSET_VERSION}"
 
 
+def _force_arm_panel_module_url() -> str:
+    """Return the force-arm action module URL with a release cache-buster."""
+    return f"{STATIC_URL_PATH}/force-arm-panel.js?v={PANEL_ASSET_VERSION}"
+
+
 async def async_register_recordings_static_paths(hass: HomeAssistant) -> None:
     """Register recordings panel assets once for the lifetime of Home Assistant."""
     domain_data = hass.data.setdefault(DOMAIN, {})
-    if domain_data.get("_recordings_static_paths_registered"):
-        return
+    lock = domain_data.setdefault("_recordings_static_paths_lock", asyncio.Lock())
+    async with lock:
+        if domain_data.get("_recordings_static_paths_registered"):
+            return
 
-    frontend_path = Path(__file__).parent / "frontend"
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                STATIC_URL_PATH,
-                str(frontend_path),
-                cache_headers=False,
-            )
-        ]
-    )
-    domain_data["_recordings_static_paths_registered"] = True
+        frontend_path = Path(__file__).parent / "frontend"
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    STATIC_URL_PATH,
+                    str(frontend_path),
+                    cache_headers=False,
+                )
+            ]
+        )
+        domain_data["_recordings_static_paths_registered"] = True
 
 
 async def async_register_recordings_panel(hass: HomeAssistant) -> None:
     """Register the X-Sense recordings sidebar panel once cameras are present."""
     domain_data = hass.data.setdefault(DOMAIN, {})
-    if domain_data.get("_recordings_panel_registered"):
+    lock = domain_data.setdefault("_recordings_panel_lock", asyncio.Lock())
+    async with lock:
+        if domain_data.get("_recordings_panel_registered"):
+            return
+
+        await async_register_recordings_static_paths(hass)
+        await panel_custom.async_register_panel(
+            hass=hass,
+            frontend_url_path=FRONTEND_URL_PATH,
+            webcomponent_name=PANEL_ELEMENT_NAME,
+            sidebar_title=PANEL_TITLE,
+            sidebar_icon="mdi:video-box",
+            module_url=_recordings_panel_module_url(),
+            embed_iframe=False,
+        )
+        domain_data["_recordings_panel_registered"] = True
+
+
+async def async_register_force_arm_panel(
+    hass: HomeAssistant, entry_id: str
+) -> None:
+    """Register the hidden force-arm action panel for an alarm entry."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    entries = domain_data.setdefault("_force_arm_panel_entries", set())
+    entries.add(entry_id)
+    lock = domain_data.setdefault("_force_arm_panel_lock", asyncio.Lock())
+    async with lock:
+        if domain_data.get("_force_arm_panel_registered"):
+            return
+
+        await async_register_recordings_static_paths(hass)
+        await panel_custom.async_register_panel(
+            hass=hass,
+            frontend_url_path=FORCE_ARM_FRONTEND_URL_PATH,
+            webcomponent_name=FORCE_ARM_PANEL_ELEMENT_NAME,
+            module_url=_force_arm_panel_module_url(),
+            embed_iframe=False,
+            require_admin=False,
+        )
+        domain_data["_force_arm_panel_registered"] = True
+
+
+def async_unregister_force_arm_panel(hass: HomeAssistant, entry_id: str) -> None:
+    """Remove the hidden force-arm panel when no alarm entries remain."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    entries = domain_data.setdefault("_force_arm_panel_entries", set())
+    entries.discard(entry_id)
+    if entries or not domain_data.get("_force_arm_panel_registered"):
         return
 
-    await async_register_recordings_static_paths(hass)
-    await panel_custom.async_register_panel(
-        hass=hass,
-        frontend_url_path=FRONTEND_URL_PATH,
-        webcomponent_name=PANEL_ELEMENT_NAME,
-        sidebar_title=PANEL_TITLE,
-        sidebar_icon="mdi:video-box",
-        module_url=_recordings_panel_module_url(),
-        embed_iframe=False,
+    frontend.async_remove_panel(
+        hass, FORCE_ARM_FRONTEND_URL_PATH, warn_if_unknown=False
     )
-    domain_data["_recordings_panel_registered"] = True
+    domain_data.pop("_force_arm_panel_registered", None)
 
 
 def async_unregister_recordings_panel(hass: HomeAssistant) -> None:

--- a/custom_components/xsense/frontend/force-arm-panel.js
+++ b/custom_components/xsense/frontend/force-arm-panel.js
@@ -1,0 +1,60 @@
+class XSenseForceArmPanel extends HTMLElement {
+  set hass(value) {
+    this._hass = value;
+    this.runAction();
+  }
+
+  connectedCallback() {
+    this._connected = true;
+    this.render("Confirming X-Sense force arm...");
+    this.runAction();
+  }
+
+  async runAction() {
+    if (!this._connected || !this._hass || this._started) return;
+
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const entityId = params.get("entity_id");
+    const mode = params.get("mode");
+    if (!entityId || !["Home", "Away"].includes(mode)) {
+      this.render("This X-Sense force-arm link is invalid.", true);
+      return;
+    }
+
+    this._started = true;
+    try {
+      await this._hass.callService("xsense", "force_arm", {
+        entity_id: entityId,
+        mode,
+      });
+      this.render(`X-Sense is force arming in ${mode} mode.`);
+      window.setTimeout(() => {
+        if (window.history.length > 1) window.history.back();
+        else window.location.assign("/");
+      }, 800);
+    } catch (error) {
+      const message = error?.message || "The X-Sense force-arm request failed.";
+      this.render(message, true);
+    }
+  }
+
+  render(message, failed = false) {
+    this.innerHTML = `
+      <style>
+        :host { display: block; min-height: 100%; background: var(--primary-background-color); color: var(--primary-text-color); }
+        main { max-width: 560px; margin: 0 auto; padding: 48px 24px; text-align: center; }
+        h1 { font-size: 24px; letter-spacing: 0; margin: 0 0 16px; }
+        p { line-height: 1.5; margin: 0; color: ${failed ? "var(--error-color)" : "var(--secondary-text-color)"}; }
+        button { margin-top: 24px; border: 0; padding: 12px 20px; background: var(--primary-color); color: var(--text-primary-color); cursor: pointer; }
+      </style>
+      <main>
+        <h1>X-Sense Security</h1>
+        <p></p>
+        ${failed ? "<button type=\"button\">Back</button>" : ""}
+      </main>`;
+    this.querySelector("p").textContent = message;
+    this.querySelector("button")?.addEventListener("click", () => window.history.back());
+  }
+}
+
+customElements.define("xsense-force-arm-panel", XSenseForceArmPanel);

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -11,15 +11,8 @@ from typing import Any
 from urllib.parse import quote
 
 from aiohttp import web
-from homeassistant.components import http, persistent_notification
-from homeassistant.const import Platform
+from homeassistant.components import http
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-
-from .alarm_control_panel import (
-    FORCE_ARM_NOTIFICATION_ID_PREFIX,
-    pending_force_arm_mode,
-)
 from .const import (
     CONF_RECORDING_MEDIA_CLIPS_ORDER,
     CONF_RECORDING_MEDIA_DAYS_ORDER,
@@ -28,7 +21,6 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .entity import coordinator_stations
 from .recordings_media import (
     HLS_MIME_TYPE,
     XSenseRecordingsMediaSource,
@@ -66,7 +58,6 @@ async def async_register_recordings_http_views(hass: HomeAssistant) -> None:
     hass.http.register_view(XSenseRecordingsPanelPlaybackView(hass))
     hass.http.register_view(XSenseRecordingsPanelThumbnailView(hass))
     hass.http.register_view(XSenseRecordingsHlsSegmentView(hass))
-    hass.http.register_view(XSenseForceArmView(hass))
     domain_data["_recordings_http_views_registered"] = True
 
 
@@ -76,23 +67,6 @@ def _recordings_runtime_available(hass: HomeAssistant) -> bool:
     if not domain_data.get("_recordings_http_views_registered"):
         return False
     return has_any_camera_entities(hass)
-
-
-def _force_arm_redirect_url(hass: HomeAssistant, station) -> str:
-    """Return the HA frontend URL for the SBS50 alarm entity."""
-    entity_id = _alarm_panel_entity_id(hass, station)
-    if entity_id:
-        return f"/?more-info-entity-id={quote(entity_id, safe='')}"
-    return "/config/integrations/integration/xsense"
-
-
-def _alarm_panel_entity_id(hass: HomeAssistant, station) -> str | None:
-    """Return the HA entity id for the SBS50 alarm control panel."""
-    return er.async_get(hass).async_get_entity_id(
-        Platform.ALARM_CONTROL_PANEL,
-        DOMAIN,
-        f"{station.sn}_alarm",
-    )
 
 
 async def async_build_panel_data(hass: HomeAssistant) -> dict[str, Any]:
@@ -453,73 +427,6 @@ class XSenseRecordingsPanelDataView(http.HomeAssistantView):
             },
         )
         return web.json_response(data)
-
-
-class XSenseForceArmView(http.HomeAssistantView):
-    """Handle authenticated force-arm confirmation links."""
-
-    url = "/api/xsense/force-arm/{entry_id}/{station_id}/{mode}"
-    name = "api:xsense:force_arm"
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the force-arm confirmation view."""
-        self.hass = hass
-
-    async def get(
-        self,
-        request: web.Request,
-        entry_id: str,
-        station_id: str,
-        mode: str,
-    ) -> web.Response:
-        """Confirm a pending SBS50 force-arm request."""
-        safe_mode = mode.title()
-        if safe_mode not in ("Home", "Away"):
-            raise web.HTTPBadRequest(reason="Invalid X-Sense arm mode")
-
-        coordinator = self.hass.data.get(DOMAIN, {}).get(entry_id)
-        if coordinator is None:
-            raise web.HTTPNotFound(reason="X-Sense account is not loaded")
-
-        station = coordinator_stations(coordinator).get(station_id)
-        if station is None:
-            raise web.HTTPNotFound(reason="X-Sense base station is not loaded")
-
-        if pending_force_arm_mode(station) != safe_mode:
-            raise web.HTTPConflict(
-                reason="X-Sense force arm is not pending for this mode"
-            )
-
-        try:
-            await coordinator.xsense.set_station_mode(
-                station,
-                safe_mode,
-                force_arm="1",
-            )
-        except Exception as err:  # noqa: BLE001
-            LOGGER.exception(
-                "X-Sense force-arm confirmation failed: station=%s mode=%s error=%s",
-                station.sn,
-                safe_mode,
-                err,
-            )
-            raise web.HTTPInternalServerError(
-                reason="X-Sense force-arm command failed"
-            ) from err
-
-        persistent_notification.async_dismiss(
-            self.hass,
-            f"{FORCE_ARM_NOTIFICATION_ID_PREFIX}{station_id}",
-        )
-        station.set_alarm_data(
-            {
-                "forceReason": None,
-                "safeModeAim": None,
-                "requestedSafeMode": None,
-                "exitDelay": None,
-            }
-        )
-        raise web.HTTPFound(location=_force_arm_redirect_url(self.hass, station))
 
 
 class XSenseRecordingsPanelDebugView(http.HomeAssistantView):

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.18.1",
+  "version": "1.4.18.2",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -966,11 +966,6 @@ class AsyncXSense(XSenseBase):
     def _camera_addx_house(self, camera: Entity) -> House | None:
         """Return a House on the ADDX node that discovered this camera."""
         data = getattr(camera, "data", {}) or {}
-        house_id = data.get("addxHouseId")
-        if house_id not in (None, ""):
-            house = self.houses.get(str(house_id))
-            if house is not None:
-                return house
         node_type = data.get("addxNodeType")
         if node_type:
             for house in self.houses.values():
@@ -1271,11 +1266,14 @@ class AsyncXSense(XSenseBase):
 
     async def _list_addx_camera_devices(self) -> list[dict]:
         """List cameras from every APK ADDX node represented by the account."""
+        houses_by_node: dict[str, House] = {}
+        for house in self.houses.values():
+            houses_by_node.setdefault(_ipc_node_type(house.mqtt_region), house)
+
         devices_by_serial: dict[str, dict] = {}
         first_error: APIFailure | None = None
-        successful_houses = 0
-        for index, house in enumerate(self.houses.values()):
-            node_type = _ipc_node_type(house.mqtt_region)
+        successful_nodes = 0
+        for index, (node_type, house) in enumerate(houses_by_node.items()):
             try:
                 data = await self.addx_call(
                     "/device/listuserdevices",
@@ -1291,17 +1289,16 @@ class AsyncXSense(XSenseBase):
                 )
                 continue
 
-            successful_houses += 1
+            successful_nodes += 1
             for raw_device in (data or {}).get("list") or []:
                 normalized = _normalized_camera_serial(raw_device.get("serialNumber"))
                 if normalized is None:
                     continue
                 device = dict(raw_device)
                 device["addxNodeType"] = node_type
-                device["addxHouseId"] = house.house_id
                 devices_by_serial.setdefault(normalized, device)
 
-        if successful_houses == 0 and first_error is not None:
+        if successful_nodes == 0 and first_error is not None:
             raise first_error
         return list(devices_by_serial.values())
 
@@ -2681,7 +2678,6 @@ def _camera_data(data: Dict) -> Dict:
 
     return {
         "activatedTime": data.get("activatedTime"),
-        "addxHouseId": data.get("addxHouseId"),
         "addxLocationId": data.get("locationId"),
         "addxNodeType": data.get("addxNodeType"),
         "addxSerialNumber": data.get("serialNumber"),

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -201,8 +201,36 @@ def _normalized_camera_serial(value) -> str | None:
 
 def _camera_addx_serial(camera: Entity) -> str:
     """Return the exact serial supplied by the APK ADDX device record."""
+    return _camera_addx_serial_candidates(camera)[0]
+
+
+def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
+    """Return APK camera identifiers in ADDX preference order."""
     data = getattr(camera, "data", {}) or {}
-    return str(data.get("addxSerialNumber") or camera.sn)
+    result: list[str] = []
+    for value in (
+        data.get("addxSerialNumber"),
+        getattr(camera, "entity_id", None),
+        getattr(camera, "sn", None),
+    ):
+        if value in (None, ""):
+            continue
+        serial = str(value)
+        if serial not in result:
+            result.append(serial)
+    return result or [""]
+
+
+def _is_addx_device_no_access(error: Exception) -> bool:
+    """Return whether ADDX rejected the camera identity for access."""
+    message = str(error)
+    return "-2002" in message or "DEVICE_NO_ACCESS" in message
+
+
+def _masked_identifier(value: str) -> str:
+    """Return a compact identifier suffix for debug logs."""
+    text = str(value)
+    return f"...{text[-6:]}" if len(text) > 6 else text
 
 
 def _camera_resolution(value) -> str | None:
@@ -938,6 +966,11 @@ class AsyncXSense(XSenseBase):
     def _camera_addx_house(self, camera: Entity) -> House | None:
         """Return a House on the ADDX node that discovered this camera."""
         data = getattr(camera, "data", {}) or {}
+        house_id = data.get("addxHouseId")
+        if house_id not in (None, ""):
+            house = self.houses.get(str(house_id))
+            if house is not None:
+                return house
         node_type = data.get("addxNodeType")
         if node_type:
             for house in self.houses.values():
@@ -1238,14 +1271,11 @@ class AsyncXSense(XSenseBase):
 
     async def _list_addx_camera_devices(self) -> list[dict]:
         """List cameras from every APK ADDX node represented by the account."""
-        houses_by_node: dict[str, House] = {}
-        for house in self.houses.values():
-            houses_by_node.setdefault(_ipc_node_type(house.mqtt_region), house)
-
         devices_by_serial: dict[str, dict] = {}
         first_error: APIFailure | None = None
-        successful_nodes = 0
-        for index, (node_type, house) in enumerate(houses_by_node.items()):
+        successful_houses = 0
+        for index, house in enumerate(self.houses.values()):
+            node_type = _ipc_node_type(house.mqtt_region)
             try:
                 data = await self.addx_call(
                     "/device/listuserdevices",
@@ -1261,16 +1291,17 @@ class AsyncXSense(XSenseBase):
                 )
                 continue
 
-            successful_nodes += 1
+            successful_houses += 1
             for raw_device in (data or {}).get("list") or []:
                 normalized = _normalized_camera_serial(raw_device.get("serialNumber"))
                 if normalized is None:
                     continue
                 device = dict(raw_device)
                 device["addxNodeType"] = node_type
+                device["addxHouseId"] = house.house_id
                 devices_by_serial.setdefault(normalized, device)
 
-        if successful_nodes == 0 and first_error is not None:
+        if successful_houses == 0 and first_error is not None:
             raise first_error
         return list(devices_by_serial.values())
 
@@ -1298,7 +1329,11 @@ class AsyncXSense(XSenseBase):
             for station in house.stations.values():
                 if (
                     is_camera_entity(station)
-                    and _normalized_camera_serial(station.sn) == normalized_serial
+                    and normalized_serial
+                    in {
+                        _normalized_camera_serial(station.entity_id),
+                        _normalized_camera_serial(station.sn),
+                    }
                 ):
                     camera_type = _camera_type(data)
                     if camera_type:
@@ -1451,13 +1486,35 @@ class AsyncXSense(XSenseBase):
         ):
             return cached
 
-        data = await self._camera_addx_call(
-            camera,
-            "/device/getWebrtcTicket",
-            serialNumber=_camera_addx_serial(camera),
-            verifyDormancyStatus=True,
-        )
+        data = None
+        last_error: APIFailure | None = None
+        for serial in _camera_addx_serial_candidates(camera):
+            try:
+                data = await self._camera_addx_call(
+                    camera,
+                    "/device/getWebrtcTicket",
+                    serialNumber=serial,
+                    verifyDormancyStatus=True,
+                )
+                camera.set_data({"addxSerialNumber": serial})
+                break
+            except APIFailure as err:
+                last_error = err
+                if not _is_addx_device_no_access(err):
+                    raise
+                LOGGER.debug(
+                    "X-Sense camera WebRTC ticket identity rejected: %s",
+                    {
+                        "camera": _masked_identifier(getattr(camera, "sn", "")),
+                        "attempted_serial": _masked_identifier(serial),
+                        "error_type": type(err).__name__,
+                    },
+                )
+        if data is None and last_error is not None:
+            raise last_error
         if isinstance(data, dict):
+            data = dict(data)
+            data["serialNumber"] = _camera_addx_serial(camera)
             camera.set_data({"cameraWebrtcTicket": data})
             return data
         return None
@@ -2624,6 +2681,7 @@ def _camera_data(data: Dict) -> Dict:
 
     return {
         "activatedTime": data.get("activatedTime"),
+        "addxHouseId": data.get("addxHouseId"),
         "addxLocationId": data.get("locationId"),
         "addxNodeType": data.get("addxNodeType"),
         "addxSerialNumber": data.get("serialNumber"),

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -598,8 +598,8 @@ def _sbs50_force_arm_prompt(
         if force_reason:
             return {
                 "forceReason": force_reason,
-                "safeModeAim": station_data.get("safeModeAim")
-                or requested_mode
+                "safeModeAim": requested_mode
+                or station_data.get("safeModeAim")
                 or station_data.get("safeMode"),
                 "requestedSafeMode": requested_mode,
                 "exitDelay": station_data.get("exitDelay"),
@@ -620,8 +620,8 @@ def _sbs50_force_arm_prompt(
             continue
         return {
             "forceReason": force_reason,
-            "safeModeAim": event_param.get("safeModeAim")
-            or requested_mode
+            "safeModeAim": requested_mode
+            or event_param.get("safeModeAim")
             or station_data.get("safeModeAim")
             or station_data.get("safeMode"),
             "requestedSafeMode": requested_mode,

--- a/custom_components/xsense/services.yaml
+++ b/custom_components/xsense/services.yaml
@@ -1,3 +1,19 @@
+force_arm:
+  name: Force arm
+  description: Confirm a pending X-Sense Home or Away arm request after open sensors blocked the normal request.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+  fields:
+    mode:
+      required: true
+      selector:
+        select:
+          options:
+            - Home
+            - Away
+
 refresh_recordings:
   name: Refresh recordings
   description: Refresh the cached X-Sense camera recording index used by the X-Sense Recordings sidebar and Home Assistant Media Browser.

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -712,6 +712,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/ar.json
+++ b/custom_components/xsense/translations/ar.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/as.json
+++ b/custom_components/xsense/translations/as.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/cs.json
+++ b/custom_components/xsense/translations/cs.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/da.json
+++ b/custom_components/xsense/translations/da.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/de.json
+++ b/custom_components/xsense/translations/de.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/el.json
+++ b/custom_components/xsense/translations/el.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -712,6 +712,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/es.json
+++ b/custom_components/xsense/translations/es.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/et.json
+++ b/custom_components/xsense/translations/et.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/fa.json
+++ b/custom_components/xsense/translations/fa.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/fi.json
+++ b/custom_components/xsense/translations/fi.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/fr.json
+++ b/custom_components/xsense/translations/fr.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/he.json
+++ b/custom_components/xsense/translations/he.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/hi.json
+++ b/custom_components/xsense/translations/hi.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/hr.json
+++ b/custom_components/xsense/translations/hr.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/hu.json
+++ b/custom_components/xsense/translations/hu.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/id.json
+++ b/custom_components/xsense/translations/id.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/it.json
+++ b/custom_components/xsense/translations/it.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/ja.json
+++ b/custom_components/xsense/translations/ja.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/ko.json
+++ b/custom_components/xsense/translations/ko.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/lt.json
+++ b/custom_components/xsense/translations/lt.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/lv.json
+++ b/custom_components/xsense/translations/lv.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/nb.json
+++ b/custom_components/xsense/translations/nb.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/nl.json
+++ b/custom_components/xsense/translations/nl.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/no.json
+++ b/custom_components/xsense/translations/no.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/pl.json
+++ b/custom_components/xsense/translations/pl.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/pt-BR.json
+++ b/custom_components/xsense/translations/pt-BR.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/pt.json
+++ b/custom_components/xsense/translations/pt.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/ro.json
+++ b/custom_components/xsense/translations/ro.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/ru.json
+++ b/custom_components/xsense/translations/ru.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/sk.json
+++ b/custom_components/xsense/translations/sk.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/sl.json
+++ b/custom_components/xsense/translations/sl.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/sv.json
+++ b/custom_components/xsense/translations/sv.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/th.json
+++ b/custom_components/xsense/translations/th.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/tr.json
+++ b/custom_components/xsense/translations/tr.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/uk.json
+++ b/custom_components/xsense/translations/uk.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/vi.json
+++ b/custom_components/xsense/translations/vi.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/zh-CN.json
+++ b/custom_components/xsense/translations/zh-CN.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/zh-Hans.json
+++ b/custom_components/xsense/translations/zh-Hans.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/zh-Hant.json
+++ b/custom_components/xsense/translations/zh-Hant.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/custom_components/xsense/translations/zh-TW.json
+++ b/custom_components/xsense/translations/zh-TW.json
@@ -711,6 +711,9 @@
     "safe_mode_publish_failed": {
       "message": "Could not publish X-Sense security mode command"
     },
+    "force_arm_not_pending": {
+      "message": "X-Sense force arm is not pending for {mode} mode"
+    },
     "cooldown_state_unknown": {
       "message": "X-Sense cooldown enabled state is unknown"
     },

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5114,7 +5114,7 @@ async def test_camera_webrtc_ticket_uses_exact_addx_identity_in_multi_home_accou
 
 
 @pytest.mark.asyncio
-async def test_camera_discovery_lists_each_house_even_on_same_addx_node():
+async def test_camera_discovery_lists_each_distinct_addx_node_once():
     client = async_xsense.AsyncXSense()
     us_house = house.House(
         None, "us-house", "US Home", "US", "us-east-1", "mqtt-us"
@@ -5134,8 +5134,6 @@ async def test_camera_discovery_lists_each_house_even_on_same_addx_node():
 
     async def addx_call(endpoint, **kwargs):
         calls.append((endpoint, kwargs))
-        if kwargs.get("_house") is second_us_house:
-            return {"list": [{"serialNumber": "US-CAM-2", "modelNo": "SSC0A"}]}
         if kwargs.get("_house") is eu_house:
             return {"list": [{"serialNumber": "EU-CAM", "modelNo": "SSC0A"}]}
         return {"list": [{"serialNumber": "US-CAM", "modelNo": "SSC0A"}]}
@@ -5146,16 +5144,11 @@ async def test_camera_discovery_lists_each_house_even_on_same_addx_node():
 
     assert calls == [
         ("/device/listuserdevices", {}),
-        ("/device/listuserdevices", {"_house": second_us_house}),
         ("/device/listuserdevices", {"_house": eu_house}),
     ]
-    assert [
-        (item["serialNumber"], item["addxNodeType"], item["addxHouseId"])
-        for item in devices
-    ] == [
-        ("US-CAM", "US", "us-house"),
-        ("US-CAM-2", "US", "second-us-house"),
-        ("EU-CAM", "EU", "eu-house"),
+    assert [(item["serialNumber"], item["addxNodeType"]) for item in devices] == [
+        ("US-CAM", "US"),
+        ("EU-CAM", "EU"),
     ]
 
 
@@ -5182,7 +5175,6 @@ async def test_camera_discovery_continues_when_an_earlier_addx_node_fails():
             "serialNumber": "EU-CAM",
             "modelNo": "SSC0A",
             "addxNodeType": "EU",
-            "addxHouseId": "eu-house",
         }
     ]
 
@@ -5230,7 +5222,6 @@ async def test_update_camera_data_preserves_exact_addx_serial_for_later_calls():
     await client.update_camera_data()
     camera = test_house.get_station_by_sn("CAM-SN")
     assert camera.data["addxSerialNumber"] == "camsn"
-    assert camera.data["addxHouseId"] == "house-id"
 
     await client.get_camera_webrtc_ticket(camera, force_refresh=True)
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5114,7 +5114,7 @@ async def test_camera_webrtc_ticket_uses_exact_addx_identity_in_multi_home_accou
 
 
 @pytest.mark.asyncio
-async def test_camera_discovery_lists_each_distinct_addx_node_once():
+async def test_camera_discovery_lists_each_house_even_on_same_addx_node():
     client = async_xsense.AsyncXSense()
     us_house = house.House(
         None, "us-house", "US Home", "US", "us-east-1", "mqtt-us"
@@ -5134,6 +5134,8 @@ async def test_camera_discovery_lists_each_distinct_addx_node_once():
 
     async def addx_call(endpoint, **kwargs):
         calls.append((endpoint, kwargs))
+        if kwargs.get("_house") is second_us_house:
+            return {"list": [{"serialNumber": "US-CAM-2", "modelNo": "SSC0A"}]}
         if kwargs.get("_house") is eu_house:
             return {"list": [{"serialNumber": "EU-CAM", "modelNo": "SSC0A"}]}
         return {"list": [{"serialNumber": "US-CAM", "modelNo": "SSC0A"}]}
@@ -5144,11 +5146,16 @@ async def test_camera_discovery_lists_each_distinct_addx_node_once():
 
     assert calls == [
         ("/device/listuserdevices", {}),
+        ("/device/listuserdevices", {"_house": second_us_house}),
         ("/device/listuserdevices", {"_house": eu_house}),
     ]
-    assert [(item["serialNumber"], item["addxNodeType"]) for item in devices] == [
-        ("US-CAM", "US"),
-        ("EU-CAM", "EU"),
+    assert [
+        (item["serialNumber"], item["addxNodeType"], item["addxHouseId"])
+        for item in devices
+    ] == [
+        ("US-CAM", "US", "us-house"),
+        ("US-CAM-2", "US", "second-us-house"),
+        ("EU-CAM", "EU", "eu-house"),
     ]
 
 
@@ -5175,6 +5182,7 @@ async def test_camera_discovery_continues_when_an_earlier_addx_node_fails():
             "serialNumber": "EU-CAM",
             "modelNo": "SSC0A",
             "addxNodeType": "EU",
+            "addxHouseId": "eu-house",
         }
     ]
 
@@ -5222,6 +5230,7 @@ async def test_update_camera_data_preserves_exact_addx_serial_for_later_calls():
     await client.update_camera_data()
     camera = test_house.get_station_by_sn("CAM-SN")
     assert camera.data["addxSerialNumber"] == "camsn"
+    assert camera.data["addxHouseId"] == "house-id"
 
     await client.get_camera_webrtc_ticket(camera, force_refresh=True)
 
@@ -5233,6 +5242,166 @@ async def test_update_camera_data_preserves_exact_addx_serial_for_later_calls():
             "verifyDormancyStatus": True,
         },
     ) in calls
+
+
+@pytest.mark.asyncio
+async def test_camera_webrtc_ticket_falls_back_to_ipc_id_before_ipc_sn():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "addx-camera-id",
+                    "ipcSn": "label-or-ipc-sn",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["addx-camera-id"]
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        return {"signalServer": "https://signal.example"}
+
+    client.addx_call = addx_call
+
+    await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+
+    assert calls == [
+        (
+            "/device/getWebrtcTicket",
+            {
+                "_house": test_house,
+                "serialNumber": "addx-camera-id",
+                "verifyDormancyStatus": True,
+            },
+        )
+    ]
+    assert camera.data["cameraWebrtcTicket"]["serialNumber"] == "addx-camera-id"
+
+
+@pytest.mark.asyncio
+async def test_camera_webrtc_ticket_retries_ipc_id_after_rejected_cached_addx_serial():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "right-addx-camera-id",
+                    "ipcSn": "label-or-ipc-sn",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["right-addx-camera-id"]
+    camera.set_data({"addxSerialNumber": "wrong-cached-id"})
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if kwargs["serialNumber"] == "wrong-cached-id":
+            raise exceptions.APIFailure(
+                "ADDX request for /device/getWebrtcTicket failed with "
+                "error -2002/DEVICE_NO_ACCESS"
+            )
+        return {"signalServer": "https://signal.example"}
+
+    client.addx_call = addx_call
+
+    await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+
+    assert [
+        kwargs["serialNumber"]
+        for endpoint, kwargs in calls
+        if endpoint == "/device/getWebrtcTicket"
+    ] == ["wrong-cached-id", "right-addx-camera-id"]
+    assert camera.data["addxSerialNumber"] == "right-addx-camera-id"
+    assert camera.data["cameraWebrtcTicket"]["serialNumber"] == "right-addx-camera-id"
+
+
+@pytest.mark.asyncio
+async def test_camera_webrtc_ticket_does_not_retry_unrelated_addx_failure():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "right-addx-camera-id",
+                    "ipcSn": "label-or-ipc-sn",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["right-addx-camera-id"]
+    camera.set_data({"addxSerialNumber": "wrong-cached-id"})
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        raise exceptions.APIFailure(
+            "ADDX request for /device/getWebrtcTicket failed with error -1000/BOOM"
+        )
+
+    client.addx_call = addx_call
+
+    with pytest.raises(exceptions.APIFailure, match="-1000/BOOM"):
+        await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+
+    assert [
+        kwargs["serialNumber"]
+        for endpoint, kwargs in calls
+        if endpoint == "/device/getWebrtcTicket"
+    ] == ["wrong-cached-id"]
+
+
+def test_camera_from_addx_device_matches_existing_house_camera_by_ipc_id():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "addx-camera-id",
+                    "ipcSn": "label-or-ipc-sn",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+
+    camera = client._camera_from_addx_device(
+        {
+            "serialNumber": "addx-camera-id",
+            "deviceName": "Camera",
+            "modelNo": "SSC0A",
+            "houseId": "addx-location-id",
+        }
+    )
+
+    assert camera is test_house.stations["addx-camera-id"]
 
 
 def test_ipc_language_uses_simple_apk_app_language_code():

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -5066,6 +5066,103 @@ async def test_failed_webrtc_signal_start_is_removed_from_sessions(monkeypatch):
     assert messages[0].code == "xsense_webrtc_start_failed"
 
 
+async def test_webrtc_offer_uses_accepted_ticket_serial_for_signal_recipient(
+    monkeypatch,
+):
+    from custom_components.xsense import camera as camera_module
+    from custom_components.xsense.camera import (
+        CAMERA_DESCRIPTION,
+        XSenseWebRTCCameraEntity,
+    )
+    from homeassistant.components.camera.webrtc import WebRTCAnswer
+
+    camera_entity = entity(
+        "SSC0A",
+        {
+            "streamProtocol": "webrtc",
+            "supportWebrtc": True,
+            "resolution": "1280x720",
+        },
+    )
+    camera_entity.entity_id = "right-addx-camera-id"
+    camera_entity.sn = "label-or-ipc-sn"
+    camera_entity.name = "Camera"
+    camera_entity.online = True
+    captured = {}
+
+    async def get_camera_webrtc_ticket(entity, *, force_refresh=False):
+        return {
+            "serialNumber": "right-addx-camera-id",
+            "signalServer": "wss://signal.example",
+        }
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = SimpleNamespace(
+                get_camera_webrtc_ticket=get_camera_webrtc_ticket,
+            )
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    class FakeTicket:
+        is_valid = True
+
+    def from_api(serial_number, data):
+        captured["ticket_serial"] = serial_number
+        return FakeTicket()
+
+    class FakeSession:
+        def __init__(self, **kwargs):
+            captured["session_ticket"] = kwargs["ticket"]
+
+        async def add_candidate(self, candidate):
+            captured.setdefault("candidates", []).append(candidate)
+
+        async def start(self):
+            return "v=0\r\n"
+
+        async def close(self):
+            captured["closed"] = True
+
+        def start_forwarding_remote_candidates(self):
+            captured["forwarding"] = True
+
+    fake_module = SimpleNamespace(
+        XSenseWebRTCTicket=SimpleNamespace(from_api=from_api),
+        XSenseWebRTCSignalSession=FakeSession,
+    )
+
+    class FakeHass:
+        data = {}
+
+        async def async_add_import_executor_job(self, func, module):
+            return fake_module
+
+        def async_create_task(self, coro):
+            return asyncio.create_task(coro)
+
+    monkeypatch.setattr(
+        camera_module, "async_get_clientsession", lambda hass: SimpleNamespace()
+    )
+
+    camera = XSenseWebRTCCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+    camera.hass = FakeHass()
+    messages = []
+
+    await camera.async_handle_async_webrtc_offer(
+        "v=0\r\n", "session-1", messages.append
+    )
+
+    assert captured["ticket_serial"] == "right-addx-camera-id"
+    assert captured["forwarding"] is True
+    assert isinstance(messages[0], WebRTCAnswer)
+
+
 async def test_webrtc_candidate_is_forwarded_to_matching_signal_session():
     from custom_components.xsense.camera import (
         CAMERA_DESCRIPTION,

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -595,6 +595,68 @@ def test_force_arm_prompt_preserves_locally_requested_mode_from_apk_response():
     assert station.alarm_data["requestedSafeMode"] == "Away"
 
 
+async def test_alarm_panel_force_arm_requires_matching_pending_mode(monkeypatch):
+    class Api:
+        def __init__(self):
+            self.calls = []
+
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            self.calls.append((station.sn, safe_mode, force_arm))
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "requestedSafeMode": "Away",
+        }
+    )
+    coordinator = Coordinator(station)
+    coordinator.xsense = Api()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    dismissed = []
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: dismissed.append(notification_id),
+    )
+
+    with pytest.raises(Exception):
+        await panel.async_force_arm("Home")
+
+    assert coordinator.xsense.calls == []
+    await panel.async_force_arm("Away")
+
+    assert coordinator.xsense.calls == [(station.sn, "Away", "1")]
+    assert station.alarm_data["forceReason"] is None
+    assert station.alarm_data["requestedSafeMode"] is None
+    assert dismissed == [f"xsense_force_arm_{station.entity_id}"]
+
+    with pytest.raises(Exception):
+        await panel.async_force_arm("Away")
+    assert coordinator.xsense.calls == [(station.sn, "Away", "1")]
+
+
+def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Home"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "safeModeAim": "Away",
+            "forceReason": [{"deviceSN": "door-sn"}],
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Home"
+    assert station.alarm_data["safeModeAim"] == "Home"
+
+
 def test_empty_force_arm_reason_clears_pending_request_without_mode_change():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
@@ -619,19 +681,11 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
     coordinator = Coordinator(station)
     coordinator.entry = type("Entry", (), {"entry_id": "entry-id"})()
     panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.entity_id = "alarm_control_panel.base_station_alarm"
     panel.hass = object()
     panel.async_write_ha_state = lambda: None
     created = []
     dismissed = []
-    monkeypatch.setitem(
-        panel._force_arm_url.__func__.__globals__,
-        "async_sign_path",
-        lambda hass, path, expiration, *, use_content_user=False: (
-            f"{path}?authSig=test"
-            if use_content_user
-            else pytest.fail("force-arm path must use the content user")
-        ),
-    )
     monkeypatch.setattr(
         "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
         lambda hass, message, title=None, notification_id=None: created.append(
@@ -658,11 +712,9 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
             "hass": panel.hass,
             "message": (
                 "One or more sensors are open.\n\n"
-                "[**Force Arm Away**]"
-                f"(/api/xsense/force-arm/entry-id/{station.entity_id}/away"
-                "?authSig=test)\n\n"
-                "This sends the guarded X-Sense force-arm command for the "
-                "pending arm request."
+                "[**Force Arm Away**](/xsense-force-arm#"
+                "entity_id=alarm_control_panel.base_station_alarm&mode=Away)\n\n"
+                "Select the link to confirm the pending X-Sense arm request."
             ),
             "title": "X-Sense arm blocked",
             "notification_id": f"xsense_force_arm_{station.entity_id}",

--- a/tests/test_entity_translation_coverage.py
+++ b/tests/test_entity_translation_coverage.py
@@ -42,6 +42,7 @@ ACTION_ERROR_FILES = (
 EXPECTED_EXCEPTION_KEYS = {
     "cooldown_state_unknown",
     "entity_unavailable",
+    "force_arm_not_pending",
     "ids_missing",
     "ids_required",
     "invalid_radon_threshold",

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1662,6 +1662,112 @@ def test_recordings_panel_registration_adds_sidebar_panel(monkeypatch):
     )
 
 
+def test_recordings_panel_registration_is_concurrency_safe(monkeypatch):
+    from custom_components.xsense import frontend
+
+    static_paths = []
+    panels = []
+
+    class Http:
+        async def async_register_static_paths(self, paths):
+            await asyncio.sleep(0)
+            static_paths.extend(paths)
+
+    async def register_panel(**kwargs):
+        await asyncio.sleep(0)
+        panels.append(kwargs)
+
+    monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
+    hass = SimpleNamespace(data={}, http=Http())
+
+    async def register_concurrently():
+        await asyncio.gather(
+            frontend.async_register_recordings_panel(hass),
+            frontend.async_register_recordings_panel(hass),
+        )
+
+    asyncio.run(register_concurrently())
+
+    assert len(static_paths) == 1
+    assert len(panels) == 1
+
+
+def test_recordings_static_path_registration_is_concurrency_safe():
+    from custom_components.xsense import frontend
+
+    static_paths = []
+
+    class Http:
+        async def async_register_static_paths(self, paths):
+            await asyncio.sleep(0)
+            static_paths.extend(paths)
+
+    hass = SimpleNamespace(data={}, http=Http())
+
+    async def register_concurrently():
+        await asyncio.gather(
+            frontend.async_register_recordings_static_paths(hass),
+            frontend.async_register_recordings_static_paths(hass),
+        )
+
+    asyncio.run(register_concurrently())
+
+    assert len(static_paths) == 1
+
+
+def test_force_arm_panel_is_hidden_camera_independent_and_reference_counted(
+    monkeypatch,
+):
+    from custom_components.xsense import frontend
+
+    panels = []
+    removed = []
+
+    async def register_panel(**kwargs):
+        panels.append(kwargs)
+
+    async def register_static_paths(hass):
+        hass.data.setdefault(DOMAIN, {})["_recordings_static_paths_registered"] = True
+
+    monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
+    monkeypatch.setattr(
+        frontend, "async_register_recordings_static_paths", register_static_paths
+    )
+    monkeypatch.setattr(
+        frontend.frontend,
+        "async_remove_panel",
+        lambda hass, path, warn_if_unknown=False: removed.append(path),
+    )
+    hass = SimpleNamespace(data={})
+
+    asyncio.run(frontend.async_register_force_arm_panel(hass, "entry-1"))
+    asyncio.run(frontend.async_register_force_arm_panel(hass, "entry-2"))
+
+    assert len(panels) == 1
+    assert panels[0]["frontend_url_path"] == "xsense-force-arm"
+    assert panels[0]["webcomponent_name"] == "xsense-force-arm-panel"
+    assert panels[0].get("sidebar_title") is None
+    assert panels[0]["require_admin"] is False
+
+    frontend.async_unregister_force_arm_panel(hass, "entry-1")
+    assert removed == []
+    frontend.async_unregister_force_arm_panel(hass, "entry-2")
+    assert removed == ["xsense-force-arm"]
+
+
+def test_force_arm_panel_calls_authenticated_entity_action():
+    source = (
+        Path("custom_components/xsense/frontend/force-arm-panel.js")
+        .read_text(encoding="utf-8")
+    )
+
+    assert 'callService("xsense", "force_arm"' in source
+    assert "entity_id: entityId" in source
+    assert "mode," in source
+    assert "/api/xsense/force-arm" not in source
+    assert "authSig" not in source
+
+
 def test_recordings_panel_unregister_removes_sidebar_panel(monkeypatch):
     from custom_components.xsense import frontend
 
@@ -2515,118 +2621,12 @@ def test_recordings_http_registration_adds_panel_views():
     asyncio.run(http.async_register_recordings_http_views(hass))
     asyncio.run(http.async_register_recordings_http_views(hass))
 
-    assert len(views) == 6
+    assert len(views) == 5
     assert isinstance(views[0], http.XSenseRecordingsPanelDataView)
     assert isinstance(views[1], http.XSenseRecordingsPanelDebugView)
     assert isinstance(views[2], http.XSenseRecordingsPanelPlaybackView)
     assert isinstance(views[3], http.XSenseRecordingsPanelThumbnailView)
     assert isinstance(views[4], http.XSenseRecordingsHlsSegmentView)
-    assert isinstance(views[5], http.XSenseForceArmView)
-
-
-def test_force_arm_view_sends_guarded_command_and_redirects(monkeypatch):
-    from aiohttp import web
-    from custom_components.xsense import http
-
-    class Api:
-        def __init__(self):
-            self.calls = []
-
-        async def set_station_mode(self, station, safe_mode, force_arm=None):
-            self.calls.append((station.sn, safe_mode, force_arm))
-
-    class Registry:
-        def async_get_entity_id(self, domain, platform, unique_id):
-            assert domain == "alarm_control_panel"
-            assert platform == DOMAIN
-            assert unique_id == "station-sn_alarm"
-            return "alarm_control_panel.base_station_alarm"
-
-    station = SimpleNamespace(
-        alarm_data={"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Away"},
-        entity_id="station-id",
-        name="Base Station",
-        sn="station-sn",
-    )
-    station.set_alarm_data = station.alarm_data.update
-    api = Api()
-    hass = SimpleNamespace(
-        data={
-            DOMAIN: {
-                "entry-id": SimpleNamespace(
-                    data={"stations": {"station-id": station}},
-                    xsense=api,
-                )
-            }
-        }
-    )
-    dismissed = []
-    monkeypatch.setattr(http.er, "async_get", lambda hass: Registry())
-    monkeypatch.setattr(
-        http.persistent_notification,
-        "async_dismiss",
-        lambda hass, notification_id: dismissed.append(notification_id),
-    )
-
-    with pytest.raises(web.HTTPFound) as exc:
-        asyncio.run(
-            http.XSenseForceArmView(hass).get(
-                SimpleNamespace(),
-                "entry-id",
-                "station-id",
-                "away",
-            )
-        )
-
-    assert api.calls == [("station-sn", "Away", "1")]
-    assert dismissed == ["xsense_force_arm_station-id"]
-    assert station.alarm_data["forceReason"] is None
-    assert station.alarm_data["safeModeAim"] is None
-    assert exc.value.location == (
-        "/?more-info-entity-id=alarm_control_panel.base_station_alarm"
-    )
-
-
-def test_force_arm_view_requires_matching_pending_prompt():
-    from aiohttp import web
-    from custom_components.xsense import http
-
-    class Api:
-        def __init__(self):
-            self.calls = []
-
-        async def set_station_mode(self, station, safe_mode, force_arm=None):
-            self.calls.append((station.sn, safe_mode, force_arm))
-
-    station = SimpleNamespace(
-        alarm_data={"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Home"},
-        entity_id="station-id",
-        name="Base Station",
-        sn="station-sn",
-    )
-    api = Api()
-    hass = SimpleNamespace(
-        data={
-            DOMAIN: {
-                "entry-id": SimpleNamespace(
-                    data={"stations": {"station-id": station}},
-                    xsense=api,
-                )
-            }
-        }
-    )
-
-    with pytest.raises(web.HTTPConflict):
-        asyncio.run(
-            http.XSenseForceArmView(hass).get(
-                SimpleNamespace(),
-                "entry-id",
-                "station-id",
-                "away",
-            )
-        )
-
-    assert api.calls == []
 
 
 def test_recordings_hls_playlist_rewrites_segments_to_token_route(tmp_path):


### PR DESCRIPTION
## Summary
- add another ADDX camera ticket fallback using the APK camera device identity when X-Sense denies the normal camera identity
- rework force-arm confirmation through an authenticated hidden HA panel instead of a state-changing URL
- include Home mode in the force-arm prompt path and keep the flow independent of the recordings sidebar

## Tests
- python -m compileall -q custom_components tests
- node --check custom_components/xsense/frontend/force-arm-panel.js
- git diff --check
- pytest -q (751 passed)
