### PR TITLE
Prepare v1.4.20 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.19.7):
-  (e.g., 1.4.19.7)
+- **X-Sense-Integration Version** (z. B. 1.4.20):
+  (e.g., 1.4.20)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.md
+++ b/.github/release-notes/1.4.20.md
@@ -1,0 +1,26 @@
+## X-Sense Home Security v1.4.20
+
+This release brings the recent v1.4.19.x pre-release work to the main release channel.
+
+### 📷 Cameras
+- Improves camera access for accounts with more than one X-Sense Home by preserving the camera Home, node, and identity context across live view, settings, audio, AI, and recording-history requests.
+- Uses the recording library as the primary camera history source and tries the APK event-history path when the recording library returns empty.
+- Uses the full local calendar-day history window when checking for camera motion and AI events.
+
+### 🔐 Alarm Panel and Actions
+- Adds force-arm support for Home and Away mode when X-Sense refuses a normal arm request because a sensor is open.
+- Adds a force-arm action for automations, plus SBS50 actions for SOS, alarm cancellation, SOS sound mode, and light-group control.
+- Keeps force-arm prompts tied to the arm request that created them and prevents successful force-arm automations from creating an unnecessary prompt.
+
+### 💧 Water Leak Sensors
+- Aligns SWS51 alarm and silence states with the states shown by the X-Sense app.
+- Keeps SWS0B water and temperature alarm states separate, as reported by that model.
+- Cleans up stale duplicate or model-inappropriate alarm and silence entities automatically.
+
+### 🎞️ Recording Playback
+- Updates the recordings panel playback engine for current browser compatibility and HLS cached playback handling.
+
+### 🛠️ Reliability
+- Prevents Home Assistant 2026.8 startup warnings from non-string X-Sense device metadata by normalizing device registry values before entities are added.
+- Prevents setup from failing when Home Assistant already has the X-Sense Recordings or force-arm panel registered.
+- Cleans up cached MQTT subscription matches when the integration is unloaded or reloaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20](.github/release-notes/1.4.20.md)
 - [1.4.19.7](.github/release-notes/1.4.19.7.md)
 - [1.4.19.6](.github/release-notes/1.4.19.6.md)
 - [1.4.19.5](.github/release-notes/1.4.19.5.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.19.7"
+PANEL_ASSET_VERSION = "1.4.20"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.19.7",
+  "version": "1.4.20",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- bump X-Sense Home Security to v1.4.20
- add rollup release notes for the v1.4.19.x prerelease work
- update changelog and issue-template version references

## Validation
- Windows: 869 passed
- Linux server/Python 3.14: 869 passed
- release metadata subset: 188 passed
- compileall clean
- git diff --check clean