### PR TITLE
Complete HLS recording caches before playback

### DIFF
--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -1058,8 +1058,9 @@ def _apk_camera_history_day_window(
         zone = timezone.utc
     local_now = datetime.fromtimestamp(now, zone)
     day_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    next_day_start = day_start + timedelta(days=1)
     start_timestamp = int(day_start.timestamp())
-    return start_timestamp, start_timestamp + 86400
+    return start_timestamp, int(next_day_start.timestamp())
 
 
 def _camera_record_history_debug_context(

--- a/custom_components/xsense/http.py
+++ b/custom_components/xsense/http.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import secrets
 from datetime import datetime
 from pathlib import Path
@@ -44,8 +43,6 @@ from .recordings_gate import has_any_camera_entities
 
 
 HLS_SEGMENT_TOKEN_TTL = 3600
-HLS_SEGMENT_WAIT_TIMEOUT = 10
-HLS_SEGMENT_WAIT_INTERVAL = 0.25
 
 
 async def async_register_recordings_http_views(hass: HomeAssistant) -> None:
@@ -617,14 +614,10 @@ class XSenseRecordingsHlsSegmentView(http.HomeAssistantView):
         except ValueError as exc:
             raise web.HTTPNotFound(reason="Invalid X-Sense HLS segment") from exc
         source = XSenseRecordingsMediaSource(self.hass)
-        waited_ms = await _async_wait_for_hls_path(source, path)
-        if waited_ms is None:
+        if not await source._async_path_ready(path):
             LOGGER.debug(
-                "X-Sense recordings HLS segment not ready after wait: %s",
-                {
-                    "filename": _log_safe_str(filename, 160),
-                    "wait_timeout_s": HLS_SEGMENT_WAIT_TIMEOUT,
-                },
+                "X-Sense recordings HLS cache is incomplete: %s",
+                {"filename": _log_safe_str(filename, 160)},
             )
             raise web.HTTPNotFound(reason="X-Sense HLS segment is not ready")
         headers = {"Cache-Control": "private, max-age=3600"}
@@ -649,7 +642,6 @@ class XSenseRecordingsHlsSegmentView(http.HomeAssistantView):
             {
                 "filename": _log_safe_str(filename, 160),
                 "bytes": size,
-                "waited_ms": waited_ms,
             },
         )
         return web.FileResponse(path, headers=headers)
@@ -820,21 +812,6 @@ def _create_hls_segment_token(hass: HomeAssistant, root: Path) -> str:
         "expires": now + HLS_SEGMENT_TOKEN_TTL,
     }
     return token
-
-
-async def _async_wait_for_hls_path(
-    source: XSenseRecordingsMediaSource,
-    path: Path,
-) -> int | None:
-    """Wait briefly for the progressive HLS cache to produce a requested path."""
-    started_at = monotonic()
-    deadline = monotonic() + HLS_SEGMENT_WAIT_TIMEOUT
-    while True:
-        if await source._async_path_ready(path):
-            return int((monotonic() - started_at) * 1000)
-        if monotonic() >= deadline:
-            return None
-        await asyncio.sleep(HLS_SEGMENT_WAIT_INTERVAL)
 
 
 def _hls_segment_root(hass: HomeAssistant, token: str) -> Path | None:

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -63,7 +63,6 @@ RECORDING_MEDIA_RECENT_SYNC_INTERVAL = timedelta(minutes=2)
 RECORDING_MEDIA_RECENT_LOOKBACK = timedelta(minutes=10)
 THUMBNAIL_WARMUP_LIMIT = 10
 EVENT_RECORDING_CLIP_LIMIT = 50
-HLS_INITIAL_SEGMENT_COUNT = 2
 HLS_CACHE_VERSION = 3
 HLS_CACHE_VERSION_FILE = ".xsense-hls-cache-version"
 HLS_CACHE_SUPPORTED_LEGACY_VERSIONS = frozenset({"2"})
@@ -847,8 +846,7 @@ class XSenseRecordingsMediaSource(MediaSource):
                     {
                         **_clip_log_context(clip),
                         "segments": hls.get("segments"),
-                        "initial_segments": hls.get("initial_segments"),
-                        "deferred_segments": hls.get("deferred_segments"),
+                        "segments_cached": hls.get("segments_cached"),
                         "playlists": hls.get("playlists"),
                         "bytes": hls.get("bytes"),
                         "download_elapsed_ms": hls.get("elapsed_ms"),
@@ -909,8 +907,7 @@ class XSenseRecordingsMediaSource(MediaSource):
                         **_clip_log_context(clip),
                         "content_type": download.get("content_type"),
                         "segments": hls.get("segments"),
-                        "initial_segments": hls.get("initial_segments"),
-                        "deferred_segments": hls.get("deferred_segments"),
+                        "segments_cached": hls.get("segments_cached"),
                         "playlists": hls.get("playlists"),
                         "bytes": hls.get("bytes"),
                         "download_elapsed_ms": hls.get("elapsed_ms"),
@@ -960,17 +957,12 @@ class XSenseRecordingsMediaSource(MediaSource):
         staging_dir = _hls_staging_cache_dir(cache_dir)
         started_at = monotonic()
         state = {
-            "remaining_initial_segments": HLS_INITIAL_SEGMENT_COUNT,
-            "initial_segments_cached": 0,
-            "deferred": [],
+            "segments_cached": 0,
             "playlists": 0,
         }
         LOGGER.debug(
             "X-Sense HLS recording cache starting: %s",
-            {
-                **_clip_log_context(clip),
-                "initial_segment_target": HLS_INITIAL_SEGMENT_COUNT,
-            },
+            {**_clip_log_context(clip), "cache_mode": "complete"},
         )
         await self._async_file_job(_clear_directory, staging_dir)
         try:
@@ -994,21 +986,8 @@ class XSenseRecordingsMediaSource(MediaSource):
         except Exception:
             await self._async_file_job(_remove_directory, staging_dir)
             raise
-        deferred = [
-            item for item in state["deferred"] if isinstance(item, tuple) and len(item) == 2
-        ]
-        deferred = [
-            (
-                deferred_url,
-                cache_dir / deferred_path.relative_to(staging_dir),
-            )
-            for deferred_url, deferred_path in deferred
-        ]
-        if deferred:
-            self._schedule_hls_background_cache(clip, deferred)
         result["elapsed_ms"] = int((monotonic() - started_at) * 1000)
-        result["deferred_segments"] = len(deferred)
-        result["initial_segments"] = int(state.get("initial_segments_cached") or 0)
+        result["segments_cached"] = int(state.get("segments_cached") or 0)
         result["playlists"] = int(state.get("playlists") or 0)
         return result
 
@@ -1065,12 +1044,36 @@ class XSenseRecordingsMediaSource(MediaSource):
                 total_bytes += map_bytes
                 rewritten.append(updated)
                 continue
+            if stripped.startswith("#") and "URI=" in stripped:
+                uri = _hls_attribute_uri(stripped)
+                attribute_url = urljoin(url, uri)
+                if uri and _is_hls_playlist_uri(attribute_url):
+                    child_dir = cache_dir / f"{prefix}_attribute_{index}"
+                    child_playlist = child_dir / "index.m3u8"
+                    child_result = await self._async_cache_hls_playlist(
+                        attribute_url,
+                        child_playlist,
+                        child_dir,
+                        prefix=f"{prefix}_attribute_{index}",
+                        depth=depth + 1,
+                        state=state,
+                    )
+                    total_bytes += int(child_result.get("bytes") or 0)
+                    segment_count += int(child_result.get("segments") or 0)
+                    child_playlist_count += 1
+                    rewritten.append(
+                        line.replace(
+                            f'URI="{uri}"',
+                            f'URI="{prefix}_attribute_{index}/index.m3u8"',
+                        )
+                    )
+                    continue
             if stripped.startswith("#"):
                 rewritten.append(line)
                 continue
 
             media_url = urljoin(url, stripped)
-            if depth == 0 and _is_hls_playlist_uri(media_url):
+            if _is_hls_playlist_uri(media_url):
                 child_dir = cache_dir / f"{prefix}_{index}"
                 child_playlist = child_dir / "index.m3u8"
                 child_result = await self._async_cache_hls_playlist(
@@ -1097,22 +1100,14 @@ class XSenseRecordingsMediaSource(MediaSource):
             ):
                 state["leading_segment_path"] = segment_path
                 state["leading_playlist_path"] = playlist_path
-            if int(state.get("remaining_initial_segments") or 0) > 0:
-                payload = await self._async_download_hls_part(media_url)
-                await self._async_file_job(
-                    _write_cache_file,
-                    segment_path,
-                    payload,
-                )
-                total_bytes += len(payload)
-                state["remaining_initial_segments"] = (
-                    int(state.get("remaining_initial_segments") or 0) - 1
-                )
-                state["initial_segments_cached"] = (
-                    int(state.get("initial_segments_cached") or 0) + 1
-                )
-            else:
-                state.setdefault("deferred", []).append((media_url, segment_path))
+            payload = await self._async_download_hls_part(media_url)
+            await self._async_file_job(
+                _write_cache_file,
+                segment_path,
+                payload,
+            )
+            total_bytes += len(payload)
+            state["segments_cached"] = int(state.get("segments_cached") or 0) + 1
             rewritten.append(segment_name)
             direct_media_segment_count += 1
 
@@ -1125,10 +1120,7 @@ class XSenseRecordingsMediaSource(MediaSource):
                 "segments": segment_count,
                 "child_playlists": child_playlist_count,
                 "keys": key_count,
-                "initial_segments_cached": int(
-                    state.get("initial_segments_cached") or 0
-                ),
-                "deferred_segments": len(state.get("deferred", [])),
+                "segments_cached": int(state.get("segments_cached") or 0),
             },
         )
         await self._async_file_job(
@@ -1141,54 +1133,6 @@ class XSenseRecordingsMediaSource(MediaSource):
             "bytes": total_bytes,
             "segments": segment_count,
         }
-
-    def _schedule_hls_background_cache(
-        self,
-        clip: dict[str, Any],
-        deferred: list[tuple[str, Path]],
-    ) -> None:
-        """Continue caching HLS segments after the first playable buffer exists."""
-        if not hasattr(self.hass, "async_create_task"):
-            return
-
-        async def _async_background_cache() -> None:
-            started_at = monotonic()
-            cached = 0
-            failed = 0
-            bytes_written = 0
-            for url, path in deferred:
-                if await self._async_path_ready(path):
-                    cached += 1
-                    continue
-                try:
-                    payload = await self._async_download_hls_part(url)
-                    await self._async_file_job(_write_cache_file, path, payload)
-                except Exception as exc:  # noqa: BLE001
-                    failed += 1
-                    LOGGER.debug(
-                        "Could not cache deferred X-Sense HLS segment: %s",
-                        {**_clip_log_context(clip), "error": str(exc)},
-                    )
-                    continue
-                cached += 1
-                bytes_written += len(payload)
-            LOGGER.debug(
-                "X-Sense HLS recording background cache finished: %s",
-                {
-                    **_clip_log_context(clip),
-                    "cached_segments": cached,
-                    "failed_segments": failed,
-                    "bytes": bytes_written,
-                    "elapsed_ms": int((monotonic() - started_at) * 1000),
-                },
-            )
-
-        _create_recording_background_task(
-            self.hass,
-            str(clip.get("entry_id") or ""),
-            _async_background_cache(),
-            "X-Sense HLS recording cache",
-        )
 
     async def _async_cache_hls_attribute_uri(
         self,
@@ -2749,6 +2693,8 @@ def _hls_cache_ready_at(cache_dir: Path, playlist_path: Path) -> bool:
         _remove_directory(cache_dir)
         return False
     if not _hls_playlist_ready(playlist_path):
+        if _path_ready(playlist_path):
+            _remove_directory(cache_dir)
         return False
     if not _read_hls_playback_profile(cache_dir):
         return _ensure_hls_playback_profile(cache_dir, playlist_path)
@@ -2789,23 +2735,37 @@ def _hls_playlist_ready(playlist_path: Path) -> bool:
         lines = playlist_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return False
-    media_lines = [
-        line.strip()
-        for line in lines
-        if line.strip() and not line.lstrip().startswith("#")
-    ]
+    media_lines = []
+    attribute_uris = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            uri = _hls_attribute_uri(stripped)
+            if uri:
+                attribute_uris.append(uri)
+            continue
+        media_lines.append(stripped)
     if not media_lines:
         return False
-    for line in media_lines:
-        path = playlist_path.parent / line
-        if _is_hls_playlist_uri(line):
-            if _hls_playlist_ready(path):
-                return True
+    for uri in attribute_uris:
+        path = playlist_path.parent / uri
+        if _is_hls_playlist_uri(uri):
+            if not _hls_playlist_ready(path):
+                return False
             continue
         if not _path_ready(path):
             return False
-        return True
-    return False
+    for line in media_lines:
+        path = playlist_path.parent / line
+        if _is_hls_playlist_uri(line):
+            if not _hls_playlist_ready(path):
+                return False
+            continue
+        if not _path_ready(path):
+            return False
+    return True
 
 
 def _mp4_signature_present(path: Path) -> bool:

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -2743,7 +2743,10 @@ def _hls_playlist_ready(playlist_path: Path) -> bool:
             continue
         if stripped.startswith("#"):
             uri = _hls_attribute_uri(stripped)
-            if uri:
+            if uri and (
+                stripped.startswith(("#EXT-X-KEY", "#EXT-X-MAP"))
+                or _is_hls_playlist_uri(uri)
+            ):
                 attribute_uris.append(uri)
             continue
         media_lines.append(stripped)

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -3446,7 +3446,8 @@ def test_recording_media_source_hls_ready_requires_attribute_playlists_and_keys(
     audio.mkdir(parents=True)
     video.mkdir(parents=True)
     (root / "index.m3u8").write_text(
-        '#EXTM3U\n#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",URI="audio/index.m3u8"\n'
+        '#EXTM3U\n#EXT-X-SESSION-DATA:DATA-ID="metadata",URI="https://example.invalid/info.json"\n'
+        '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",URI="audio/index.m3u8"\n'
         '#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO="audio"\nvideo/index.m3u8\n',
         encoding="utf-8",
     )

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -2423,7 +2423,7 @@ def test_recording_media_source_caches_hd_hls_without_sd_fallback(
     )
     assert (playlist.parent / "segment_0002.ts").read_bytes() == b"segment-one"
     assert (playlist.parent / "segment_0003.ts").read_bytes() == b"segment-two"
-    assert not (playlist.parent / "segment_0004.ts").exists()
+    assert (playlist.parent / "segment_0004.ts").read_bytes() == b"segment-three"
 
 
 def test_recording_media_source_preserves_original_leading_hls_ts_segment(
@@ -3375,7 +3375,7 @@ def test_recording_media_source_prefers_hls_cache_over_legacy_mp4(
     assert not output_path.exists()
 
 
-def test_recording_media_source_hls_master_ready_with_one_buffered_variant(
+def test_recording_media_source_hls_master_requires_every_variant_and_segment(
     monkeypatch,
     tmp_path,
 ):
@@ -3425,7 +3425,46 @@ def test_recording_media_source_hls_master_ready_with_one_buffered_variant(
         lambda current_clip: root / "index.m3u8",
     )
 
+    assert not media_source._hls_playlist_ready(root / "index.m3u8")
+    (variant_a / "segment_0003.ts").write_bytes(b"segment-two")
+    (variant_b / "segment_0004.ts").write_bytes(b"segment-three")
     assert media_source._hls_ready(clip)
+
+    (variant_a / "segment_0003.ts").unlink()
+    assert not media_source._hls_ready(clip)
+    assert not root.exists()
+
+
+def test_recording_media_source_hls_ready_requires_attribute_playlists_and_keys(
+    tmp_path,
+):
+    from custom_components.xsense import recordings_media as media_source
+
+    root = tmp_path / "hls"
+    audio = root / "audio"
+    video = root / "video"
+    audio.mkdir(parents=True)
+    video.mkdir(parents=True)
+    (root / "index.m3u8").write_text(
+        '#EXTM3U\n#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",URI="audio/index.m3u8"\n'
+        '#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO="audio"\nvideo/index.m3u8\n',
+        encoding="utf-8",
+    )
+    (audio / "index.m3u8").write_text(
+        "#EXTM3U\naudio_0001.ts\n#EXT-X-ENDLIST\n",
+        encoding="utf-8",
+    )
+    (audio / "audio_0001.ts").write_bytes(b"audio")
+    (video / "index.m3u8").write_text(
+        '#EXTM3U\n#EXT-X-KEY:METHOD=AES-128,URI="key.bin"\n'
+        "video_0001.ts\n#EXT-X-ENDLIST\n",
+        encoding="utf-8",
+    )
+    (video / "video_0001.ts").write_bytes(b"video")
+
+    assert not media_source._hls_playlist_ready(root / "index.m3u8")
+    (video / "key.bin").write_bytes(b"key")
+    assert media_source._hls_playlist_ready(root / "index.m3u8")
 
 
 def test_recording_media_source_lazy_shows_uncached_direct_clips_when_sync_disabled(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -1935,6 +1936,29 @@ def test_camera_event_history_day_window_uses_home_assistant_time_zone():
         "2026-08-27T22:00:00+00:00"
     )
     assert end - start == 86400
+
+
+@pytest.mark.parametrize(
+    ("local_time", "expected_seconds"),
+    (
+        (datetime(2026, 3, 29, 12, tzinfo=ZoneInfo("Europe/Berlin")), 23 * 3600),
+        (datetime(2026, 10, 25, 12, tzinfo=ZoneInfo("Europe/Berlin")), 25 * 3600),
+    ),
+)
+def test_camera_event_history_day_window_tracks_dst_boundaries(
+    local_time, expected_seconds
+):
+    from custom_components.xsense.coordinator import _apk_camera_history_day_window
+
+    coordinator = SimpleNamespace(
+        hass=SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Berlin"))
+    )
+
+    start, end = _apk_camera_history_day_window(
+        coordinator, int(local_time.timestamp())
+    )
+
+    assert end - start == expected_seconds
 
 
 def test_camera_event_history_station_data_preserves_direct_video_url():


### PR DESCRIPTION
## Summary

- cache every referenced HLS playlist, segment, key, and map before publishing a recording for playback
- discard incomplete caches so they can be fetched again cleanly
- use Home Assistant's local calendar day, including DST boundaries, for camera event-history polling
- ignore optional HLS metadata links when checking playback readiness

## Scope

This changes cached recording playback and camera event-history windows only. It does not alter the live WebRTC path.

## Validation

- 872 tests passed on Windows
- 872 tests passed on Linux with Python 3.14
- compile, frontend syntax, lint, dependency, and diff checks passed