### PR TITLE
Fix SWS51 silence entities

### DIFF
--- a/APK_EVIDENCE.md
+++ b/APK_EVIDENCE.md
@@ -74,6 +74,12 @@ Current local APK evidence:
   while SBS50 sends `sosType` through its second-generation path. The existing
   client helper only implements the latter shape, so no generic SOS entity is
   exposed until both model routes are represented and guarded independently.
+- `SWS51` uses separate `waterMuteStatus` and `tempMuteStatus` fields in its
+  reachable device UI (`s1/C.java` and `s1/D.java`); it does not use the generic
+  `mute` or `muteStatus` fields for display. Values `1` (silenced) and `2`
+  (remind later) both suppress the corresponding alarm indication. Home
+  Assistant therefore exposes the water and temperature silence states, treats
+  both values as active, and removes stale generic Device Silenced entities.
 
 ## APK 1400 entity naming policy
 

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -230,6 +230,9 @@ OBSOLETE_ACTION_KEYS_BY_DEVICE_TYPE = {
     "XS0B-iR": ("test",),
 }
 OBSOLETE_SENSOR_KEYS_BY_DEVICE_TYPE = {}
+OBSOLETE_BINARY_SENSOR_KEYS_BY_DEVICE_TYPE = {
+    "SWS51": ("mute_status", "mute"),
+}
 BLUEPRINT_MAINTENANCE_CHECK_INTERVAL = timedelta(minutes=5)
 STARTUP_MAINTENANCE_DELAY = 30
 
@@ -342,14 +345,22 @@ def _obsolete_sensor_unique_ids(data) -> set[str]:
 
 def _obsolete_binary_sensor_unique_ids(data) -> set[str]:
     """Return exact obsolete binary-sensor unique IDs for known devices."""
-    return {
-        _sensor_unique_id(entity.entity_id, key)
-        for entity in (
-            *data.get("stations", {}).values(),
-            *data.get("devices", {}).values(),
+    unique_ids: set[str] = set()
+    for entity in (
+        *data.get("stations", {}).values(),
+        *data.get("devices", {}).values(),
+    ):
+        unique_ids.update(
+            _sensor_unique_id(entity.entity_id, key)
+            for key in OBSOLETE_BINARY_SENSOR_KEYS
         )
-        for key in OBSOLETE_BINARY_SENSOR_KEYS
-    }
+        unique_ids.update(
+            _sensor_unique_id(entity.entity_id, key)
+            for key in OBSOLETE_BINARY_SENSOR_KEYS_BY_DEVICE_TYPE.get(
+                getattr(entity, "type", None), ()
+            )
+        )
+    return unique_ids
 
 
 def _obsolete_action_unique_ids(data) -> set[str]:

--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -119,10 +119,17 @@ def has_alarm_status(entity: Entity) -> bool:
 
 def has_mute_status(entity: Entity) -> bool:
     """Return if an X-Sense entity should expose mute status."""
+    if entity.type == "SWS51":
+        return False
     entity_def = entities.get(entity.type) or {}
     return entity.type == "XS01-WX" or "muteStatus" in entity.data or any(
         action.get("action") == "mute" for action in entity_def.get("actions", ())
     )
+
+
+def has_generic_mute_state(entity: Entity) -> bool:
+    """Return if a device uses the generic APK mute state."""
+    return entity.type != "SWS51" and "mute" in entity.data
 
 
 def has_life_end_status(entity: Entity) -> bool:
@@ -320,7 +327,7 @@ _ALL_SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         key="mute",
         translation_key="mute",
         icon="mdi:volume-off",
-        exists_fn=has_data("mute"),
+        exists_fn=has_generic_mute_state,
         value_fn=data_bool("mute"),
     ),
     XSenseBinarySensorEntityDescription(

--- a/custom_components/xsense/python_xsense/mapping.py
+++ b/custom_components/xsense/python_xsense/mapping.py
@@ -82,6 +82,25 @@ def bool_state(value: typing.Any) -> bool | None:
     return None
 
 
+def alarm_silence_state(value: typing.Any) -> bool | None:
+    """Normalize APK alarm silence states, including remind-later mode."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value in {1, 2}:
+            return True
+        if value == 0:
+            return False
+        return None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "2", "true", "on"}:
+            return True
+        if normalized in {"0", "false", "off"}:
+            return False
+    return None
+
+
 def open_state(value: typing.Any) -> bool | None:
     """Return door/opening state where true means open."""
     result = bool_state(value)
@@ -181,14 +200,14 @@ type_mapping: dict[str, Callable[[typing.Any], typing.Any]] = {
     "showCodecChange": bool_state,
     "sunshineEnable": bool_state,
     "tempAlarmStatus": bool_state,
-    "tempMuteStatus": bool_state,
+    "tempMuteStatus": alarm_silence_state,
     "test": bool_state,
     "timeZoneEnabled": bool_state,
     "timeZoneValid": bool_state,
     "usbCharge": bool_state,
     "voiceVolumeSwitch": bool_state,
     "waterAlarmStatus": bool_state,
-    "waterMuteStatus": bool_state,
+    "waterMuteStatus": alarm_silence_state,
     "whiteLightScintillation": bool_state,
     "warnIsOpen": bool_state,
     "chirpToneEnable": bool_state,

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1425,6 +1425,18 @@ def test_xc0m_ir_maps_compact_temperature_and_humidity_fields():
     assert data["time"] == "20260705090102"
 
 
+@pytest.mark.parametrize("value", ("1", "2", 1, 2, True))
+def test_alarm_silence_states_include_apk_remind_later_mode(value):
+    assert mapping.map_type("waterMuteStatus", value) is True
+    assert mapping.map_type("tempMuteStatus", value) is True
+
+
+@pytest.mark.parametrize("value", ("0", 0, False))
+def test_alarm_silence_states_report_inactive(value):
+    assert mapping.map_type("waterMuteStatus", value) is False
+    assert mapping.map_type("tempMuteStatus", value) is False
+
+
 @pytest.mark.asyncio
 async def test_get_station_state_uses_second_info_for_xc0m_ir():
     client = async_xsense.AsyncXSense()

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from custom_components.xsense.alarm_control_panel import (
@@ -139,6 +141,27 @@ def test_reported_test_active_state_is_exposed_from_device_data():
 
     assert description.exists_fn(station)
     assert description.value_fn(station) is False
+
+
+def test_sws51_exposes_specific_silence_states_without_generic_duplicates():
+    """SWS51 uses separate APK water and temperature silence states."""
+    device = SimpleNamespace(
+        type="SWS51",
+        data={
+            "mute": True,
+            "muteStatus": True,
+            "waterMuteStatus": False,
+            "tempMuteStatus": True,
+        },
+    )
+    descriptions = {description.key: description for description in BINARY_SENSORS}
+
+    assert not descriptions["mute"].exists_fn(device)
+    assert not descriptions["mute_status"].exists_fn(device)
+    assert descriptions["water_mute_status"].exists_fn(device)
+    assert descriptions["water_mute_status"].value_fn(device) is False
+    assert descriptions["temperature_mute_status"].exists_fn(device)
+    assert descriptions["temperature_mute_status"].value_fn(device) is True
 
 
 def test_station_sensor_stays_available_when_station_id_alias_changes():

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -12,6 +12,7 @@ if not hasattr(sys.modules.get("custom_components"), "__path__"):
 from custom_components.xsense import (
     OBSOLETE_ACTION_KEYS_BY_DEVICE_TYPE,
     OBSOLETE_BINARY_SENSOR_KEYS,
+    OBSOLETE_BINARY_SENSOR_KEYS_BY_DEVICE_TYPE,
     LEGACY_OBSOLETE_BINARY_SENSOR_KEYS,
     OBSOLETE_NUMBER_KEYS,
     OBSOLETE_SELECT_KEYS,
@@ -22,6 +23,7 @@ from custom_components.xsense import (
     _camera_ai_detection_unique_ids_by_service_state,
     _migrate_legacy_none_entity_ids,
     _obsolete_action_unique_ids,
+    _obsolete_binary_sensor_unique_ids,
     _obsolete_camera_motion_unique_ids,
     _obsolete_sensor_unique_ids,
     _unsupported_led_light_switch_unique_ids,
@@ -96,6 +98,26 @@ def test_obsolete_action_unique_ids_target_removed_model_actions_only():
         "kitchen-smoke-test",
         "office-smoke-test",
     }
+
+
+def test_sws51_generic_mute_entities_are_removed_without_touching_specific_states():
+    sws51 = SimpleNamespace(entity_id="basement_leak", type="SWS51")
+    sws0b = SimpleNamespace(entity_id="utility_leak", type="SWS0B")
+
+    unique_ids = _obsolete_binary_sensor_unique_ids(
+        {"stations": {}, "devices": {"sws51": sws51, "sws0b": sws0b}}
+    )
+
+    assert OBSOLETE_BINARY_SENSOR_KEYS_BY_DEVICE_TYPE["SWS51"] == (
+        "mute_status",
+        "mute",
+    )
+    assert "basement-leak-mute-status" in unique_ids
+    assert "basement-leak-mute" in unique_ids
+    assert "basement-leak-water-mute-status" not in unique_ids
+    assert "basement-leak-temperature-mute-status" not in unique_ids
+    assert "utility-leak-mute-status" not in unique_ids
+    assert "utility-leak-mute" not in unique_ids
 
 
 def test_xs01_wx_self_test_report_entities_are_not_obsolete():


### PR DESCRIPTION
## Summary
- remove the two incorrect generic Device Silenced entities from SWS51 while retaining its APK-backed water and temperature silence states
- treat APK values 1 (silenced) and 2 (remind later) as active silence states
- clean stale generic SWS51 mute entities from the Home Assistant entity registry
- document the APK 1400 evidence and add focused regression coverage

## Validation
- 776 tests passed on Windows
- 776 tests passed on Linux with Home Assistant 2026.8.3