### PR TITLE
Prepare v1.4.19 release rollup

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.18.2):
-  (e.g., 1.4.18.2)
+- **X-Sense-Integration Version** (z. B. 1.4.19):
+  (e.g., 1.4.19)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.md
+++ b/.github/release-notes/1.4.19.md
@@ -1,0 +1,17 @@
+## X-Sense Home Security v1.4.19
+
+This release brings the v1.4.18.1 and v1.4.18.2 pre-release changes to the main release channel.
+
+### 📷 Cameras
+- Improves camera access for accounts with more than one X-Sense Home by keeping requests on the camera's ADDX node and preserving the exact camera identity returned by X-Sense.
+- Retries WebRTC ticket requests with the APK camera device identity when X-Sense rejects the normal ADDX identity.
+- Keeps existing camera data available when another camera node cannot be refreshed.
+
+### 🔐 Alarm Panel
+- Adds SBS50 force-arm confirmation after a normal Home or Away arm request is refused because a sensor is open.
+- Uses an authenticated Home Assistant action page that also works for alarm systems without X-Sense cameras.
+- Clears the force-arm prompt after the request succeeds, is cancelled, or the system is disarmed.
+
+### 🛠️ Reliability
+- Prevents integration setup from failing when Home Assistant already has the X-Sense Recordings or force-arm panel registered.
+- Cleans up cached MQTT subscription matches when the integration is unloaded or reloaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19](.github/release-notes/1.4.19.md)
 - [1.4.18.2](.github/release-notes/1.4.18.2.md)
 - [1.4.18.1](.github/release-notes/1.4.18.1.md)
 - [1.4.18](.github/release-notes/1.4.18.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.18.2"
+PANEL_ASSET_VERSION = "1.4.19"
 
 
 def _recordings_panel_module_url() -> str:
@@ -59,6 +59,9 @@ async def async_register_recordings_panel(hass: HomeAssistant) -> None:
     async with lock:
         if domain_data.get("_recordings_panel_registered"):
             return
+        if frontend.async_panel_exists(hass, FRONTEND_URL_PATH):
+            domain_data["_recordings_panel_registered"] = True
+            return
 
         await async_register_recordings_static_paths(hass)
         await panel_custom.async_register_panel(
@@ -83,6 +86,9 @@ async def async_register_force_arm_panel(
     lock = domain_data.setdefault("_force_arm_panel_lock", asyncio.Lock())
     async with lock:
         if domain_data.get("_force_arm_panel_registered"):
+            return
+        if frontend.async_panel_exists(hass, FORCE_ARM_FRONTEND_URL_PATH):
+            domain_data["_force_arm_panel_registered"] = True
             return
 
         await async_register_recordings_static_paths(hass)

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.18.2",
+  "version": "1.4.19",
   "zeroconf": []
 }

--- a/custom_components/xsense/mqtt.py
+++ b/custom_components/xsense/mqtt.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Callable, Coroutine, Iterable
 import contextlib
-from functools import lru_cache, partial
+from functools import partial
 from itertools import chain
 import inspect
 import logging
@@ -84,6 +84,7 @@ class XSenseMQTT:
         )
         self._wildcard_subscriptions: set[Subscription] = set()
         self._retained_topics: defaultdict[Subscription, set[str]] = defaultdict(set)
+        self._matching_subscriptions_cache: dict[str, list[Subscription]] = {}
 
         self._subscribe_debouncer = EnsureJobAfterCooldown(
             INITIAL_SUBSCRIBE_COOLDOWN, self._async_perform_subscriptions
@@ -395,6 +396,9 @@ class XSenseMQTT:
             if disconnect_paho_client:
                 self._mqttc.disconnect()
 
+        # Release cached subscription jobs when this config entry unloads.
+        self._matching_subscriptions_cache.clear()
+
     # unchanged
     @callback
     def async_restore_tracked_subscriptions(
@@ -403,7 +407,7 @@ class XSenseMQTT:
         """Restore tracked subscriptions after reload."""
         for subscription in subscriptions:
             self._async_track_subscription(subscription)
-        self._matching_subscriptions.cache_clear()
+        self._matching_subscriptions_cache.clear()
 
     # unchanged
     @callback
@@ -521,7 +525,7 @@ class XSenseMQTT:
         )
 
         self._async_track_subscription(subscription)
-        self._matching_subscriptions.cache_clear()
+        self._matching_subscriptions_cache.clear()
 
         if self.connected:
             self.config_entry.async_create_background_task(
@@ -537,7 +541,7 @@ class XSenseMQTT:
     def _async_remove(self, subscription: Subscription) -> None:
         """Remove subscription."""
         self._async_untrack_subscription(subscription)
-        self._matching_subscriptions.cache_clear()
+        self._matching_subscriptions_cache.clear()
         if subscription in self._retained_topics:
             del self._retained_topics[subscription]
         # Only unsubscribe if currently connected
@@ -650,8 +654,9 @@ class XSenseMQTT:
         self._async_connection_result(True)
 
     # def _async_queue_resubscribe
-    @lru_cache(None)  # pylint: disable=method-cache-max-size-none
     def _matching_subscriptions(self, topic: str) -> list[Subscription]:
+        if topic in self._matching_subscriptions_cache:
+            return self._matching_subscriptions_cache[topic]
         subscriptions: list[Subscription] = []
         if topic in self._simple_subscriptions:
             subscriptions.extend(self._simple_subscriptions[topic])
@@ -662,6 +667,7 @@ class XSenseMQTT:
             # is_simple_match is False
             if subscription.complex_matcher(topic)  # type: ignore[misc]
         )
+        self._matching_subscriptions_cache[topic] = subscriptions
         return subscriptions
 
     @callback

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 from collections import defaultdict
 from datetime import timedelta
@@ -7,7 +8,8 @@ import json
 import logging
 import sys
 import types
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -188,9 +190,37 @@ def _subscription_test_client():
     client._simple_subscriptions = defaultdict(set)
     client._wildcard_subscriptions = set()
     client._retained_topics = defaultdict(set)
+    client._matching_subscriptions_cache = {}
     client._subscription_id = 0
     client.connected = False
     return client
+
+
+@pytest.mark.asyncio
+async def test_xsense_mqtt_disconnect_releases_subscription_match_cache():
+    class Debouncer:
+        async def async_cleanup(self):
+            return None
+
+        def set_timeout(self, timeout):
+            return None
+
+    client = _subscription_test_client()
+    client._subscribe_debouncer = Debouncer()
+    client._unsubscribe_debouncer = Debouncer()
+    client._pending_operations = {}
+    client._connection_lock = asyncio.Lock()
+    client._should_reconnect = True
+    client._reconnect_task = None
+    client._async_perform_unsubscribes = AsyncMock()
+    client._mqttc = SimpleNamespace(disconnect=Mock())
+
+    client._matching_subscriptions("x/sense/one")
+    assert set(client._matching_subscriptions_cache) == {"x/sense/one"}
+
+    await client.async_disconnect()
+
+    assert client._matching_subscriptions_cache == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1692,6 +1692,36 @@ def test_recordings_panel_registration_is_concurrency_safe(monkeypatch):
     assert len(panels) == 1
 
 
+def test_recordings_panel_registration_adopts_existing_home_assistant_panel(
+    monkeypatch,
+):
+    from custom_components.xsense import frontend
+
+    panels = []
+    static_paths = []
+
+    class Http:
+        async def async_register_static_paths(self, paths):
+            static_paths.extend(paths)
+
+    async def register_panel(**kwargs):
+        panels.append(kwargs)
+
+    monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
+    monkeypatch.setattr(
+        frontend.frontend,
+        "async_panel_exists",
+        lambda hass, path: path == frontend.FRONTEND_URL_PATH,
+    )
+    hass = SimpleNamespace(data={}, http=Http())
+
+    asyncio.run(frontend.async_register_recordings_panel(hass))
+
+    assert panels == []
+    assert static_paths == []
+    assert hass.data[DOMAIN]["_recordings_panel_registered"] is True
+
+
 def test_recordings_static_path_registration_is_concurrency_safe():
     from custom_components.xsense import frontend
 
@@ -1753,6 +1783,31 @@ def test_force_arm_panel_is_hidden_camera_independent_and_reference_counted(
     assert removed == []
     frontend.async_unregister_force_arm_panel(hass, "entry-2")
     assert removed == ["xsense-force-arm"]
+
+
+def test_force_arm_panel_registration_adopts_existing_home_assistant_panel(
+    monkeypatch,
+):
+    from custom_components.xsense import frontend
+
+    panels = []
+
+    async def register_panel(**kwargs):
+        panels.append(kwargs)
+
+    monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
+    monkeypatch.setattr(
+        frontend.frontend,
+        "async_panel_exists",
+        lambda hass, path: path == frontend.FORCE_ARM_FRONTEND_URL_PATH,
+    )
+    hass = SimpleNamespace(data={})
+
+    asyncio.run(frontend.async_register_force_arm_panel(hass, "entry-1"))
+
+    assert panels == []
+    assert hass.data[DOMAIN]["_force_arm_panel_entries"] == {"entry-1"}
+    assert hass.data[DOMAIN]["_force_arm_panel_registered"] is True
 
 
 def test_force_arm_panel_calls_authenticated_entity_action():


### PR DESCRIPTION
## Summary
- roll up v1.4.18.1 and v1.4.18.2 changes as v1.4.19
- adopt already-registered X-Sense panels instead of raising an overwrite error during setup
- make MQTT subscription matching cache entry-local and release it on unload
- add lifecycle regression coverage

## Release scope
- multi-Home camera identity and node handling
- SBS50 force-arm confirmation for Home and Away modes
- panel registration and config-entry reload reliability

## Checks
- 754 tests passed on Linux with Python 3.14
- Python compile checks passed
- frontend JavaScript syntax checks passed
- targeted async, undefined-name, and cache checks passed