### PR TITLE
Align camera event polling with APK history paths

### DIFF
--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, EVENT_HOMEASSISTANT_STARTED
@@ -560,18 +561,12 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         skipped = 0
         seen_now: set[str] = set()
         now = int(datetime.now(timezone.utc).timestamp())
-        last_poll = getattr(self, "_camera_event_history_last_poll", None)
-        if first_poll:
-            start_timestamp = now - 86400
-        elif isinstance(last_poll, int):
-            start_timestamp = min(now, last_poll) - 60
-        else:
-            start_timestamp = now - 300
+        start_timestamp, end_timestamp = _apk_camera_history_day_window(self, now)
         try:
             history = await self.xsense.get_camera_event_history_for_cameras(
                 cameras,
                 start_timestamp,
-                now,
+                end_timestamp,
             )
         except APIFailure as ex:
             LOGGER.debug("Could not update X-Sense camera record history: %s", ex)
@@ -604,7 +599,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             applied,
             skipped,
             first_poll,
-            now - start_timestamp,
+            end_timestamp - start_timestamp,
         )
         return applied > 0
 
@@ -1046,6 +1041,25 @@ def _set_camera_ai_service_available(cameras: list[Any], available: bool) -> Non
         data = getattr(camera, "data", None)
         if isinstance(data, dict):
             data[CAMERA_AI_SERVICE_AVAILABLE] = available
+
+
+def _apk_camera_history_day_window(
+    coordinator: XSenseDataUpdateCoordinator, now: int
+) -> tuple[int, int]:
+    """Return the local calendar-day epoch window used by the X-Sense app."""
+    time_zone = "UTC"
+    hass = getattr(coordinator, "hass", None)
+    config = getattr(hass, "config", None)
+    if configured_time_zone := getattr(config, "time_zone", None):
+        time_zone = configured_time_zone
+    try:
+        zone = ZoneInfo(time_zone)
+    except ZoneInfoNotFoundError:
+        zone = timezone.utc
+    local_now = datetime.fromtimestamp(now, zone)
+    day_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_timestamp = int(day_start.timestamp())
+    return start_timestamp, start_timestamp + 86400
 
 
 def _camera_record_history_debug_context(

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -607,6 +607,7 @@ class AsyncXSense(XSenseBase):
         successful_requests = 0
         for camera, house, serials in requests:
             camera_request_succeeded = False
+            accepted_serial = None
             for serial_index, serial in enumerate(serials):
                 try:
                     history = await self.get_camera_event_history(
@@ -640,16 +641,59 @@ class AsyncXSense(XSenseBase):
                 if not isinstance(group_records, list) or not group_records:
                     continue
 
-                camera.set_data(
-                    {
-                        "addxAccessSerialNumber": serial,
-                        "addxSerialNumber": serial,
-                    }
-                )
+                accepted_serial = serial
                 records.extend(
                     record for record in group_records if isinstance(record, dict)
                 )
                 break
+
+            if accepted_serial is None:
+                for serial_index, serial in enumerate(serials):
+                    try:
+                        history = await self.get_camera_event_record_history(
+                            [serial],
+                            start_timestamp,
+                            end_timestamp,
+                            house=house,
+                            start=start,
+                            limit=limit,
+                        )
+                    except APIFailure as err:
+                        if first_error is None:
+                            first_error = err
+                        LOGGER.debug(
+                            "X-Sense camera event-library history unavailable: %s",
+                            {
+                                "identity_index": serial_index,
+                                "identity_count": len(serials),
+                                "error_type": type(err).__name__,
+                            },
+                        )
+                        continue
+
+                    camera_request_succeeded = True
+                    data = (
+                        history.get("data")
+                        if isinstance(history.get("data"), dict)
+                        else history
+                    )
+                    group_records = data.get("list") if isinstance(data, dict) else None
+                    if not isinstance(group_records, list) or not group_records:
+                        continue
+
+                    accepted_serial = serial
+                    records.extend(
+                        record for record in group_records if isinstance(record, dict)
+                    )
+                    break
+
+            if accepted_serial is not None:
+                camera.set_data(
+                    {
+                        "addxAccessSerialNumber": accepted_serial,
+                        "addxSerialNumber": accepted_serial,
+                    }
+                )
 
             if camera_request_succeeded:
                 successful_requests += 1
@@ -664,6 +708,7 @@ class AsyncXSense(XSenseBase):
         start_timestamp: int,
         end_timestamp: int,
         *,
+        house: House | None = None,
         start: int = 0,
         limit: int = 20,
         tags: list[str] | None = None,
@@ -699,7 +744,11 @@ class AsyncXSense(XSenseBase):
         if serial_number_to_activity_zone:
             payload["serialNumberToActivityZone"] = serial_number_to_activity_zone
 
-        data = await self.addx_call("/library/newselectlibrary/event", **payload)
+        data = await self.addx_call(
+            "/library/newselectlibrary/event",
+            **({"_house": house} if house is not None else {}),
+            **payload,
+        )
         LOGGER.debug(
             "X-Sense camera event record history response: %s",
             _debug_data_shape(data),

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5095,6 +5095,63 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
     ]
 
 
+@pytest.mark.asyncio
+async def test_camera_event_history_tries_apk_event_library_after_playback_empty():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    updates = []
+    camera = SimpleNamespace(
+        sn="camera-label",
+        entity_id="camera-access-id",
+        data={"addxSerialNumber": "camera-list-id"},
+        house=house,
+        set_data=lambda data: updates.append(data),
+    )
+    calls = []
+
+    async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
+        calls.append(("playback", serials, kwargs["house"]))
+        return {"list": []}
+
+    async def get_event_history(serials, start_timestamp, end_timestamp, **kwargs):
+        calls.append(("event", serials, kwargs["house"]))
+        if serials == ["camera-access-id"]:
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-access-id",
+                        "videoEvent": "motion",
+                    }
+                ]
+            }
+        return {"list": []}
+
+    client.get_camera_event_history = get_history
+    client.get_camera_event_record_history = get_event_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        [camera], 1781484300, 1781487900
+    )
+
+    assert calls == [
+        ("playback", ["camera-list-id"], house),
+        ("playback", ["camera-access-id"], house),
+        ("playback", ["camera-label"], house),
+        ("event", ["camera-list-id"], house),
+        ("event", ["camera-access-id"], house),
+    ]
+    assert result["list"] == [
+        {"serialNumber": "camera-access-id", "videoEvent": "motion"}
+    ]
+    assert updates == [
+        {
+            "addxAccessSerialNumber": "camera-access-id",
+            "addxSerialNumber": "camera-access-id",
+        }
+    ]
+
+
 def test_camera_addx_serial_candidates_keep_proven_access_identity_first():
     camera = SimpleNamespace(
         sn="camera-label",
@@ -5134,6 +5191,7 @@ def test_camera_addx_house_prefers_exact_addx_house_id_before_node():
 @pytest.mark.asyncio
 async def test_camera_event_record_history_uses_apk_event_filter_path():
     client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-2", mqtt_region="eu-west-1")
     calls = []
 
     async def addx_call(endpoint, **kwargs):
@@ -5146,6 +5204,7 @@ async def test_camera_event_record_history_uses_apk_event_filter_path():
         ["camera-sn"],
         1781484300,
         1781487900,
+        house=house,
         start=5,
         limit=10,
         tags=["motion"],
@@ -5161,6 +5220,7 @@ async def test_camera_event_record_history_uses_apk_event_filter_path():
         (
             "/library/newselectlibrary/event",
             {
+                "_house": house,
                 "startTimestamp": 1781484300,
                 "endTimestamp": 1781487900,
                 "from": 5,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 import inspect
 import json
 import logging
@@ -1875,7 +1876,7 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
     assert coordinator._camera_event_history_last_poll is not None
 
 
-async def test_camera_event_history_uses_initial_lookback_then_incremental_window():
+async def test_camera_event_history_keeps_apk_calendar_day_window():
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
 
     class Camera:
@@ -1918,7 +1919,22 @@ async def test_camera_event_history_uses_initial_lookback_then_incremental_windo
     assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
 
     assert windows[0][1] - windows[0][0] == 86400
-    assert 60 <= windows[1][1] - windows[1][0] <= 62
+    assert windows[1] == windows[0]
+
+
+def test_camera_event_history_day_window_uses_home_assistant_time_zone():
+    from custom_components.xsense.coordinator import _apk_camera_history_day_window
+
+    coordinator = SimpleNamespace(
+        hass=SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Berlin"))
+    )
+
+    start, end = _apk_camera_history_day_window(coordinator, 1787927696)
+
+    assert datetime.fromtimestamp(start, timezone.utc).isoformat() == (
+        "2026-08-27T22:00:00+00:00"
+    )
+    assert end - start == 86400
 
 
 def test_camera_event_history_station_data_preserves_direct_video_url():


### PR DESCRIPTION
## Summary
- keep the proven APK playback-library query as the primary camera history path
- fall back to the APK event-library endpoint when playback history is empty across all camera identities
- preserve the camera Home/node context on both paths
- query the full Home Assistant local calendar day, matching the APK, instead of narrowing later polls to a rolling 60-second window

## Context
Issue #285 confirms live view and camera settings now use the retained identity correctly, while motion and AI events still receive valid but empty history responses on a multi-Home account. This keeps the working path intact and covers the other APK history path without moving requests back to the default Home.

## Tests
- 866 tests passed on Windows
- 866 tests passed on Linux/Python 3.14
- focused camera-history tests: 12 passed