### PR TITLE
Prepare v1.4.19.5 camera identity prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19.4):
-  (e.g., 1.4.19.4)
+- **X-Sense-Integration Version** (z. B. 1.4.19.5):
+  (e.g., 1.4.19.5)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.5.md
+++ b/.github/release-notes/1.4.19.5.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.19.5
+
+### 📷 Multi-Home Camera Access
+- Keeps the camera identity accepted by X-Sense available across live view, recording history, settings, audio, and AI requests.
+- Retains the additional camera identity returned with the WebRTC ticket as a fallback for accounts with multiple X-Sense Homes.
+- Prevents routine camera metadata refreshes from replacing an identity that previously succeeded.
+
+Please test camera motion and AI events, camera settings, and live view on multi-Home accounts.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.13"
+          - "3.14"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements-runtime.txt
+            requirements-test.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements-runtime.txt -r requirements-test.txt
+
+      - name: Compile Python sources
+        run: python -m compileall -q custom_components tests
+
+      - name: Run test suite
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: python -m pytest -p pytest_asyncio.plugin -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19.5](.github/release-notes/1.4.19.5.md)
 - [1.4.19.4](.github/release-notes/1.4.19.4.md)
 - [1.4.19.3](.github/release-notes/1.4.19.3.md)
 - [1.4.19.2](.github/release-notes/1.4.19.2.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19.4"
+PANEL_ASSET_VERSION = "1.4.19.5"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.19.4",
+  "version": "1.4.19.5",
   "zeroconf": []
 }

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,8 @@
 pytest==9.1.1
 pytest-asyncio==1.4.0
+homeassistant==2026.8.3
+paho-mqtt==2.1.0
+numpy==2.3.2
+PyTurboJPEG==1.8.3
+av==17.0.1
+ha-ffmpeg==3.2.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 pytest==9.1.1
 pytest-asyncio==1.4.0
-homeassistant==2026.8.3
+homeassistant==2026.2.3; python_version < "3.14"
+homeassistant==2026.8.3; python_version >= "3.14"
 paho-mqtt==2.1.0
 numpy==2.3.2
 PyTurboJPEG==1.8.3


### PR DESCRIPTION
## Summary

- prepare the `1.4.19.5` prerelease for multi-Home camera identity handling
- keep manifest, frontend asset version, changelog, issue template, and release notes synchronized
- restore automated full-suite testing on Python 3.13 and 3.14 for every pull request

## Validation

- Windows: 853 tests passed
- Linux server, Python 3.14 and Home Assistant 2026.8.3: 853 tests passed
- dependency integrity, compileall, and diff checks passed