### PR TITLE
Prepare v1.4.19.4 alarm state prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19.3):
-  (e.g., 1.4.19.3)
+- **X-Sense-Integration Version** (z. B. 1.4.19.4):
+  (e.g., 1.4.19.4)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.4.md
+++ b/.github/release-notes/1.4.19.4.md
@@ -1,0 +1,11 @@
+## X-Sense Home Security v1.4.19.4
+
+### 💧 Water Leak Sensor States
+- Corrects the SWS51 Device Silenced state so a dry sensor with no silence period is no longer shown as silenced.
+- Aligns SWS51 alarm and silence states with the states shown by the X-Sense app: triggered, silenced, and remind me later.
+- Keeps the SWS0B water and temperature alarm states separate, as reported by that model.
+
+### 🚨 Alarm and Silence States
+- Interprets alarm and silence status codes according to each supported device family instead of applying one rule to every detector.
+- Keeps persistent Device Silenced entities only on models that report an actual silence state.
+- Cleans up stale Device Silenced entities on models where the X-Sense app exposes mute only as an alarm-time command.

--- a/APK_EVIDENCE.md
+++ b/APK_EVIDENCE.md
@@ -91,6 +91,14 @@ Current local APK evidence:
   shown by `s1/a0.java`. Home Assistant therefore exposes one alarm and one
   silence state for SWS51, while dual water/temperature states remain
   payload-gated for SWS0B.
+- `s1/F.java` labels SWS51 as `Silenced` only when `alarmStatus == 1` and
+  `muteStatus == 0`. A nonzero `silenceTime` with `muteStatus == 0` is the
+  separate `Remind Me Later Enabled` state. When the alarm is clear, neither
+  condition is active, regardless of the retained mute code.
+- `s1/D.java` and `s1/E.java` label each SWS0B water/temperature alarm as
+  `Silenced` for mute code `1` and `Remind Me Later` for code `2`, but only
+  while that specific alarm status is active. The mute codes are not
+  standalone boolean states.
 - APK 1400's `s1/a0.java` model-to-view registry also confirms that `SMS01`
   displays motion against the system security mode rather than a device
   `alarmStatus`. Models `SDA51`, `STH0A`, `STH0B`, `STH0C`, `STH51`, `SWS0B`,
@@ -102,10 +110,12 @@ Current local APK evidence:
   APK 1400 treats every positive value as an active alarm and uses values `2`
   and `3` for CO/combined alarm cases. The adapter therefore maps `0` to clear
   and every positive code to active for Home Assistant's binary alarm entity.
-- Newer detector `muteStatus` is also coded. APK 1400 presents a detector as
-  silenced while the value is `1`, `2`, or `3`; values `4` and above represent
-  an active, unsilenced alarm. The adapter preserves that distinction instead
-  of passing the field through generic `0`/`1` boolean conversion.
+- Detector `muteStatus` is model-specific. APK 1400 handlers `C0876k`,
+  `C0877l`, `O`, and `P` present an active alarm as silenced for values `1`,
+  `2`, or `3`, while values `4` and above represent an unsilenced alarm. The
+  older detector handlers present an active alarm as silenced at value `0` and
+  unsilenced at value `1`. The adapter preserves the numeric code; the HA
+  entity applies the matching model handler and requires an active alarm.
 - Device `activate` is not limited to `0`/`1`: APK 1400 sends `2` in supported
   activation/install flows and treats nonzero activation values as active in
   its device-status path. The adapter therefore maps every positive activation
@@ -114,11 +124,12 @@ Current local APK evidence:
   canonical `alarmStatus` and `activate` fields. Home Assistant exposes only the
   canonical entities and removes stale duplicate Alarm Active/Activated entity
   registry entries.
-- APK payload variants report the generic silence state as either `muteStatus`
-  or `mute`. Home Assistant folds both into one canonical Device Silenced
-  entity and removes the duplicate raw `mute` entity. SWS51 uses this canonical
-  generic silence entity; SWS0B retains its distinct water and temperature
-  silence states when those APK fields are present.
+- A direct `mute` event field can feed the canonical Device Silenced entity
+  when it is actually reported. `muteStatus` remains a model-specific APK code
+  and is never treated as a generic boolean. SMA0A/SMA51 use it to decide when
+  the mailbox mute command is available, so they do not expose a persistent
+  Device Silenced entity. SWS51 uses its alarm-aware generic silence entity;
+  SWS0B retains its separate alarm-aware water and temperature silence states.
 
 ## APK 1400 entity naming policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19.4](.github/release-notes/1.4.19.4.md)
 - [1.4.19.3](.github/release-notes/1.4.19.3.md)
 - [1.4.19.2](.github/release-notes/1.4.19.2.md)
 - [1.4.19.1](.github/release-notes/1.4.19.1.md)

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -231,6 +231,8 @@ OBSOLETE_ACTION_KEYS_BY_DEVICE_TYPE = {
 }
 OBSOLETE_SENSOR_KEYS_BY_DEVICE_TYPE = {}
 OBSOLETE_BINARY_SENSOR_KEYS_BY_DEVICE_TYPE = {
+    "SMA0A": ("mute_status",),
+    "SMA51": ("mute_status",),
     "SMS01": ("alarm_status",),
     "SDA51": ("mute_status",),
     "STH0A": ("mute_status",),

--- a/custom_components/xsense/binary_sensor.py
+++ b/custom_components/xsense/binary_sensor.py
@@ -178,8 +178,6 @@ MUTE_STATUS_DEVICE_TYPES = frozenset(
         "SD11-MR",
         "SD19-MN",
         "SK0Z-3S",
-        "SMA0A",
-        "SMA51",
         "SWS0A",
         "SWS51",
         "XC01-M",
@@ -216,6 +214,39 @@ MUTE_STATUS_DEVICE_TYPES = frozenset(
     }
 )
 
+# APK 1400 handlers C0876k, C0877l, O, and P use muteStatus 1-3 for
+# silenced alarms and 4+ for alarms that are still sounding.
+CODED_MUTE_STATUS_DEVICE_TYPES = frozenset(
+    {
+        "CB0Z-3S",
+        "LP/N-SCA-0A",
+        "SC01-MN",
+        "SC01-MR",
+        "SC06-WX",
+        "SC07-MR",
+        "SC07-WX",
+        "SC07-iA",
+        "XP0A-MR",
+        "XP0A-iR",
+        "XP0H-MR",
+        "XP0H-iR",
+        "XP0J-iA",
+        "XP0P-MR",
+        "XP0S-iA",
+        "XP0T-iA",
+        "XP0V-iA",
+        "XP0W-iA",
+    }
+)
+
+# The remaining detector handlers expose an alarm as silenced only while the
+# alarm is active and muteStatus is 0.
+ZERO_CODE_MUTE_STATUS_DEVICE_TYPES = MUTE_STATUS_DEVICE_TYPES.difference(
+    CODED_MUTE_STATUS_DEVICE_TYPES,
+)
+
+COMMAND_ONLY_MUTE_STATUS_DEVICE_TYPES = frozenset({"SMA0A", "SMA51"})
+
 
 def alarm_device_class(entity: Entity) -> BinarySensorDeviceClass | None:
     """Return the Home Assistant device class for an XSense alarm state."""
@@ -232,6 +263,8 @@ def has_alarm_status(entity: Entity) -> bool:
 
 def has_mute_status(entity: Entity) -> bool:
     """Return if an X-Sense entity should expose mute status."""
+    if entity.type in COMMAND_ONLY_MUTE_STATUS_DEVICE_TYPES:
+        return False
     return (
         "muteStatus" in entity.data
         or "mute" in entity.data
@@ -240,11 +273,56 @@ def has_mute_status(entity: Entity) -> bool:
 
 
 def mute_status(entity: Entity) -> bool | None:
-    """Return the canonical APK silence state across payload variants."""
-    value = entity.data.get("muteStatus")
-    if value in (None, ""):
-        value = entity.data.get("mute")
-    return boolean_state(value)
+    """Return the model-specific silence state used by APK 1400."""
+    raw_value = entity.data.get("muteStatus")
+
+    model = str(getattr(entity, "type", "") or "")
+    if raw_value not in (None, "") and model in MUTE_STATUS_DEVICE_TYPES:
+        alarm_active = boolean_state(entity.data.get("alarmStatus"))
+        if alarm_active is False:
+            return False
+        if alarm_active is None:
+            return None
+
+        code = status_code(raw_value)
+        if code is None:
+            return None
+        if model in CODED_MUTE_STATUS_DEVICE_TYPES:
+            return 1 <= code <= 3
+        if model in ZERO_CODE_MUTE_STATUS_DEVICE_TYPES:
+            return code == 0
+
+    fallback = entity.data.get("mute")
+    if fallback in (None, ""):
+        fallback = raw_value
+    return boolean_state(fallback)
+
+
+def status_code(value) -> int | None:
+    """Return an integer APK status code without applying boolean semantics."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def alarm_silence_status(
+    entity: Entity, alarm_key: str, mute_key: str
+) -> bool | None:
+    """Return APK silence/remind-later state for a specific active alarm."""
+    alarm_active = boolean_state(entity.data.get(alarm_key))
+    if alarm_active is False:
+        return False
+    if alarm_active is None:
+        return None
+    code = status_code(entity.data.get(mute_key))
+    return code in {1, 2} if code is not None else None
 
 
 def has_life_end_status(entity: Entity) -> bool:
@@ -491,7 +569,9 @@ _ALL_SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         translation_key="water_mute_status",
         icon="mdi:water-off",
         exists_fn=has_data("waterMuteStatus"),
-        value_fn=data_bool("waterMuteStatus"),
+        value_fn=lambda entity: alarm_silence_status(
+            entity, "waterAlarmStatus", "waterMuteStatus"
+        ),
     ),
     XSenseBinarySensorEntityDescription(
         key="temperature_alarm_status",
@@ -505,7 +585,9 @@ _ALL_SENSORS: tuple[XSenseBinarySensorEntityDescription, ...] = (
         translation_key="temperature_mute_status",
         icon="mdi:thermometer-off",
         exists_fn=has_data("tempMuteStatus"),
-        value_fn=data_bool("tempMuteStatus"),
+        value_fn=lambda entity: alarm_silence_status(
+            entity, "tempAlarmStatus", "tempMuteStatus"
+        ),
     ),
     XSenseBinarySensorEntityDescription(
         key="timezone_enabled",

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19.3"
+PANEL_ASSET_VERSION = "1.4.19.4"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.19.3",
+  "version": "1.4.19.4",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/mapping.py
+++ b/custom_components/xsense/python_xsense/mapping.py
@@ -106,52 +106,6 @@ def positive_code_state(value: typing.Any) -> bool | None:
     return None
 
 
-def detector_silence_state(value: typing.Any) -> bool | None:
-    """Normalize APK detector mute codes into a silenced state."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        if value == 0 or value >= 4:
-            return False
-        if value > 0:
-            return True
-        return None
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"true", "on"}:
-            return True
-        if normalized in {"false", "off"}:
-            return False
-        try:
-            code = int(normalized)
-        except ValueError:
-            return None
-        if code == 0 or code >= 4:
-            return False
-        if code > 0:
-            return True
-    return None
-
-
-def alarm_silence_state(value: typing.Any) -> bool | None:
-    """Normalize APK alarm silence states, including remind-later mode."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
-        if value in {1, 2}:
-            return True
-        if value == 0:
-            return False
-        return None
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "2", "true", "on"}:
-            return True
-        if normalized in {"0", "false", "off"}:
-            return False
-    return None
-
-
 def open_state(value: typing.Any) -> bool | None:
     """Return door/opening state where true means open."""
     result = bool_state(value)
@@ -235,7 +189,9 @@ type_mapping: dict[str, Callable[[typing.Any], typing.Any]] = {
     "mechanicalDingDongSwitch": bool_state,
     "mirrorFlip": bool_state,
     "mute": bool_state,
-    "muteStatus": detector_silence_state,
+    # APK 1400 interprets muteStatus differently per device handler. Preserve
+    # the numeric status code and let the HA entity apply the model rule.
+    "muteStatus": safe_int,
     "needAlarm": bool_state,
     "needMotion": bool_state,
     "needNightVision": bool_state,
@@ -251,14 +207,14 @@ type_mapping: dict[str, Callable[[typing.Any], typing.Any]] = {
     "showCodecChange": bool_state,
     "sunshineEnable": bool_state,
     "tempAlarmStatus": bool_state,
-    "tempMuteStatus": alarm_silence_state,
+    "tempMuteStatus": safe_int,
     "test": bool_state,
     "timeZoneEnabled": bool_state,
     "timeZoneValid": bool_state,
     "usbCharge": bool_state,
     "voiceVolumeSwitch": bool_state,
     "waterAlarmStatus": bool_state,
-    "waterMuteStatus": alarm_silence_state,
+    "waterMuteStatus": safe_int,
     "whiteLightScintillation": bool_state,
     "warnIsOpen": bool_state,
     "chirpToneEnable": bool_state,

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1012,7 +1012,7 @@ def test_parse_get_state_updates_child_status_when_apk_key_is_device_id():
 
     child = station_obj.devices["00000007"]
     assert child.data["alarmStatus"] is True
-    assert child.data["muteStatus"] is False
+    assert child.data["muteStatus"] == 0
     assert "00000007" not in station_obj.data
 
 
@@ -1169,7 +1169,7 @@ def test_parse_get_state_accepts_apk_reported_device_list():
     child = station_obj.devices["device-id"]
     assert child.online is True
     assert child.data["alarmStatus"] is False
-    assert child.data["muteStatus"] is True
+    assert child.data["muteStatus"] == 1
 
 
 def test_parse_get_state_updates_sbs10_child_from_apk_device_list():
@@ -1213,7 +1213,7 @@ def test_parse_get_state_updates_sbs10_child_from_apk_device_list():
     child = station_obj.devices["device-id"]
     assert child.online is True
     assert child.data["alarmStatus"] is False
-    assert child.data["muteStatus"] is True
+    assert child.data["muteStatus"] == 1
 
 
 def test_parse_get_state_does_not_use_stale_alarm_status_when_missing():
@@ -1425,28 +1425,20 @@ def test_xc0m_ir_maps_compact_temperature_and_humidity_fields():
     assert data["time"] == "20260705090102"
 
 
-@pytest.mark.parametrize("value", ("1", "2", 1, 2, True))
-def test_alarm_silence_states_include_apk_remind_later_mode(value):
-    assert mapping.map_type("waterMuteStatus", value) is True
-    assert mapping.map_type("tempMuteStatus", value) is True
+@pytest.mark.parametrize(
+    ("value", "expected"), (("0", 0), ("1", 1), ("2", 2), (0, 0), (1, 1))
+)
+def test_alarm_silence_status_preserves_apk_code(value, expected):
+    assert mapping.map_type("waterMuteStatus", value) == expected
+    assert mapping.map_type("tempMuteStatus", value) == expected
 
 
-@pytest.mark.parametrize("value", ("0", 0, False))
-def test_alarm_silence_states_report_inactive(value):
-    assert mapping.map_type("waterMuteStatus", value) is False
-    assert mapping.map_type("tempMuteStatus", value) is False
-
-
-@pytest.mark.parametrize("value", ("1", "2", "3", 1, 2, 3, True))
-def test_detector_mute_codes_report_silenced(value):
-    """APK detector mute codes 1-3 represent an active silence period."""
-    assert mapping.map_type("muteStatus", value) is True
-
-
-@pytest.mark.parametrize("value", ("0", "4", "5", 0, 4, 5, False))
-def test_detector_mute_codes_report_not_silenced(value):
-    """APK detector mute code 0 and active-alarm codes 4+ are not silenced."""
-    assert mapping.map_type("muteStatus", value) is False
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (("0", 0), ("1", 1), ("2", 2), ("3", 3), ("4", 4), (0, 0), (1, 1)),
+)
+def test_detector_mute_status_preserves_apk_code(value, expected):
+    assert mapping.map_type("muteStatus", value) == expected
 
 
 @pytest.mark.parametrize("value", ("1", "2", "3", 1, 2, 3, True))
@@ -1647,7 +1639,7 @@ async def test_get_state_reads_sws51_sbs50_child_info_like_apk():
     ]
     assert device.data["batInfo"] == 3
     assert device.data["alarmStatus"] is False
-    assert device.data["muteStatus"] is True
+    assert device.data["muteStatus"] == 1
 
 
 @pytest.mark.asyncio
@@ -1711,7 +1703,7 @@ async def test_get_state_reads_xc01m_sbs50_child_info_like_apk():
     assert device.data["coPpmPeak"] == 6
     assert device.data["coPpmPeakTime"] == "20260709111213"
     assert device.data["isLifeEnd"] is False
-    assert device.data["muteStatus"] is False
+    assert device.data["muteStatus"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -10,7 +10,11 @@ from custom_components.xsense.alarm_control_panel import (
 from custom_components.xsense.python_xsense.base import XSenseBase
 from custom_components.xsense.python_xsense.station import Station
 from custom_components.xsense.binary_sensor import (
+    CODED_MUTE_STATUS_DEVICE_TYPES,
+    COMMAND_ONLY_MUTE_STATUS_DEVICE_TYPES,
+    MUTE_STATUS_DEVICE_TYPES,
     SENSORS as BINARY_SENSORS,
+    ZERO_CODE_MUTE_STATUS_DEVICE_TYPES,
     XSenseBinarySensorEntity,
     XSenseBinarySensorEntityDescription,
     XSenseMQTTConnectedEntity,
@@ -143,26 +147,113 @@ def test_reported_test_active_state_is_exposed_from_device_data():
     assert description.value_fn(station) is False
 
 
-def test_sws51_uses_apk_generic_alarm_and_silence_states():
-    """APK 1400 maps SWS51 to alarmStatus/muteStatus, not SWS0B fields."""
+@pytest.mark.parametrize(
+    ("alarm_status", "mute_status", "silence_time", "expected"),
+    (
+        (False, "1", "0", False),
+        (False, "0", "0", False),
+        (True, "1", "0", False),
+        (True, "0", "0", True),
+        (True, "0", "600", True),
+    ),
+)
+def test_sws51_uses_apk_alarm_and_silence_conditions(
+    alarm_status, mute_status, silence_time, expected
+):
+    """Mirror APK 1400 S1.F for triggered, silenced, and remind-later states."""
     device = SimpleNamespace(
         type="SWS51",
         data={
-            "alarmStatus": True,
-            "muteStatus": True,
+            "alarmStatus": alarm_status,
+            "muteStatus": mute_status,
+            "silenceTime": silence_time,
         },
     )
     descriptions = {description.key: description for description in BINARY_SENSORS}
 
     assert descriptions["alarm_status"].exists_fn(device)
-    assert descriptions["alarm_status"].value_fn(device) is True
+    assert descriptions["alarm_status"].value_fn(device) is alarm_status
     assert "mute" not in descriptions
     assert descriptions["mute_status"].exists_fn(device)
-    assert descriptions["mute_status"].value_fn(device) is True
+    assert descriptions["mute_status"].value_fn(device) is expected
     assert not descriptions["water_alarm_status"].exists_fn(device)
     assert not descriptions["water_mute_status"].exists_fn(device)
     assert not descriptions["temperature_alarm_status"].exists_fn(device)
     assert not descriptions["temperature_mute_status"].exists_fn(device)
+
+
+@pytest.mark.parametrize(
+    ("model", "alarm_status", "mute_status", "expected"),
+    (
+        ("XS01-M", True, "0", True),
+        ("XS01-M", True, "1", False),
+        ("XS01-M", False, "0", False),
+        ("SC07-MR", True, "1", True),
+        ("SC07-MR", True, "3", True),
+        ("SC07-MR", True, "4", False),
+        ("SC07-MR", False, "1", False),
+    ),
+)
+def test_apk_detector_families_use_their_own_mute_status_codes(
+    model, alarm_status, mute_status, expected
+):
+    device = SimpleNamespace(
+        type=model,
+        data={
+            "alarmStatus": alarm_status,
+            "muteStatus": mute_status,
+        },
+    )
+    description = next(
+        item for item in BINARY_SENSORS if item.key == "mute_status"
+    )
+
+    assert description.value_fn(device) is expected
+
+
+def test_apk_mute_status_model_families_are_exhaustive_and_disjoint():
+    assert CODED_MUTE_STATUS_DEVICE_TYPES.isdisjoint(
+        ZERO_CODE_MUTE_STATUS_DEVICE_TYPES
+    )
+    assert (
+        CODED_MUTE_STATUS_DEVICE_TYPES
+        | ZERO_CODE_MUTE_STATUS_DEVICE_TYPES
+    ) == MUTE_STATUS_DEVICE_TYPES
+    assert COMMAND_ONLY_MUTE_STATUS_DEVICE_TYPES == {"SMA0A", "SMA51"}
+
+
+def test_vendored_entity_preserves_raw_apk_mute_status_code():
+    station = Station(
+        House(),
+        stationId="station-id",
+        stationName="Water Leak Sensor",
+        stationSn="SWS51SN",
+        category="SWS51",
+        online=1,
+    )
+
+    station.set_data(
+        {
+            "status": {
+                "alarmStatus": "0",
+                "muteStatus": "1",
+                "silenceTime": "0",
+            }
+        }
+    )
+
+    assert station.data["muteStatus"] == 1
+    description = next(
+        item for item in BINARY_SENSORS if item.key == "mute_status"
+    )
+    assert description.value_fn(station) is False
+
+    station.set_data(
+        {"status": {"alarmStatus": "1", "muteStatus": "0", "silenceTime": "0"}}
+    )
+
+    assert station.data["muteStatus"] == 0
+    assert description.value_fn(station) is True
 
 
 def test_sws0b_uses_apk_dual_water_and_temperature_states():
@@ -170,9 +261,9 @@ def test_sws0b_uses_apk_dual_water_and_temperature_states():
         type="SWS0B",
         data={
             "waterAlarmStatus": False,
-            "waterMuteStatus": False,
+            "waterMuteStatus": 0,
             "tempAlarmStatus": True,
-            "tempMuteStatus": True,
+            "tempMuteStatus": 1,
         },
     )
     descriptions = {description.key: description for description in BINARY_SENSORS}
@@ -181,6 +272,36 @@ def test_sws0b_uses_apk_dual_water_and_temperature_states():
     assert descriptions["water_mute_status"].value_fn(device) is False
     assert descriptions["temperature_alarm_status"].value_fn(device) is True
     assert descriptions["temperature_mute_status"].value_fn(device) is True
+
+
+@pytest.mark.parametrize(
+    ("alarm_key", "mute_key", "alarm_status", "mute_status", "expected"),
+    (
+        ("waterAlarmStatus", "waterMuteStatus", False, 1, False),
+        ("waterAlarmStatus", "waterMuteStatus", True, 0, False),
+        ("waterAlarmStatus", "waterMuteStatus", True, 1, True),
+        ("waterAlarmStatus", "waterMuteStatus", True, 2, True),
+        ("tempAlarmStatus", "tempMuteStatus", False, 2, False),
+        ("tempAlarmStatus", "tempMuteStatus", True, 1, True),
+    ),
+)
+def test_sws0b_silence_states_require_the_corresponding_active_alarm(
+    alarm_key, mute_key, alarm_status, mute_status, expected
+):
+    device = SimpleNamespace(
+        type="SWS0B",
+        data={alarm_key: alarm_status, mute_key: mute_status},
+    )
+    description_key = (
+        "water_mute_status"
+        if mute_key == "waterMuteStatus"
+        else "temperature_mute_status"
+    )
+    description = next(
+        item for item in BINARY_SENSORS if item.key == description_key
+    )
+
+    assert description.value_fn(device) is expected
 
 
 @pytest.mark.parametrize(
@@ -223,17 +344,16 @@ def test_unexpected_cloud_state_remains_payload_gated(model, key, description_ke
     assert descriptions[description_key].value_fn(device) is True
 
 
-def test_generic_mute_payload_uses_single_canonical_silence_entity():
+def test_mailbox_mute_command_does_not_create_fake_silence_state():
     device = SimpleNamespace(type="SMA51", data={"mute": True})
     descriptions = {description.key: description for description in BINARY_SENSORS}
 
-    assert descriptions["mute_status"].exists_fn(device)
-    assert descriptions["mute_status"].value_fn(device) is True
+    assert not descriptions["mute_status"].exists_fn(device)
     assert "mute" not in descriptions
 
 
 def test_empty_canonical_mute_status_falls_back_to_raw_mute_state():
-    device = SimpleNamespace(type="SMA51", data={"muteStatus": "", "mute": True})
+    device = SimpleNamespace(type="UNKNOWN", data={"muteStatus": "", "mute": True})
     descriptions = {description.key: description for description in BINARY_SENSORS}
 
     assert descriptions["mute_status"].value_fn(device) is True


### PR DESCRIPTION
## Summary\n- preserve model-specific X-Sense alarm and mute status codes\n- align SWS51 and SWS0B alarm/silence states with the APK\n- remove stale persistent silence entities from command-only models\n- prepare the v1.4.19.4 prerelease metadata and notes\n\n## Validation\n- Windows: 850 passed\n- Linux server: 850 passed\n- compileall and git diff checks passed