### PR TITLE
Prepare v1.4.20.1 recording prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20):
-  (e.g., 1.4.20)
+- **X-Sense-Integration Version** (z. B. 1.4.20.1):
+  (e.g., 1.4.20.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.1.md
+++ b/.github/release-notes/1.4.20.1.md
@@ -1,0 +1,11 @@
+## X-Sense Home Security v1.4.20.1
+
+### 🎞️ Recording Playback
+- Waits until every part of a cached HLS recording is available before offering the clip for playback.
+- Removes incomplete caches so recordings can be downloaded again cleanly instead of serving a broken clip.
+- Keeps optional HLS metadata from preventing an otherwise complete recording from playing.
+
+### 📷 Camera Event History
+- Uses the correct Home Assistant local calendar day when checking camera events across daylight-saving time changes.
+
+Please test cached recording playback, including clips that previously failed or stopped partway through.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.1](.github/release-notes/1.4.20.1.md)
 - [1.4.20](.github/release-notes/1.4.20.md)
 - [1.4.19.7](.github/release-notes/1.4.19.7.md)
 - [1.4.19.6](.github/release-notes/1.4.19.6.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20"
+PANEL_ASSET_VERSION = "1.4.20.1"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20",
+  "version": "1.4.20.1",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary

- bump the integration and frontend asset version to 1.4.20.1
- add user-facing prerelease notes for complete HLS recording caches
- include the camera event-history calendar-day correction
- update the changelog and issue-template version example

The implementation was merged separately in #307.