### PR TITLE
Prepare v1.4.19.6 force-arm prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19.5):
-  (e.g., 1.4.19.5)
+- **X-Sense-Integration Version** (z. B. 1.4.19.6):
+  (e.g., 1.4.19.6)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.6.md
+++ b/.github/release-notes/1.4.19.6.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.19.6
+
+### 🚨 Force Arm Prompts
+- Shows the force-arm prompt only when an Away or Home request is rejected because a sensor is open.
+- Prevents successful force-arm automations and unrelated historical events from creating an unnecessary prompt.
+- Clears expired or completed arm requests so an old response cannot affect a later request.
+
+Please test normal and forced Away and Home arming with sensors both open and closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19.6](.github/release-notes/1.4.19.6.md)
 - [1.4.19.5](.github/release-notes/1.4.19.5.md)
 - [1.4.19.4](.github/release-notes/1.4.19.4.md)
 - [1.4.19.3](.github/release-notes/1.4.19.3.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19.5"
+PANEL_ASSET_VERSION = "1.4.19.6"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.19.5",
+  "version": "1.4.19.6",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- publish the audited force-arm prompt lifecycle as v1.4.19.6
- synchronize manifest, frontend asset version, issue template, changelog, and release notes
- request testing for normal and forced Home/Away arming with open and closed sensors

## Validation
- 864 tests passed
- release metadata tests passed
- compileall and diff checks passed