### PR TITLE
Show force-arm prompts only for blocked arm requests

### DIFF
--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
@@ -36,6 +37,7 @@ SAFEMODE_TO_STATE: dict[str, AlarmControlPanelState] = {
     "Away": AlarmControlPanelState.ARMED_AWAY,
 }
 FORCE_ARM_NOTIFICATION_ID_PREFIX = "xsense_force_arm_"
+ARM_REQUEST_TIMEOUT_SECONDS = 60
 FORCE_ARM_SERVICE = "force_arm"
 FORCE_ARM_NOW_SERVICE = "force_arm_now"
 TRIGGER_SOS_SERVICE = "trigger_sos"
@@ -174,6 +176,7 @@ class XSenseAlarmControlPanel(
         }
         self._safemode: str | None = None
         self._pending_force_arm_mode: str | None = None
+        self._cancel_arm_request_timeout = None
 
     @property
     def _station(self):
@@ -221,11 +224,15 @@ class XSenseAlarmControlPanel(
         station = self._station
         if station is None:
             self._safemode = None
+            self._async_cancel_arm_request_timeout()
             self._async_clear_force_arm_notification()
             self.async_write_ha_state()
             return
 
         pending_mode = pending_force_arm_mode(station)
+        alarm_data = getattr(station, "alarm_data", {}) or {}
+        if pending_mode is not None or not alarm_data.get("requestedSafeMode"):
+            self._async_cancel_arm_request_timeout()
         if pending_mode != self._pending_force_arm_mode:
             self._pending_force_arm_mode = pending_mode
             if pending_mode is None:
@@ -298,6 +305,7 @@ class XSenseAlarmControlPanel(
 
     async def async_will_remove_from_hass(self) -> None:
         """Dismiss entry-owned notifications when the entity unloads."""
+        self._async_cancel_arm_request_timeout()
         self._async_clear_force_arm_notification()
         await super().async_will_remove_from_hass()
 
@@ -368,6 +376,14 @@ class XSenseAlarmControlPanel(
         if station is None:
             raise xsense_error("station_unavailable")
 
+        self._async_clear_arm_request(station)
+        await self._set_safe_mode(mode, force_arm="1")
+        self.async_write_ha_state()
+
+    @callback
+    def _async_clear_arm_request(self, station) -> None:
+        """Clear local state for an APK-style mode request."""
+        self._async_cancel_arm_request_timeout()
         station.set_alarm_data(
             {
                 "forceReason": None,
@@ -378,8 +394,37 @@ class XSenseAlarmControlPanel(
         )
         self._pending_force_arm_mode = None
         self._async_clear_force_arm_notification()
-        await self._set_safe_mode(mode, force_arm="1")
+
+    @callback
+    def _async_cancel_arm_request_timeout(self) -> None:
+        """Cancel the active normal-arm response timeout."""
+        if self._cancel_arm_request_timeout is not None:
+            self._cancel_arm_request_timeout()
+            self._cancel_arm_request_timeout = None
+
+    @callback
+    def _async_arm_request_timed_out(self, _now) -> None:
+        """Expire an unanswered mode request like the APK's 60-second timer."""
+        self._cancel_arm_request_timeout = None
+        station = self._station
+        if station is None:
+            return
+        alarm_data = getattr(station, "alarm_data", {}) or {}
+        if not alarm_data.get("requestedSafeMode") or alarm_data.get("forceReason"):
+            return
+        LOGGER.debug("Station %s arm request timed out", station.sn)
+        self._async_clear_arm_request(station)
         self.async_write_ha_state()
+
+    @callback
+    def _async_start_arm_request_timeout(self) -> None:
+        """Start the APK-aligned normal-arm response timeout."""
+        self._async_cancel_arm_request_timeout()
+        self._cancel_arm_request_timeout = async_call_later(
+            self.hass,
+            ARM_REQUEST_TIMEOUT_SECONDS,
+            self._async_arm_request_timed_out,
+        )
 
     async def _set_safe_mode(self, safe_mode: str, *, force_arm: str) -> None:
         """Request a safeMode change through the APK app-mode shadow."""
@@ -398,16 +443,23 @@ class XSenseAlarmControlPanel(
         api = coordinator.xsense
 
         if safe_mode in ("Home", "Away") and force_arm == "0":
-            station.set_alarm_data({"requestedSafeMode": safe_mode})
-        elif safe_mode == "Disarmed":
+            current_mode = getattr(station, "alarm_mode", None)
+            if current_mode == safe_mode:
+                self._async_clear_arm_request(station)
+                return
             station.set_alarm_data(
                 {
                     "forceReason": None,
                     "safeModeAim": None,
-                    "requestedSafeMode": None,
+                    "requestedSafeMode": safe_mode,
                     "exitDelay": None,
                 }
             )
+            self._pending_force_arm_mode = None
+            self._async_clear_force_arm_notification()
+            self._async_start_arm_request_timeout()
+        elif safe_mode == "Disarmed":
+            self._async_clear_arm_request(station)
 
         try:
             await api.set_station_mode(station, safe_mode, force_arm=force_arm)
@@ -420,7 +472,7 @@ class XSenseAlarmControlPanel(
 
         except Exception as ex:  # noqa: BLE001
             if force_arm == "0":
-                station.set_alarm_data({"requestedSafeMode": None})
+                self._async_clear_arm_request(station)
             LOGGER.exception(
                 "Could not set safeMode %s forceArm=%s for station %s: %s",
                 safe_mode,

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -132,11 +132,7 @@ def pending_force_arm_mode(station) -> str | None:
     if not force_reason:
         return None
 
-    mode = (
-        alarm_data.get("requestedSafeMode")
-        or alarm_data.get("safeModeAim")
-        or alarm_data.get("safeMode")
-    )
+    mode = alarm_data.get("requestedSafeMode")
     if mode in ("Home", "Away"):
         return mode
     return None
@@ -372,7 +368,6 @@ class XSenseAlarmControlPanel(
         if station is None:
             raise xsense_error("station_unavailable")
 
-        await self._set_safe_mode(mode, force_arm="1")
         station.set_alarm_data(
             {
                 "forceReason": None,
@@ -383,6 +378,7 @@ class XSenseAlarmControlPanel(
         )
         self._pending_force_arm_mode = None
         self._async_clear_force_arm_notification()
+        await self._set_safe_mode(mode, force_arm="1")
         self.async_write_ha_state()
 
     async def _set_safe_mode(self, safe_mode: str, *, force_arm: str) -> None:

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import aiohttp
 
 from .aws_signer import AWSSigner
-from .base import XSenseBase, shadow_update_body
+from .base import XSenseBase, _apply_sbs50_force_arm_prompt, shadow_update_body
 from .entity import Entity
 from .entity_map import EntityType
 from .exceptions import SessionExpired, APIFailure, XSenseError
@@ -1777,7 +1777,17 @@ class AsyncXSense(XSenseBase):
             return
 
         if "reported" in res.get("state", {}):
-            station.set_alarm_data(res["state"]["reported"])
+            reported = res["state"]["reported"].copy()
+            _apply_sbs50_force_arm_prompt(station, reported)
+            station.set_alarm_data(
+                {
+                    key: value
+                    for key, value in reported.items()
+                    if key not in {"forceReason", "safeModeAim"}
+                }
+            )
+            if "safeMode" in reported:
+                self.apply_safe_mode(station, reported["safeMode"])
 
     async def get_station_state(self, station: Station):
         for page in _station_info_shadow_names(station):

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -565,21 +565,32 @@ def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:
 def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
     """Track the APK bypass confirmation prompt for SBS50 arm requests."""
     current_alarm_data = getattr(station, "alarm_data", {}) or {}
+    reported_mode = station_data.get("safeMode")
+    requested_mode = current_alarm_data.get("requestedSafeMode")
+    request_completed = reported_mode in ("Home", "Away") and (
+        reported_mode == requested_mode
+    )
+    if request_completed:
+        station.set_alarm_data(
+            {
+                "forceReason": None,
+                "safeModeAim": None,
+                "requestedSafeMode": None,
+                "exitDelay": None,
+            }
+        )
+        return
+
     prompt = _sbs50_force_arm_prompt(
         station_data,
-        requested_mode=current_alarm_data.get("requestedSafeMode"),
+        requested_mode=requested_mode,
     )
     if prompt is not None:
         station.set_alarm_data(prompt)
         return
 
     force_reason_reported = "forceReason" in station_data
-    reported_mode = station_data.get("safeMode")
-    requested_mode = current_alarm_data.get("requestedSafeMode")
-    request_completed = reported_mode in ("Home", "Away") and (
-        requested_mode is None or reported_mode == requested_mode
-    )
-    if force_reason_reported or request_completed:
+    if force_reason_reported:
         station.set_alarm_data(
             {
                 "forceReason": None,
@@ -593,6 +604,9 @@ def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
 def _sbs50_force_arm_prompt(
     station_data: Dict, *, requested_mode: str | None = None
 ) -> Dict | None:
+    if requested_mode not in ("Home", "Away"):
+        return None
+
     if "forceReason" in station_data:
         force_reason = station_data.get("forceReason")
         if force_reason:
@@ -604,29 +618,6 @@ def _sbs50_force_arm_prompt(
                 "requestedSafeMode": requested_mode,
                 "exitDelay": station_data.get("exitDelay"),
             }
-
-    notices = station_data.get("notices")
-    if not isinstance(notices, list):
-        return None
-
-    for notice in notices:
-        if not isinstance(notice, dict):
-            continue
-        event_param = notice.get("eventParam")
-        if not isinstance(event_param, dict):
-            continue
-        force_reason = event_param.get("forceReason")
-        if not force_reason:
-            continue
-        return {
-            "forceReason": force_reason,
-            "safeModeAim": requested_mode
-            or event_param.get("safeModeAim")
-            or station_data.get("safeModeAim")
-            or station_data.get("safeMode"),
-            "requestedSafeMode": requested_mode,
-            "exitDelay": event_param.get("exitDelay"),
-        }
 
     return None
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1398,6 +1398,70 @@ async def test_get_station_state_uses_second_info_for_new_wifi_devices_like_apk(
     assert station.data == {"temperature": 21}
 
 
+@pytest.mark.asyncio
+async def test_get_alarm_state_ignores_stale_force_reason_without_local_request():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS50",
+    )
+
+    async def get_thing(station_arg, page):
+        client._lastres = FakeResponse(200)
+        return {
+            "state": {
+                "reported": {
+                    "safeMode": "Disarmed",
+                    "forceReason": [{"door-sn": "1"}],
+                    "exitDelay": "0",
+                }
+            }
+        }
+
+    client.get_thing = get_thing
+
+    await client.get_alarm_state(station_obj)
+
+    assert station_obj.safe_mode == "Disarmed"
+    assert station_obj.alarm_data["safeMode"] == "Disarmed"
+    assert station_obj.alarm_data.get("forceReason") is None
+
+
+@pytest.mark.asyncio
+async def test_get_alarm_state_keeps_force_reason_for_active_local_request():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS50",
+    )
+    station_obj.set_alarm_data({"requestedSafeMode": "Away"})
+
+    async def get_thing(station_arg, page):
+        client._lastres = FakeResponse(200)
+        return {
+            "state": {
+                "reported": {
+                    "safeMode": "Disarmed",
+                    "forceReason": [{"door-sn": "1"}],
+                    "exitDelay": "0",
+                }
+            }
+        }
+
+    client.get_thing = get_thing
+
+    await client.get_alarm_state(station_obj)
+
+    assert station_obj.alarm_data["requestedSafeMode"] == "Away"
+    assert station_obj.alarm_data["forceReason"] == [{"door-sn": "1"}]
+
+
 def test_xc0m_ir_maps_compact_temperature_and_humidity_fields():
     data = mapping.map_values(
         "XC0M-iR",

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -96,6 +96,15 @@ def _xs01_wx_from_real_shadow():
     return station
 
 
+def _patch_alarm_call_later(monkeypatch, replacement):
+    """Patch the timer global used by the collected entity class."""
+    monkeypatch.setitem(
+        XSenseAlarmControlPanel._async_start_arm_request_timeout.__globals__,
+        "async_call_later",
+        replacement,
+    )
+
+
 def test_xs01_wx_online_time_report_marks_station_online():
     station = _xs01_wx_from_real_shadow()
 
@@ -724,7 +733,7 @@ def test_alarm_control_panel_requires_security_device_family():
         assert station_supports_alarm_panel(security_station)
 
 
-async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
+async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation(monkeypatch):
     class Api:
         def __init__(self):
             self.calls = []
@@ -751,6 +760,14 @@ async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
     coordinator = Coordinator(station)
     coordinator.xsense = api
     panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: None
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
 
     await panel.async_alarm_arm_home()
     await panel.async_alarm_arm_away()
@@ -760,6 +777,196 @@ async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
         (station.sn, "Away", "0"),
     ]
     assert station.alarm_data["requestedSafeMode"] == "Away"
+
+
+async def test_normal_arm_clears_stale_bypass_state_before_publish(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "forceReason": [{"door-sn": "1"}],
+            "safeModeAim": "Home",
+            "requestedSafeMode": None,
+            "exitDelay": "0",
+        }
+    )
+    state_during_publish = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            state_during_publish.append(dict(station.alarm_data))
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: None
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    await panel.async_alarm_arm_home()
+
+    assert state_during_publish == [
+        {
+            "forceReason": None,
+            "safeModeAim": None,
+            "requestedSafeMode": "Home",
+            "exitDelay": None,
+        }
+    ]
+
+
+async def test_normal_arm_request_expires_after_apk_timeout(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    callbacks = []
+    cancelled = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    def schedule(hass, delay, action):
+        callbacks.append((delay, action))
+
+        def cancel():
+            cancelled.append(True)
+
+        return cancel
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    dismissed = []
+    _patch_alarm_call_later(monkeypatch, schedule)
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: dismissed.append(notification_id),
+    )
+
+    await panel.async_alarm_arm_away()
+    assert callbacks[0][0] == 60
+    assert station.alarm_data["requestedSafeMode"] == "Away"
+
+    callbacks[0][1](None)
+
+    assert station.alarm_data["requestedSafeMode"] is None
+    assert station.alarm_data["forceReason"] is None
+    assert panel._cancel_arm_request_timeout is None
+    assert dismissed == [
+        f"xsense_force_arm_{station.entity_id}",
+        f"xsense_force_arm_{station.entity_id}",
+    ]
+    assert cancelled == []
+
+
+async def test_force_arm_prompt_stops_request_timeout(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    cancelled = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: cancelled.append(True)
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    await panel.async_alarm_arm_home()
+    XSenseBase.__new__(XSenseBase).parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [{"door-sn": "1"}],
+            "exitDelay": "0",
+        },
+    )
+    panel._handle_coordinator_update()
+
+    assert cancelled == [True]
+    assert panel._cancel_arm_request_timeout is None
+    assert pending_force_arm_mode(station) == "Home"
+
+
+async def test_normal_arm_is_noop_when_station_already_reports_target_mode(
+    monkeypatch,
+):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.safe_mode = "Home"
+    calls = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            calls.append((safe_mode, force_arm))
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    await panel.async_alarm_arm_home()
+
+    assert calls == []
+    assert station.alarm_data.get("requestedSafeMode") is None
+
+
+async def test_alarm_panel_unload_cancels_request_timeout(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    cancelled = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    async def super_remove(self):
+        return None
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: cancelled.append(True)
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+    monkeypatch.setattr(
+        "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_will_remove_from_hass",
+        super_remove,
+    )
+
+    await panel.async_alarm_arm_home()
+    await panel.async_will_remove_from_hass()
+
+    assert cancelled == [True]
 
 
 def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_mode_result():

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -762,25 +762,19 @@ async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation():
     assert station.alarm_data["requestedSafeMode"] == "Away"
 
 
-def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_notice():
+def test_force_arm_prompt_is_parsed_and_cleared_from_sbs50_mode_result():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Home"})
     api = XSenseBase.__new__(XSenseBase)
 
     api.parse_get_state(
         station,
         {
             "safeMode": "Disarmed",
-            "notices": [
-                {
-                    "type": "SKP0A",
-                    "eventParam": {
-                        "safeModeAim": "Home",
-                        "forceReason": [{"deviceSN": "door-sn"}],
-                        "exitDelay": "0",
-                    },
-                }
-            ],
+            "safeModeAim": "Home",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
         },
     )
 
@@ -896,6 +890,37 @@ async def test_alarm_panel_force_arm_now_does_not_require_pending_prompt(monkeyp
     assert dismissed == [f"xsense_force_arm_{station.entity_id}"]
 
 
+async def test_force_arm_now_clears_prompt_before_sending_command(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "safeModeAim": "Away",
+            "requestedSafeMode": "Away",
+        }
+    )
+    states_during_call = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            states_during_call.append(pending_force_arm_mode(station))
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    await panel.async_force_arm_now("Away")
+
+    assert states_during_call == [None]
+
+
 async def test_alarm_panel_exposes_apk_sos_and_alarm_actions():
     """Security actions use the exact SBS50 APK client commands."""
 
@@ -1009,6 +1034,69 @@ def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target(
     assert station.alarm_data["safeModeAim"] == "Home"
 
 
+def test_force_arm_prompt_ignores_stale_reason_without_local_request():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "safeModeAim": "Away",
+            "forceReason": [{"deviceSN": "door-sn"}],
+        },
+    )
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
+
+
+def test_force_arm_prompt_ignores_historical_notices_during_local_request():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Away"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "notices": [
+                {
+                    "type": "SKP0A",
+                    "eventParam": {
+                        "safeModeAim": "Away",
+                        "forceReason": [{"deviceSN": "old-door-sn"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
+
+
+def test_successful_normal_arm_ignores_stale_force_reason():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Home"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Home",
+            "forceReason": [{"deviceSN": "door-sn"}],
+        },
+    )
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data["forceReason"] is None
+    assert station.alarm_data["requestedSafeMode"] is None
+
+
 def test_empty_force_arm_reason_clears_pending_request_without_mode_change():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
@@ -1055,7 +1143,11 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
     )
 
     station.set_alarm_data(
-        {"forceReason": [{"deviceSN": "door-sn"}], "safeModeAim": "Away"}
+        {
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "safeModeAim": "Away",
+            "requestedSafeMode": "Away",
+        }
     )
     panel._handle_coordinator_update()
 


### PR DESCRIPTION
## Summary

- create force-arm prompts only while a normal Home or Away request is pending
- use the live APK `SBS50ModeTopicResult.forceReason` response instead of historical notices
- clear prompt state before direct `force_arm_now` automation commands are sent
- clear stale reasons when normal arming succeeds

## Validation

- Windows: 857 tests passed
- Linux Python 3.13: 857 tests passed
- Linux Python 3.14: 857 tests passed
- compileall and diff checks passed