### PR TITLE
Improve multi-Home camera event routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19):
-  (e.g., 1.4.19)
+- **X-Sense-Integration Version** (z. B. 1.4.19.1):
+  (e.g., 1.4.19.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.1.md
+++ b/.github/release-notes/1.4.19.1.md
@@ -1,0 +1,10 @@
+## X-Sense Home Security v1.4.19.1
+
+### 📷 Camera Events
+- Improves motion and AI-detection event delivery for camera accounts with more than one X-Sense Home.
+- Uses each camera's exact X-Sense camera identity and Home context when polling recording history.
+- Polls recording history per camera so activity from one camera cannot hide another camera's recent events.
+- Matches recording clips back to the correct Home Assistant camera when X-Sense uses a different ADDX camera identifier.
+
+### 🛠️ Reliability
+- Prevents the one-time duplicate X-Sense panel registration error during integration setup or reload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19.1](.github/release-notes/1.4.19.1.md)
 - [1.4.19](.github/release-notes/1.4.19.md)
 - [1.4.18.2](.github/release-notes/1.4.18.2.md)
 - [1.4.18.1](.github/release-notes/1.4.18.1.md)

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -18,7 +18,12 @@ from homeassistant.helpers.event import async_call_later, async_track_time_inter
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.logging import catch_log_exception
 
-from .python_xsense import AsyncXSense, House
+from .python_xsense import (
+    AsyncXSense,
+    House,
+    camera_addx_serial,
+    camera_matches_identifier,
+)
 from .python_xsense.async_xsense import is_camera_entity
 from .python_xsense.event_parser import (
     camera_ai_history_event_key as _camera_ai_history_event_key,
@@ -70,6 +75,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_camera_update_attempt: datetime | None = None
         self._camera_station_cache: dict[str, Any] = {}
         self._camera_ai_history_seen: set[str] = set()
+        self._camera_ai_service_houses: dict[str, set[str]] = {}
         self._camera_ai_history_unsub = None
         self._camera_ai_history_lock = asyncio.Lock()
         self._startup_refresh_complete = False
@@ -469,6 +475,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             service_list_available = True
 
+        if service_list_available:
+            self._camera_ai_service_houses = _camera_ai_service_house_map(services)
+
         server_ids = [
             str(service.get("serverId"))
             for service in services
@@ -536,9 +545,8 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _update_camera_event_history(self, cameras: list[Any]) -> bool:
         """Poll APK ADDX camera record history for regular motion events."""
-        serial_numbers = [
-            str(camera.sn) for camera in cameras if getattr(camera, "sn", None)
-        ]
+        serial_numbers = [camera_addx_serial(camera) for camera in cameras]
+        serial_numbers = [serial for serial in serial_numbers if serial]
         if not serial_numbers:
             LOGGER.debug(
                 "X-Sense camera record history poll skipped: no serial numbers"
@@ -551,8 +559,8 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         seen_now: set[str] = set()
         now = int(datetime.now(timezone.utc).timestamp())
         try:
-            history = await self.xsense.get_camera_event_history(
-                serial_numbers,
+            history = await self.xsense.get_camera_event_history_for_cameras(
+                cameras,
                 now - 3600,
                 now,
             )
@@ -599,7 +607,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not isinstance(station_data, dict) or not station_data:
             return False
 
-        station = _camera_station_for_event_data(self, station_data, payload)
+        station = _camera_station_for_ai_server(self, server_id)
+        if station is None:
+            station = _camera_station_for_event_data(self, station_data, payload)
         if station is None:
             LOGGER.debug(
                 "No X-Sense camera found for AI history event: %s",
@@ -724,7 +734,20 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             station_sn = _mqtt_target_station_sn(station_data)
             device_sn = _mqtt_target_device_sn(station_data)
 
-        station = self._get_station_by_id(station_sn)
+        topic_kind = _mqtt_topic_kind(topic)
+        station = None
+        if topic_kind == "ai_plan":
+            server_id = data.get("serverId")
+            if server_id in (None, "") and isinstance(station_data, dict):
+                server_id = station_data.get("serverId")
+            station = _camera_station_for_ai_server(self, server_id)
+            if station is None:
+                station = _camera_station_for_identifiers(
+                    self,
+                    [device_sn, *_mqtt_identifier_candidates(station_data, data)],
+                )
+        if station is None:
+            station = self._get_station_by_id(station_sn)
         if station is None:
             station = self._get_station_by_device_sn(device_sn)
         identifier_candidates: list[str] = []
@@ -736,6 +759,8 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 station = self._get_station_by_id(identifier)
                 if station is None:
                     station = self._get_station_by_device_sn(identifier)
+                if station is None:
+                    station = _camera_station_for_identifiers(self, [identifier])
                 if station is not None:
                     break
 
@@ -1041,13 +1066,87 @@ def _camera_station_for_event_data(
 ):
     """Return the camera station matched by APK event identifiers."""
     identifiers = _mqtt_identifier_candidates(station_data, payload)
+    return _camera_station_for_identifiers(coordinator, identifiers)
+
+
+def _camera_station_for_identifiers(
+    coordinator: XSenseDataUpdateCoordinator,
+    identifiers: list[Any],
+):
+    """Return the camera matching X-Sense station, IPC, or ADDX identifiers."""
     for identifier in identifiers:
-        station = coordinator._get_station_by_id(identifier)
+        if identifier in (None, ""):
+            continue
+        station = coordinator._get_station_by_id(str(identifier))
         if station is None:
-            station = coordinator._get_station_by_device_sn(identifier)
+            station = coordinator._get_station_by_device_sn(str(identifier))
         if station is not None and is_camera_entity(station):
             return station
+        for camera in _camera_entities(coordinator):
+            if camera_matches_identifier(camera, identifier):
+                return camera
     return None
+
+
+def _camera_station_for_ai_server(
+    coordinator: XSenseDataUpdateCoordinator, server_id: Any
+):
+    """Return the unique camera in the APK AI service's Home."""
+    if server_id in (None, ""):
+        return None
+    house_ids = getattr(coordinator, "_camera_ai_service_houses", {}).get(
+        str(server_id)
+    )
+    if not house_ids:
+        return None
+    if isinstance(house_ids, str):
+        house_ids = {house_ids}
+
+    matches = []
+    for camera in _camera_entities(coordinator):
+        camera_house = getattr(camera, "house", None)
+        data = getattr(camera, "data", {}) or {}
+        camera_house_ids = {
+            str(value)
+            for value in (
+                getattr(camera_house, "house_id", None),
+                data.get("addxHouseId"),
+                data.get("addxLocationId"),
+            )
+            if value not in (None, "")
+        }
+        if camera_house_ids & set(house_ids):
+            matches.append(camera)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _camera_ai_service_house_map(
+    services: Any,
+) -> dict[str, set[str]]:
+    """Return APK AI service Home coverage, including nested plan Homes."""
+    result: dict[str, set[str]] = {}
+    if not isinstance(services, list):
+        return result
+    for service in services:
+        if not isinstance(service, dict) or service.get("serverId") in (None, ""):
+            continue
+        house_ids = {
+            str(value)
+            for value in (service.get("houseId"),)
+            if value not in (None, "")
+        }
+        ai_plan = service.get("aiPlan")
+        if isinstance(ai_plan, dict):
+            plan_house_ids = ai_plan.get("houseIds")
+            if isinstance(plan_house_ids, list):
+                house_ids.update(
+                    str(value)
+                    for value in plan_house_ids
+                    if value not in (None, "")
+                )
+        if house_ids:
+            result[str(service["serverId"])] = house_ids
+    return result
 
 
 def _is_keypad_notice_topic(topic: str) -> bool:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19"
+PANEL_ASSET_VERSION = "1.4.19.1"
 
 
 def _recordings_panel_module_url() -> str:
@@ -29,6 +29,12 @@ def _recordings_panel_module_url() -> str:
 def _force_arm_panel_module_url() -> str:
     """Return the force-arm action module URL with a release cache-buster."""
     return f"{STATIC_URL_PATH}/force-arm-panel.js?v={PANEL_ASSET_VERSION}"
+
+
+def _panel_exists(hass: HomeAssistant, frontend_url_path: str) -> bool:
+    """Return whether Home Assistant already owns this panel path."""
+    panels = hass.data.get(frontend.DATA_PANELS, {})
+    return isinstance(panels, dict) and frontend_url_path in panels
 
 
 async def async_register_recordings_static_paths(hass: HomeAssistant) -> None:
@@ -59,7 +65,7 @@ async def async_register_recordings_panel(hass: HomeAssistant) -> None:
     async with lock:
         if domain_data.get("_recordings_panel_registered"):
             return
-        if frontend.async_panel_exists(hass, FRONTEND_URL_PATH):
+        if _panel_exists(hass, FRONTEND_URL_PATH):
             domain_data["_recordings_panel_registered"] = True
             return
 
@@ -87,7 +93,7 @@ async def async_register_force_arm_panel(
     async with lock:
         if domain_data.get("_force_arm_panel_registered"):
             return
-        if frontend.async_panel_exists(hass, FORCE_ARM_FRONTEND_URL_PATH):
+        if _panel_exists(hass, FORCE_ARM_FRONTEND_URL_PATH):
             domain_data["_force_arm_panel_registered"] = True
             return
 

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -23,6 +23,6 @@
     "paho-mqtt>=2.1.0,<3"
   ],
   "ssdp": [],
-  "version": "1.4.19",
+  "version": "1.4.19.1",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/__init__.py
+++ b/custom_components/xsense/python_xsense/__init__.py
@@ -1,7 +1,7 @@
 """Async X-Sense cloud, MQTT, and camera client library."""
 
 from .device import Device
-from .async_xsense import AsyncXSense
+from .async_xsense import AsyncXSense, camera_addx_serial, camera_matches_identifier
 from .house import House
 from .mqtt_helper import MQTTHelper
 from .station import Station
@@ -10,6 +10,8 @@ __version__ = "0.1.0"
 
 __all__ = [
     "AsyncXSense",
+    "camera_addx_serial",
+    "camera_matches_identifier",
     "Device",
     "House",
     "MQTTHelper",

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -187,7 +187,7 @@ def is_camera_entity(entity: Entity) -> bool:
     """Return if an entity came from the APK camera sources."""
     return (
         getattr(entity, "entity_type", None) == EntityType.CAMERA
-        or entity.type in CAMERA_TYPES
+        or getattr(entity, "type", None) in CAMERA_TYPES
     )
 
 
@@ -219,6 +219,22 @@ def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
         if serial not in result:
             result.append(serial)
     return result or [""]
+
+
+def camera_addx_serial(camera: Entity) -> str:
+    """Return the APK ADDX serial used for account-level camera APIs."""
+    return _camera_addx_serial(camera)
+
+
+def camera_matches_identifier(camera: Entity, identifier: Any) -> bool:
+    """Return whether an APK event identifier belongs to this camera."""
+    normalized = _normalized_camera_serial(identifier)
+    if normalized is None:
+        return False
+    return any(
+        _normalized_camera_serial(candidate) == normalized
+        for candidate in _camera_addx_serial_candidates(camera)
+    )
 
 
 def _is_addx_device_no_access(error: Exception) -> bool:
@@ -528,6 +544,7 @@ class AsyncXSense(XSenseBase):
         start_timestamp: int,
         end_timestamp: int,
         *,
+        house: House | None = None,
         start: int = 0,
         limit: int = 20,
     ) -> dict:
@@ -543,6 +560,7 @@ class AsyncXSense(XSenseBase):
             serialNumber=serials,
             tags=[],
             marked=0,
+            **({"_house": house} if house is not None else {}),
             **{"from": start},
         )
         LOGGER.debug(
@@ -550,6 +568,63 @@ class AsyncXSense(XSenseBase):
             _debug_data_shape(data),
         )
         return data if isinstance(data, dict) else {}
+
+    async def get_camera_event_history_for_cameras(
+        self,
+        cameras: list[Entity],
+        start_timestamp: int,
+        end_timestamp: int,
+        *,
+        start: int = 0,
+        limit: int = 20,
+    ) -> dict:
+        """Return camera records through each camera's APK ADDX Home context."""
+        requests: list[tuple[House | None, str]] = []
+        seen_serials: set[str] = set()
+        for camera in cameras:
+            serial = _camera_addx_serial(camera)
+            normalized_serial = _normalized_camera_serial(serial) or serial
+            if not serial or normalized_serial in seen_serials:
+                continue
+            seen_serials.add(normalized_serial)
+            requests.append((self._camera_addx_house(camera), serial))
+
+        records: list[dict[str, Any]] = []
+        first_error: APIFailure | None = None
+        successful_requests = 0
+        for house, serial in requests:
+            try:
+                history = await self.get_camera_event_history(
+                    [serial],
+                    start_timestamp,
+                    end_timestamp,
+                    house=house,
+                    start=start,
+                    limit=limit,
+                )
+            except APIFailure as err:
+                if first_error is None:
+                    first_error = err
+                LOGGER.debug(
+                    "X-Sense camera record history unavailable on ADDX Home",
+                    exc_info=True,
+                )
+                continue
+            successful_requests += 1
+            data = (
+                history.get("data")
+                if isinstance(history.get("data"), dict)
+                else history
+            )
+            group_records = data.get("list") if isinstance(data, dict) else None
+            if isinstance(group_records, list):
+                records.extend(
+                    record for record in group_records if isinstance(record, dict)
+                )
+
+        if successful_requests == 0 and first_error is not None:
+            raise first_error
+        return {"list": records, "total": len(records)}
 
     async def get_camera_event_record_history(
         self,
@@ -966,6 +1041,11 @@ class AsyncXSense(XSenseBase):
     def _camera_addx_house(self, camera: Entity) -> House | None:
         """Return a House on the ADDX node that discovered this camera."""
         data = getattr(camera, "data", {}) or {}
+        addx_house_id = data.get("addxHouseId")
+        if addx_house_id not in (None, ""):
+            for house in self.houses.values():
+                if str(house.house_id) == str(addx_house_id):
+                    return house
         node_type = data.get("addxNodeType")
         if node_type:
             for house in self.houses.values():
@@ -2678,6 +2758,7 @@ def _camera_data(data: Dict) -> Dict:
 
     return {
         "activatedTime": data.get("activatedTime"),
+        "addxHouseId": data.get("houseId"),
         "addxLocationId": data.get("locationId"),
         "addxNodeType": data.get("addxNodeType"),
         "addxSerialNumber": data.get("serialNumber"),

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -29,7 +29,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.storage import Store
 
-from .python_xsense.async_xsense import is_camera_entity
+from .python_xsense.async_xsense import camera_addx_serial, is_camera_entity
 from .recordings_gate import has_any_camera_entities
 from .const import (
     CONF_RECORDING_MEDIA_CLIPS_ORDER,
@@ -1539,6 +1539,15 @@ class XSenseRecordingIndex:
 
     async def _async_refresh(self) -> dict[str, Any]:
         cameras = _coordinator_cameras(self.coordinator, self.entry_id)
+        camera_entities = [
+            entity
+            for camera in cameras
+            if (
+                entity := _coordinator_camera_entity(
+                    self.coordinator, str(camera.get("serial") or "")
+                )
+            )
+        ]
         serials = [camera["serial"] for camera in cameras if camera.get("serial")]
         if not serials:
             empty_index = {
@@ -1553,8 +1562,8 @@ class XSenseRecordingIndex:
 
         end = datetime.now(timezone.utc)
         start = end - timedelta(days=RECORDING_LOOKBACK_DAYS)
-        history = await self.coordinator.xsense.get_camera_event_history(
-            serials,
+        history = await self.coordinator.xsense.get_camera_event_history_for_cameras(
+            camera_entities,
             int(start.timestamp()),
             int(end.timestamp()),
             limit=RECORDING_PAGE_LIMIT,
@@ -1636,6 +1645,7 @@ def _coordinator_cameras(coordinator: Any, entry_id: str) -> list[dict[str, Any]
             {
                 "entry_id": entry_id,
                 "serial": serial,
+                "addx_serial": camera_addx_serial(entity),
                 "entity_id": str(getattr(entity, "entity_id", "") or ""),
                 "name": str(getattr(entity, "name", "") or serial),
                 "online": bool(getattr(entity, "online", False)),
@@ -1670,7 +1680,20 @@ def _recording_clip_from_record(
     )
     if not serial:
         return None
-    camera = next((item for item in cameras if item.get("serial") == serial), None)
+    normalized_serial = _normalized_recording_camera_identifier(serial)
+    camera = next(
+        (
+            item
+            for item in cameras
+            if normalized_serial
+            in {
+                _normalized_recording_camera_identifier(item.get("serial")),
+                _normalized_recording_camera_identifier(item.get("entity_id")),
+                _normalized_recording_camera_identifier(item.get("addx_serial")),
+            }
+        ),
+        None,
+    )
     if camera is None:
         return None
     media_root = media_root or _recording_media_root_from_value(None)
@@ -1683,7 +1706,7 @@ def _recording_clip_from_record(
     camera_entity_id = str(camera.get("entity_id") or "")
     return _recording_clip_from_playback(
         entry_id,
-        serial,
+        str(camera.get("serial") or serial),
         camera_entity_id,
         {
             **playback,
@@ -1691,6 +1714,15 @@ def _recording_clip_from_record(
             "end_time_s": end,
         },
         media_root,
+    )
+
+
+def _normalized_recording_camera_identifier(value: Any) -> str:
+    """Normalize X-Sense camera identifiers for history record matching."""
+    return "".join(
+        character
+        for character in str(value or "").lower()
+        if character.isalnum()
     )
 
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -4793,6 +4793,114 @@ async def test_camera_event_history_uses_apk_addx_library_record_path():
 
 
 @pytest.mark.asyncio
+async def test_camera_event_history_uses_requested_addx_home():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-2", mqtt_region="eu-west-1")
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        return {"list": []}
+
+    client.addx_call = addx_call
+
+    await client.get_camera_event_history(
+        ["camera-sn"],
+        1781484300,
+        1781487900,
+        house=house,
+    )
+
+    assert calls[0][1]["_house"] is house
+
+
+@pytest.mark.asyncio
+async def test_camera_event_history_groups_cameras_by_addx_home():
+    client = async_xsense.AsyncXSense()
+    house_1 = SimpleNamespace(house_id="house-1", mqtt_region="us-east-1")
+    house_2 = SimpleNamespace(house_id="house-2", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house_1, "house-2": house_2}
+    camera_1 = SimpleNamespace(
+        sn="ipc-camera-1",
+        entity_id="ipc-camera-1",
+        data={"addxSerialNumber": "addx-camera-1"},
+        house=house_1,
+    )
+    camera_2 = SimpleNamespace(
+        sn="ipc-camera-2",
+        entity_id="ipc-camera-2",
+        data={"addxSerialNumber": "addx-camera-2"},
+        house=house_2,
+    )
+    calls = []
+
+    async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
+        calls.append((serials, kwargs["house"]))
+        return {"list": [{"serialNumber": serials[0]}]}
+
+    client.get_camera_event_history = get_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        [camera_1, camera_2], 1781484300, 1781487900
+    )
+
+    assert calls == [
+        (["addx-camera-1"], house_1),
+        (["addx-camera-2"], house_2),
+    ]
+    assert [record["serialNumber"] for record in result["list"]] == [
+        "addx-camera-1",
+        "addx-camera-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_camera_event_history_queries_each_camera_without_shared_page_limit():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="us-east-1")
+    client.houses = {"house-1": house}
+    cameras = [
+        SimpleNamespace(
+            sn=f"ipc-camera-{index}",
+            entity_id=f"ipc-camera-{index}",
+            data={"addxSerialNumber": f"addx-camera-{index}"},
+            house=house,
+        )
+        for index in (1, 2)
+    ]
+    calls = []
+
+    async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
+        calls.append((serials, kwargs["house"], kwargs["limit"]))
+        return {"list": [{"serialNumber": serials[0]}]}
+
+    client.get_camera_event_history = get_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        cameras, 1781484300, 1781487900, limit=25
+    )
+
+    assert calls == [
+        (["addx-camera-1"], house, 25),
+        (["addx-camera-2"], house, 25),
+    ]
+    assert len(result["list"]) == 2
+
+
+def test_camera_addx_house_prefers_exact_addx_house_id_before_node():
+    client = async_xsense.AsyncXSense()
+    house_1 = SimpleNamespace(house_id="house-1", mqtt_region="us-east-1")
+    house_2 = SimpleNamespace(house_id="house-2", mqtt_region="us-east-1")
+    client.houses = {"house-1": house_1, "house-2": house_2}
+    camera = SimpleNamespace(
+        data={"addxHouseId": "house-2", "addxNodeType": "US"},
+        house=house_1,
+    )
+
+    assert client._camera_addx_house(camera) is house_2
+
+
+@pytest.mark.asyncio
 async def test_camera_event_record_history_uses_apk_event_filter_path():
     client = async_xsense.AsyncXSense()
     calls = []

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -1920,6 +1920,30 @@ def test_recording_media_source_preserves_direct_video_url():
     )
 
 
+def test_recording_media_source_matches_addx_camera_serial_alias():
+    from custom_components.xsense import recordings_media as media_source
+
+    clip = media_source._recording_clip_from_record(
+        "entry-id",
+        [
+            {
+                "entry_id": "entry-id",
+                "serial": "IPC-CAMERA-SN",
+                "addx_serial": "addx-camera-sn",
+                "entity_id": "camera.garden",
+            }
+        ],
+        {
+            "serialNumber": "ADDX_CAMERA_SN",
+            "timestamp": 1782049304000,
+            "videoUrl": "https://example.invalid/clip.m3u8",
+        },
+    )
+
+    assert clip is not None
+    assert clip["serial"] == "IPC-CAMERA-SN"
+
+
 def test_recording_media_source_prefers_hd_direct_video_candidate():
     from custom_components.xsense import recordings_media as media_source
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1458,6 +1458,7 @@ def test_mqtt_ai_plan_event_routes_by_nested_camera_identity():
     class Camera:
         sn = "camera-sn"
         shadow_name = "SSC0Acamera-sn"
+        type = "SSC0A"
 
         def __init__(self):
             self.data = {}
@@ -1501,6 +1502,203 @@ def test_mqtt_ai_plan_event_routes_by_nested_camera_identity():
     assert "isMoved" not in parsed[0][1]
     assert "lastMotionTime" not in parsed[0][1]
     assert updates == [True]
+
+
+def test_mqtt_ai_plan_event_prefers_addx_camera_over_dispatch_station():
+    """Route account AI events by ADDX camera id, not the dispatch station."""
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Camera:
+        sn = "camera-station-sn"
+        entity_id = "camera-station-id"
+        type = "SSC0A"
+        shadow_name = "SSC0Acamera-station-sn"
+
+        def __init__(self):
+            self.data = {"addxSerialNumber": "addx-camera-id"}
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    class BaseStation:
+        sn = "dispatch-station-sn"
+        entity_id = "dispatch-station-id"
+        type = "SBS50"
+        shadow_name = "SBS50dispatch-station-sn"
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    camera = Camera()
+    base_station = BaseStation()
+
+    class House:
+        def __init__(self, stations):
+            self.stations = stations
+
+        def get_station_by_sn(self, identifier):
+            return next(
+                (
+                    station
+                    for station in self.stations.values()
+                    if identifier in {station.sn, station.entity_id}
+                ),
+                None,
+            )
+
+    parsed = []
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(
+        houses={
+            "camera-house": House({"camera-station-id": camera}),
+            "sensor-house": House({"dispatch-station-id": base_station}),
+        },
+        parse_get_state=lambda station, data: parsed.append((station, data)),
+    )
+    coordinator.async_update_listeners = lambda: None
+
+    coordinator.async_event_received(
+        "@xsense/events/aiplan/user-id-code",
+        json.dumps(
+            {
+                "eventTime": "20260826050000",
+                "eventData": {
+                    "dispatchDevs": [
+                        {
+                            "stationSn": "dispatch-station-sn",
+                            "deviceSn": "addx-camera-id",
+                        }
+                    ],
+                    "eventItems": [
+                        {"eventType": "person", "eventTime": "20260826050001"}
+                    ],
+                },
+            }
+        ).encode(),
+    )
+
+    assert parsed[0][0] is camera
+    assert parsed[0][1]["lastAiDetection"] == "person"
+
+
+def test_mqtt_ai_plan_event_uses_apk_service_home_before_dispatch_device():
+    """Route APK AI events by serviceId when dispatchDevs targets an alarm device."""
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Camera:
+        sn = "camera-sn"
+        entity_id = "camera-id"
+        type = "SSC0A"
+        shadow_name = "SSC0Acamera-sn"
+
+        def __init__(self, house):
+            self.house = house
+            self.data = {}
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    class BaseStation:
+        sn = "dispatch-station-sn"
+        entity_id = "dispatch-station-id"
+        type = "SBS50"
+        shadow_name = "SBS50dispatch-station-sn"
+
+        def get_device_by_sn(self, identifier):
+            return self if identifier == "dispatch-device-sn" else None
+
+    class House:
+        def __init__(self, house_id):
+            self.house_id = house_id
+            self.stations = {}
+
+        def get_station_by_sn(self, identifier):
+            return next(
+                (
+                    station
+                    for station in self.stations.values()
+                    if identifier in {station.sn, station.entity_id}
+                ),
+                None,
+            )
+
+    camera_house = House("camera-house-id")
+    camera = Camera(camera_house)
+    camera_house.stations = {"camera-id": camera}
+    sensor_house = House("sensor-house-id")
+    sensor_house.stations = {"dispatch-station-id": BaseStation()}
+    parsed = []
+
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(
+        houses={"camera-house-id": camera_house, "sensor-house-id": sensor_house},
+        parse_get_state=lambda station, data: parsed.append((station, data)),
+    )
+    coordinator._camera_ai_service_houses = {"service-id": {"camera-house-id"}}
+    coordinator.async_update_listeners = lambda: None
+
+    coordinator.async_event_received(
+        "@xsense/events/aiplan/user-id-code",
+        json.dumps(
+            {
+                "eventTime": "20260826050000",
+                "eventData": {
+                    "serverId": "service-id",
+                    "dispatchDevs": [
+                        {
+                            "stationSn": "dispatch-station-sn",
+                            "deviceSn": "dispatch-device-sn",
+                        }
+                    ],
+                    "eventItems": [
+                        {"eventType": "person", "eventTime": "20260826050001"}
+                    ],
+                },
+            }
+        ).encode(),
+    )
+
+    assert parsed[0][0] is camera
+    assert parsed[0][1]["lastAiDetection"] == "person"
+
+
+def test_camera_ai_service_house_map_includes_nested_apk_plan_homes():
+    from custom_components.xsense.coordinator import _camera_ai_service_house_map
+
+    assert _camera_ai_service_house_map(
+        [
+            {
+                "serverId": "service-id",
+                "houseId": "billing-house",
+                "aiPlan": {"houseIds": ["camera-house", "other-house"]},
+            }
+        ]
+    ) == {
+        "service-id": {"billing-house", "camera-house", "other-house"}
+    }
+
+
+def test_camera_ai_server_routes_unique_camera_from_nested_plan_home():
+    from custom_components.xsense.coordinator import _camera_station_for_ai_server
+
+    camera_house = SimpleNamespace(house_id="camera-house")
+    camera = SimpleNamespace(
+        sn="camera-sn",
+        entity_id="camera-id",
+        type="SSC0A",
+        house=camera_house,
+        data={"addxHouseId": "camera-house"},
+    )
+    coordinator = SimpleNamespace(
+        xsense=SimpleNamespace(
+            houses={"camera-house": SimpleNamespace(stations={"camera-id": camera})}
+        ),
+        _camera_ai_service_houses={
+            "service-id": {"billing-house", "camera-house"}
+        },
+    )
+
+    assert _camera_station_for_ai_server(coordinator, "service-id") is camera
 
 
 async def test_camera_ai_history_poll_routes_apk_alarm_items():
@@ -1561,7 +1759,10 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
                 ]
             }
 
-        async def get_camera_event_history(self, serial_numbers, start_timestamp, end_timestamp):
+        async def get_camera_event_history_for_cameras(
+            self, cameras, start_timestamp, end_timestamp
+        ):
+            assert cameras == [house.stations["camera-id"]]
             return {}
 
         def parse_get_state(self, station_arg, data):
@@ -1598,7 +1799,7 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
         shadow_name = "SSC0Acamera-sn"
 
         def __init__(self):
-            self.data = {}
+            self.data = {"addxSerialNumber": "addx-camera-id"}
 
         def get_device_by_sn(self, _identifier):
             return None
@@ -1622,15 +1823,15 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
         async def get_ai_service_list(self):
             return []
 
-        async def get_camera_event_history(
-            self, serial_numbers, start_timestamp, end_timestamp
+        async def get_camera_event_history_for_cameras(
+            self, cameras, start_timestamp, end_timestamp
         ):
-            assert serial_numbers == ["camera-sn"]
+            assert cameras == [house.stations["camera-id"]]
             assert end_timestamp > start_timestamp
             return {
                 "list": [
                     {
-                        "serialNumber": "camera-sn",
+                        "serialNumber": "addx-camera-id",
                         "timestamp": 1781478300,
                         "startTime": 1781478300,
                         "endTime": 1781478310,
@@ -1745,9 +1946,10 @@ async def test_camera_event_history_does_not_mark_unapplied_records_seen(caplog)
         async def get_ai_service_list(self):
             return []
 
-        async def get_camera_event_history(
-            self, serial_numbers, start_timestamp, end_timestamp
+        async def get_camera_event_history_for_cameras(
+            self, cameras, start_timestamp, end_timestamp
         ):
+            assert cameras == [self.houses["house-id"].stations["camera-id"]]
             return {
                 "list": [
                     {

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1708,12 +1708,10 @@ def test_recordings_panel_registration_adopts_existing_home_assistant_panel(
         panels.append(kwargs)
 
     monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
-    monkeypatch.setattr(
-        frontend.frontend,
-        "async_panel_exists",
-        lambda hass, path: path == frontend.FRONTEND_URL_PATH,
+    hass = SimpleNamespace(
+        data={frontend.frontend.DATA_PANELS: {frontend.FRONTEND_URL_PATH: object()}},
+        http=Http(),
     )
-    hass = SimpleNamespace(data={}, http=Http())
 
     asyncio.run(frontend.async_register_recordings_panel(hass))
 
@@ -1796,12 +1794,13 @@ def test_force_arm_panel_registration_adopts_existing_home_assistant_panel(
         panels.append(kwargs)
 
     monkeypatch.setattr(frontend.panel_custom, "async_register_panel", register_panel)
-    monkeypatch.setattr(
-        frontend.frontend,
-        "async_panel_exists",
-        lambda hass, path: path == frontend.FORCE_ARM_FRONTEND_URL_PATH,
+    hass = SimpleNamespace(
+        data={
+            frontend.frontend.DATA_PANELS: {
+                frontend.FORCE_ARM_FRONTEND_URL_PATH: object()
+            }
+        }
     )
-    hass = SimpleNamespace(data={})
 
     asyncio.run(frontend.async_register_force_arm_panel(hass, "entry-1"))
 


### PR DESCRIPTION
## Summary
- route motion and AI events using each camera's exact ADDX identity and Home context
- include nested APK AI-plan Home coverage and poll recording history separately per camera
- match recording history back to the correct Home Assistant camera
- avoid duplicate panel registration errors during setup and reload
- prepare the v1.4.19.1 prerelease metadata

## Validation
- 763 tests passed on Windows
- 763 tests passed on Linux with Python 3.14
- Ruff, compileall, and git diff checks passed