### PR TITLE
Mark v1.4.20 as hotfix rollup

### DIFF
--- a/.github/release-notes/1.4.20.md
+++ b/.github/release-notes/1.4.20.md
@@ -1,6 +1,6 @@
 ## X-Sense Home Security v1.4.20
 
-This release brings the recent v1.4.19.x pre-release work to the main release channel.
+This is a hotfix rollup release that brings the recent v1.4.19.x pre-release work to the main release channel.
 
 ### 📷 Cameras
 - Improves camera access for accounts with more than one X-Sense Home by preserving the camera Home, node, and identity context across live view, settings, audio, AI, and recording-history requests.


### PR DESCRIPTION
## Summary
- update checked-in v1.4.20 release notes to match the published GitHub release wording
- explicitly identify v1.4.20 as a hotfix rollup release

## Validation
- tests/test_release_metadata.py: 18 passed
- git diff --check clean