### PR TITLE
Normalize device registry metadata

### DIFF
--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import XSenseDataUpdateCoordinator
-from .entity import coordinator_stations
+from .entity import _device_info_str, coordinator_stations
 from .errors import xsense_error
 from .frontend import (
     FORCE_ARM_FRONTEND_URL_PATH,
@@ -170,9 +170,9 @@ class XSenseAlarmControlPanel(
         self._attr_unique_id = f"{station.sn}_alarm"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, station.entity_id)},
-            "name": station.name,
+            "name": _device_info_str(station.name),
             "manufacturer": MANUFACTURER,
-            "model": station.type,
+            "model": _device_info_str(station.type),
         }
         self._safemode: str | None = None
         self._pending_force_arm_mode: str | None = None

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -22,6 +22,21 @@ _APK_CAMERA_NON_OFFLINE_STATUSES = {11, 12}
 DEVICE_ENTITY_WITHOUT_STATION = ""
 
 
+def _device_info_str(value: object) -> str | None:
+    """Return a Home Assistant DeviceInfo-safe string value."""
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _software_version(value: object) -> str | None:
+    """Return a normalized firmware/software version string."""
+    version = _device_info_str(value)
+    if version is None:
+        return None
+    return version.removeprefix("v")
+
+
 def _apk_entity_is_available(entity: Entity) -> bool:
     """Return whether the APK treats this entity as not offline."""
     if getattr(entity, "entity_type", None) == EntityType.CAMERA:
@@ -69,11 +84,11 @@ class XSenseEntity(CoordinatorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entity.entity_id)},
             manufacturer=MANUFACTURER,
-            model=entity.type,
-            name=entity.name,
+            model=_device_info_str(entity.type),
+            name=_device_info_str(entity.name),
         )
-        if "sw" in entity.data and entity.data["sw"]:
-            self._attr_device_info["sw_version"] = entity.data["sw"].removeprefix("v")
+        if sw_version := _software_version(entity.data.get("sw")):
+            self._attr_device_info["sw_version"] = sw_version
         if station_id:
             parent = (DOMAIN, station_id)
             self._attr_device_info.update({ATTR_VIA_DEVICE: parent})

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -234,6 +234,54 @@ def test_static_identifiers_are_not_exposed_in_device_info():
     assert "connections" not in device_info
 
 
+def test_device_info_fields_are_strings_before_home_assistant_registry_validation():
+    from custom_components.xsense.entity import XSenseEntity
+
+    class ProbeEntity(XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    source = SimpleNamespace(
+        entity_id="station_1",
+        data={"sw": 101},
+        sn="serial-number",
+        type=50,
+        name=12345,
+    )
+
+    device_info = ProbeEntity(SimpleNamespace(), source).device_info
+
+    assert device_info["model"] == "50"
+    assert device_info["name"] == "12345"
+    assert device_info["sw_version"] == "101"
+
+
+def test_device_info_software_version_accepts_string_prefix_and_ignores_empty_values():
+    from custom_components.xsense.entity import XSenseEntity
+
+    class ProbeEntity(XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    versioned = SimpleNamespace(
+        entity_id="station_1",
+        data={"sw": "v2.3.4"},
+        sn="serial-number",
+        type="SBS50",
+        name="Base Station",
+    )
+    missing = SimpleNamespace(
+        entity_id="station_2",
+        data={"sw": None},
+        sn="serial-number-2",
+        type="SBS50",
+        name="Base Station 2",
+    )
+
+    assert (
+        ProbeEntity(SimpleNamespace(), versioned).device_info["sw_version"] == "2.3.4"
+    )
+    assert "sw_version" not in ProbeEntity(SimpleNamespace(), missing).device_info
+
+
 def test_alarm_panel_device_info_does_not_expose_serial_number():
     from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
 
@@ -249,6 +297,22 @@ def test_alarm_panel_device_info_does_not_expose_serial_number():
     assert device_info["identifiers"] == {("xsense", "station_1")}
     assert device_info["model"] == "SBS50"
     assert "serial_number" not in device_info
+
+
+def test_alarm_panel_device_info_fields_are_strings():
+    from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
+
+    station = SimpleNamespace(
+        entity_id="station_1",
+        name=12345,
+        type=50,
+        sn="serial-number",
+    )
+
+    device_info = XSenseAlarmControlPanel(SimpleNamespace(), station).device_info
+
+    assert device_info["name"] == "12345"
+    assert device_info["model"] == "50"
 
 
 def test_visible_identifier_connections_are_removed_from_registry_metadata():


### PR DESCRIPTION
## Summary
- normalize X-Sense DeviceInfo model/name values before Home Assistant registry validation
- normalize firmware values before assigning DeviceInfo sw_version
- add regression tests for numeric and empty device metadata values

## Validation
- Windows: 869 passed
- Linux server/Python 3.14: 869 passed
- compileall clean
- git diff --check clean

Refs #302