### PR TITLE
Expose APK automation actions

### DIFF
--- a/.github/release-notes/1.4.19.1.md
+++ b/.github/release-notes/1.4.19.1.md
@@ -8,3 +8,11 @@
 
 ### 🛠️ Reliability
 - Prevents the one-time duplicate X-Sense panel registration error during integration setup or reload.
+
+### 🛡️ Security Automations
+- Adds a **Force arm now** action for Home Assistant automations. It can arm the X-Sense system in Home or Away mode while bypassing open sensors, without requiring the interactive confirmation prompt.
+- Keeps notification links restricted to the pending arm request that created them.
+- Adds actions to trigger or cancel an SBS50 SOS alarm, cancel an active sensor alarm, and choose whether SOS uses the buzzer or flashing light only.
+
+### 💡 Light Automations
+- Adds an action to turn an SBS50 light group on or off.

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -14,7 +14,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_platform
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -37,7 +37,13 @@ SAFEMODE_TO_STATE: dict[str, AlarmControlPanelState] = {
 }
 FORCE_ARM_NOTIFICATION_ID_PREFIX = "xsense_force_arm_"
 FORCE_ARM_SERVICE = "force_arm"
+FORCE_ARM_NOW_SERVICE = "force_arm_now"
+TRIGGER_SOS_SERVICE = "trigger_sos"
+CANCEL_SOS_SERVICE = "cancel_sos"
+CANCEL_ALARM_SERVICE = "cancel_alarm"
+SET_SOS_SOUND_SERVICE = "set_sos_sound"
 FORCE_ARM_SCHEMA = {vol.Required("mode"): vol.In(("Home", "Away"))}
+SET_SOS_SOUND_SCHEMA = {vol.Required("audible"): cv.boolean}
 
 
 async def async_setup_entry(
@@ -68,6 +74,31 @@ async def async_setup_entry(
                 FORCE_ARM_SERVICE,
                 FORCE_ARM_SCHEMA,
                 "async_force_arm",
+            )
+            platform.async_register_entity_service(
+                FORCE_ARM_NOW_SERVICE,
+                FORCE_ARM_SCHEMA,
+                "async_force_arm_now",
+            )
+            platform.async_register_entity_service(
+                TRIGGER_SOS_SERVICE,
+                {},
+                "async_trigger_sos",
+            )
+            platform.async_register_entity_service(
+                CANCEL_SOS_SERVICE,
+                {},
+                "async_cancel_sos",
+            )
+            platform.async_register_entity_service(
+                CANCEL_ALARM_SERVICE,
+                {},
+                "async_cancel_alarm",
+            )
+            platform.async_register_entity_service(
+                SET_SOS_SOUND_SERVICE,
+                SET_SOS_SOUND_SCHEMA,
+                "async_set_sos_sound",
             )
         await async_register_force_arm_panel(hass, entry.entry_id)
         entry.async_on_unload(
@@ -295,6 +326,51 @@ class XSenseAlarmControlPanel(
         pending_mode = pending_force_arm_mode(station)
         if pending_mode != mode:
             raise xsense_error("force_arm_not_pending", mode=mode)
+
+        await self._async_force_arm_mode(mode)
+
+    async def async_force_arm_now(self, mode: str) -> None:
+        """Force arm directly for a Home Assistant automation."""
+        if self._station is None:
+            raise xsense_error("station_unavailable")
+
+        await self._async_force_arm_mode(mode)
+
+    async def async_trigger_sos(self) -> None:
+        """Trigger the SBS50 SOS alarm using the APK command."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
+        await self.coordinator.xsense.trigger_sos(station, sos_type="1")
+
+    async def async_cancel_sos(self) -> None:
+        """Cancel the SBS50 SOS alarm using the APK command."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
+        await self.coordinator.xsense.cancel_sos(station)
+
+    async def async_cancel_alarm(self) -> None:
+        """Cancel the active SBS50 sensor alarm using the APK command."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
+        await self.coordinator.xsense.cancel_alarm(station)
+
+    async def async_set_sos_sound(self, audible: bool) -> None:
+        """Choose flashing light only or flashing light plus buzzer for SOS."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
+        await self.coordinator.xsense.set_sos_sound(
+            station, "1" if audible else "0"
+        )
+
+    async def _async_force_arm_mode(self, mode: str) -> None:
+        """Send an APK force-arm command and clear any pending prompt."""
+        station = self._station
+        if station is None:
+            raise xsense_error("station_unavailable")
 
         await self._set_safe_mode(mode, force_arm="1")
         station.set_alarm_data(

--- a/custom_components/xsense/services.yaml
+++ b/custom_components/xsense/services.yaml
@@ -14,6 +14,61 @@ force_arm:
             - Home
             - Away
 
+force_arm_now:
+  name: Force arm now
+  description: Force arm an X-Sense system in Home or Away mode without waiting for or showing a confirmation prompt. Open sensors are bypassed.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+  fields:
+    mode:
+      required: true
+      selector:
+        select:
+          options:
+            - Home
+            - Away
+
+trigger_sos:
+  name: Trigger SOS alarm
+  description: Trigger the X-Sense SBS50 SOS alarm. This sounds the physical alarm immediately.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+
+cancel_sos:
+  name: Cancel SOS alarm
+  description: Cancel an active X-Sense SBS50 SOS alarm.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+
+cancel_alarm:
+  name: Cancel active alarm
+  description: Cancel an active X-Sense SBS50 sensor alarm using the same command as the X-Sense app.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+
+set_sos_sound:
+  name: Set SOS sound
+  description: Choose whether an SBS50 SOS alarm flashes its light only or also sounds its buzzer.
+  target:
+    entity:
+      integration: xsense
+      domain: alarm_control_panel
+  fields:
+    audible:
+      name: Audible alarm
+      description: Enable the SBS50 buzzer as well as the flashing light for SOS alarms.
+      required: true
+      selector:
+        boolean:
+
 refresh_recordings:
   name: Refresh recordings
   description: Refresh the cached X-Sense camera recording index used by the X-Sense Recordings sidebar and Home Assistant Media Browser.
@@ -238,3 +293,28 @@ remove_light_group_devices:
       required: true
       selector:
         object:
+
+set_light_group_power:
+  name: Set light group power
+  description: Turn an X-Sense SBS50 light group on or off.
+  target:
+    entity:
+      integration: xsense
+      domain: switch
+  fields:
+    group_id:
+      name: Group ID
+      required: true
+      selector:
+        text:
+    device_ids:
+      name: Device serial numbers
+      description: Serial numbers of the lights in the group.
+      required: true
+      selector:
+        object:
+    enabled:
+      name: Power
+      required: true
+      selector:
+        boolean:

--- a/custom_components/xsense/switch.py
+++ b/custom_components/xsense/switch.py
@@ -103,6 +103,13 @@ LIGHT_GROUP_REMOVE_DEVICES_SCHEMA = {
     vol.Required(ATTR_DEVICE_IDS): vol.All(cv.ensure_list, [cv.string]),
 }
 
+LIGHT_GROUP_POWER_SCHEMA = {
+    vol.Required(ATTR_GROUP_ID): cv.string,
+    vol.Required(ATTR_DEVICE_IDS): vol.All(cv.ensure_list, [cv.string]),
+    vol.Required(ATTR_ENABLED): cv.boolean,
+}
+
+
 def boolean_state(value) -> bool | None:
     """Return the normalized state for explicit X-Sense boolean payload values."""
     if isinstance(value, bool):
@@ -702,6 +709,11 @@ async def async_setup_entry(
             LIGHT_GROUP_REMOVE_DEVICES_SCHEMA,
             "async_remove_light_group_devices",
         )
+        platform.async_register_entity_service(
+            "set_light_group_power",
+            LIGHT_GROUP_POWER_SCHEMA,
+            "async_set_light_group_power",
+        )
 
     for station in coordinator_stations(coordinator).values():
         seen_entity_ids.add(station.entity_id)
@@ -901,6 +913,20 @@ class XSenseSwitchEntity(XSenseEntity, SwitchEntity):
         entity = self._light_group_entity()
         await self.coordinator.xsense.remove_light_group_devices(
             entity, device_ids=_non_empty_strings(device_ids, "device_ids")
+        )
+        self.coordinator.async_update_listeners()
+
+    async def async_set_light_group_power(
+        self, group_id: str, device_ids: list[str], enabled: bool
+    ) -> None:
+        """Turn an SBS50 light group on or off through the APK group shadow."""
+        entity = self._light_group_entity()
+        station = entity.station
+        await self.coordinator.xsense.set_light_group_power(
+            station,
+            group_id=str(group_id).strip(),
+            device_sns=_non_empty_strings(device_ids, "device_ids"),
+            on=enabled,
         )
         self.coordinator.async_update_listeners()
 

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -638,6 +638,140 @@ async def test_alarm_panel_force_arm_requires_matching_pending_mode(monkeypatch)
     assert coordinator.xsense.calls == [(station.sn, "Away", "1")]
 
 
+async def test_alarm_panel_force_arm_now_does_not_require_pending_prompt(monkeypatch):
+    """The automation action force arms without first creating a prompt."""
+
+    class API:
+        def __init__(self):
+            self.calls = []
+
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            self.calls.append((station.sn, safe_mode, force_arm))
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "forceReason": None,
+            "safeModeAim": None,
+            "requestedSafeMode": None,
+        }
+    )
+    assert pending_force_arm_mode(station) is None
+    api = API()
+    coordinator = Coordinator(station)
+    coordinator.xsense = api
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    dismissed = []
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: dismissed.append(notification_id),
+    )
+
+    await panel.async_force_arm_now("Away")
+
+    assert api.calls == [(station.sn, "Away", "1")]
+    assert station.alarm_data["forceReason"] is None
+    assert station.alarm_data["requestedSafeMode"] is None
+    assert dismissed == [f"xsense_force_arm_{station.entity_id}"]
+
+
+async def test_alarm_panel_exposes_apk_sos_and_alarm_actions():
+    """Security actions use the exact SBS50 APK client commands."""
+
+    class API:
+        def __init__(self):
+            self.calls = []
+
+        async def trigger_sos(self, station, sos_type="1"):
+            self.calls.append(("trigger_sos", station.sn, sos_type))
+
+        async def cancel_sos(self, station):
+            self.calls.append(("cancel_sos", station.sn))
+
+        async def cancel_alarm(self, station):
+            self.calls.append(("cancel_alarm", station.sn))
+
+        async def set_sos_sound(self, station, sound):
+            self.calls.append(("set_sos_sound", station.sn, sound))
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    api = API()
+    coordinator = Coordinator(station)
+    coordinator.xsense = api
+    panel = XSenseAlarmControlPanel(coordinator, station)
+
+    await panel.async_trigger_sos()
+    await panel.async_cancel_sos()
+    await panel.async_cancel_alarm()
+    await panel.async_set_sos_sound(audible=False)
+    await panel.async_set_sos_sound(audible=True)
+
+    assert api.calls == [
+        ("trigger_sos", station.sn, "1"),
+        ("cancel_sos", station.sn),
+        ("cancel_alarm", station.sn),
+        ("set_sos_sound", station.sn, "0"),
+        ("set_sos_sound", station.sn, "1"),
+    ]
+
+
+async def test_light_group_power_action_uses_apk_group_shadow():
+    """The light-group action resolves the SBS50 parent and member serials."""
+
+    class API:
+        def __init__(self):
+            self.calls = []
+
+        async def set_light_group_power(
+            self, station, group_id, device_sns, on
+        ):
+            self.calls.append((station.sn, group_id, device_sns, on))
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_devices(
+        {
+            "devices": [
+                {
+                    "deviceId": "light-id",
+                    "deviceName": "Porch Light",
+                    "deviceSn": "light-sn",
+                    "deviceType": "SPL51",
+                    "roomName": "Porch",
+                }
+            ]
+        }
+    )
+    light = station.get_device_by_sn("light-sn")
+    api = API()
+    coordinator = Coordinator(station, {light.entity_id: light})
+    coordinator.xsense = api
+    switch = XSenseSwitchEntity(
+        coordinator,
+        light,
+        XSenseSwitchEntityDescription(
+            key="light_power",
+            data_key="on",
+            exists_fn=lambda current: True,
+            value_fn=lambda current: False,
+        ),
+        station_id=station.entity_id,
+    )
+
+    await switch.async_set_light_group_power(
+        group_id=" group-1 ", device_ids=[" light-sn ", "light-2"], enabled=True
+    )
+
+    assert api.calls == [
+        (station.sn, "group-1", ["light-sn", "light-2"], True)
+    ]
+    assert coordinator.update_listener_calls == 1
+
+
 def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"


### PR DESCRIPTION
## Summary
- add direct force-arm actions for Home Assistant automations while retaining the prompt-bound confirmation action
- expose APK-backed SOS trigger/cancel, active-alarm cancel, and SOS sound controls
- expose SBS50 light-group power control
- add focused behavior coverage and include the actions in the pending v1.4.19.1 prerelease notes

## Validation
- 766 tests passed on Windows
- 766 tests passed on Linux with Home Assistant 2026.8.3