### PR TITLE
Preserve proven camera identities across ADDX calls

### DIFF
--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -207,8 +207,15 @@ def _camera_addx_serial(camera: Entity) -> str:
 def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
     """Return APK camera identifiers in ADDX preference order."""
     data = getattr(camera, "data", {}) or {}
+    ticket = data.get("cameraWebrtcTicket")
+    if not isinstance(ticket, dict):
+        ticket = {}
     result: list[str] = []
     for value in (
+        data.get("addxAccessSerialNumber"),
+        ticket.get("serialNumber"),
+        data.get("addxRealSerialNumber"),
+        ticket.get("realCxSerialNumber"),
         data.get("addxSerialNumber"),
         getattr(camera, "entity_id", None),
         getattr(camera, "sn", None),
@@ -633,7 +640,12 @@ class AsyncXSense(XSenseBase):
                 if not isinstance(group_records, list) or not group_records:
                     continue
 
-                camera.set_data({"addxSerialNumber": serial})
+                camera.set_data(
+                    {
+                        "addxAccessSerialNumber": serial,
+                        "addxSerialNumber": serial,
+                    }
+                )
                 records.extend(
                     record for record in group_records if isinstance(record, dict)
                 )
@@ -1593,7 +1605,12 @@ class AsyncXSense(XSenseBase):
                     serialNumber=serial,
                     verifyDormancyStatus=True,
                 )
-                camera.set_data({"addxSerialNumber": serial})
+                camera.set_data(
+                    {
+                        "addxAccessSerialNumber": serial,
+                        "addxSerialNumber": serial,
+                    }
+                )
                 break
             except APIFailure as err:
                 last_error = err
@@ -1611,8 +1628,16 @@ class AsyncXSense(XSenseBase):
             raise last_error
         if isinstance(data, dict):
             data = dict(data)
-            data["serialNumber"] = _camera_addx_serial(camera)
-            camera.set_data({"cameraWebrtcTicket": data})
+            accepted_serial = _camera_addx_serial(camera)
+            data["serialNumber"] = accepted_serial
+            camera_data = {
+                "addxAccessSerialNumber": accepted_serial,
+                "cameraWebrtcTicket": data,
+            }
+            real_serial = data.get("realCxSerialNumber")
+            if real_serial not in (None, ""):
+                camera_data["addxRealSerialNumber"] = str(real_serial)
+            camera.set_data(camera_data)
             return data
         return None
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -4171,6 +4171,66 @@ async def test_update_camera_data_updates_known_camera_from_addx_device_list():
 
 
 @pytest.mark.asyncio
+async def test_update_camera_data_keeps_proven_addx_access_identity():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "camera-list-id",
+                    "ipcSn": "camera-label",
+                    "ipcName": "Front Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["camera-list-id"]
+    camera.set_data({"addxAccessSerialNumber": "working-camera-id"})
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        calls.append((endpoint, kwargs))
+        if endpoint == "/device/listuserdevices":
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-list-id",
+                        "deviceName": "Front Camera",
+                        "houseId": "house-id",
+                        "modelNo": "SSC0A",
+                        "deviceSupport": {
+                            "supportLiveAudio": 0,
+                            "supportLiveSpeakerVolume": 0,
+                            "supportRecordingAudio": 0,
+                            "supportPersonDetect": 0,
+                        },
+                    }
+                ]
+            }
+        return {}
+
+    client.addx_call = addx_call
+
+    await client.update_camera_data()
+
+    assert camera.data["addxAccessSerialNumber"] == "working-camera-id"
+    assert camera.data["addxSerialNumber"] == "camera-list-id"
+    assert (
+        "/device/getuserconfig",
+        {
+            "_house": test_house,
+            "serialNumber": "working-camera-id",
+            "voiceReminder": False,
+        },
+    ) in calls
+
+
+@pytest.mark.asyncio
 async def test_update_camera_data_keeps_existing_home_camera_entries_not_in_addx_list():
     client = async_xsense.AsyncXSense()
     test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
@@ -4963,7 +5023,35 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
 
     assert calls == [["camera-list-id"], ["camera-access-id"]]
     assert result["list"] == [{"serialNumber": "camera-access-id"}]
-    assert updates == [{"addxSerialNumber": "camera-access-id"}]
+    assert updates == [
+        {
+            "addxAccessSerialNumber": "camera-access-id",
+            "addxSerialNumber": "camera-access-id",
+        }
+    ]
+
+
+def test_camera_addx_serial_candidates_keep_proven_access_identity_first():
+    camera = SimpleNamespace(
+        sn="camera-label",
+        entity_id="camera-access-id",
+        data={
+            "addxAccessSerialNumber": "working-camera-id",
+            "addxSerialNumber": "camera-list-id",
+            "cameraWebrtcTicket": {
+                "serialNumber": "working-camera-id",
+                "realCxSerialNumber": "real-camera-id",
+            },
+        },
+    )
+
+    assert async_xsense._camera_addx_serial_candidates(camera) == [
+        "working-camera-id",
+        "real-camera-id",
+        "camera-list-id",
+        "camera-access-id",
+        "camera-label",
+    ]
 
 
 def test_camera_addx_house_prefers_exact_addx_house_id_before_node():
@@ -5537,7 +5625,48 @@ async def test_camera_webrtc_ticket_retries_ipc_id_after_rejected_cached_addx_se
         if endpoint == "/device/getWebrtcTicket"
     ] == ["wrong-cached-id", "right-addx-camera-id"]
     assert camera.data["addxSerialNumber"] == "right-addx-camera-id"
+    assert camera.data["addxAccessSerialNumber"] == "right-addx-camera-id"
     assert camera.data["cameraWebrtcTicket"]["serialNumber"] == "right-addx-camera-id"
+
+
+@pytest.mark.asyncio
+async def test_camera_webrtc_ticket_retains_real_camera_identity_as_fallback():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "camera-access-id",
+                    "ipcSn": "camera-label",
+                    "ipcName": "Camera",
+                    "category": "SSC0A",
+                }
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["camera-access-id"]
+    camera.set_data({"addxSerialNumber": "camera-list-id"})
+
+    async def addx_call(endpoint, **kwargs):
+        return {
+            "signalServer": "https://signal.example",
+            "realCxSerialNumber": "real-camera-id",
+        }
+
+    client.addx_call = addx_call
+
+    await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+
+    assert camera.data["addxAccessSerialNumber"] == "camera-list-id"
+    assert camera.data["addxRealSerialNumber"] == "real-camera-id"
+    assert async_xsense._camera_addx_serial_candidates(camera)[:2] == [
+        "camera-list-id",
+        "real-camera-id",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve the camera identity that has already succeeded against ADDX
- reuse that identity for history, WebRTC, settings, audio, AI, and other camera calls
- retain `realCxSerialNumber` as an additional APK-provided fallback
- prevent later camera-list metadata refreshes from replacing the proven access identity

## Why

Multi-Home accounts can expose different identifiers for the same camera. Live view may establish a working identity, but a later metadata refresh previously replaced it with the camera-list identity. Subsequent recording-history and camera-settings requests could then return empty results or access errors.

## Validation

- Windows: 853 tests passed
- Linux server, Python 3.14 and Home Assistant 2026.8.3: 853 tests passed
- focused adapter suite on Linux: 320 tests passed
- `pip check`, `compileall`, and `git diff --check` passed