### PR TITLE
Prepare v1.4.19.7 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19.6):
-  (e.g., 1.4.19.6)
+- **X-Sense-Integration Version** (z. B. 1.4.19.7):
+  (e.g., 1.4.19.7)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.19.7.md
+++ b/.github/release-notes/1.4.19.7.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.19.7
+
+### 📷 Camera Motion and AI Events
+- Uses the full local calendar-day history window used by the X-Sense app when polling camera events.
+- Keeps the recording library as the primary history source and tries the APK event-history path when the recording library is empty.
+- Preserves each camera's Home, node, and retained identity context across both history paths for multi-Home accounts.
+
+Please test camera motion and AI event delivery, especially with cameras in accounts that contain more than one Home.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.19.7](.github/release-notes/1.4.19.7.md)
 - [1.4.19.6](.github/release-notes/1.4.19.6.md)
 - [1.4.19.5](.github/release-notes/1.4.19.5.md)
 - [1.4.19.4](.github/release-notes/1.4.19.4.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19.6"
+PANEL_ASSET_VERSION = "1.4.19.7"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.19.6",
+  "version": "1.4.19.7",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- bump the integration and frontend asset version to 1.4.19.7
- add user-facing prerelease notes for camera motion and AI event polling
- update the changelog and issue template version

## Verification
- 866 tests passed on Windows
- 866 tests passed on Linux server with Python 3.14
- compileall and git diff checks passed