### PR TITLE
Keep camera images tied to motion events

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.3):
-  (e.g., 1.4.20.3)
+- **X-Sense-Integration Version** (z. B. 1.4.20.4):
+  (e.g., 1.4.20.4)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.4.md
+++ b/.github/release-notes/1.4.20.4.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.20.4
+
+### 📷 Camera Motion Images
+- Keeps the newest X-Sense motion-event image available through the Home Assistant camera entity after camera metadata refreshes.
+- Prevents an older stored camera thumbnail from replacing a newer motion-event image.
+- Keeps camera images aligned with the latest event so image-based automations such as LLM Vision receive the most recent available frame.
+
+Please test camera image updates after genuine motion events and image-based automations such as LLM Vision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.4](.github/release-notes/1.4.20.4.md)
 - [1.4.20.3](.github/release-notes/1.4.20.3.md)
 - [1.4.20.2](.github/release-notes/1.4.20.2.md)
 - [1.4.20.1](.github/release-notes/1.4.20.1.md)

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -672,12 +672,16 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _cache_camera_stations(self) -> None:
         """Remember ADDX camera stations between camera API refreshes."""
-        self._camera_station_cache = {
-            station.entity_id: station
-            for house in self.xsense.houses.values()
-            for station in house.stations.values()
-            if is_camera_entity(station)
-        }
+        refreshed_cache: dict[str, Any] = {}
+        for house in self.xsense.houses.values():
+            for station in house.stations.values():
+                if not is_camera_entity(station):
+                    continue
+                previous = self._camera_station_cache.get(station.entity_id)
+                if previous is not None:
+                    _preserve_camera_event_image(previous, station)
+                refreshed_cache[station.entity_id] = station
+        self._camera_station_cache = refreshed_cache
 
     def _merge_cached_camera_stations(self, stations: dict[str, Any]) -> None:
         """Keep ADDX-only cameras present when the camera API refresh is skipped."""
@@ -1017,6 +1021,53 @@ def _camera_entities(coordinator: XSenseDataUpdateCoordinator) -> list[Any]:
         for station in house.stations.values()
         if is_camera_entity(station)
     ]
+
+
+_CAMERA_EVENT_IMAGE_KEYS = (
+    "lastEventImageUrl",
+    "lastEventPackageImageUrl",
+    "lastEventImageTime",
+)
+
+
+def _preserve_camera_event_image(previous: Any, refreshed: Any) -> None:
+    """Carry the latest motion image across ADDX metadata object replacement."""
+    previous_data = getattr(previous, "data", None)
+    refreshed_data = getattr(refreshed, "data", None)
+    if not isinstance(previous_data, dict) or not isinstance(refreshed_data, dict):
+        return
+
+    previous_time = _camera_image_timestamp(previous_data.get("lastEventImageTime"))
+    refreshed_time = _camera_image_timestamp(refreshed_data.get("lastEventImageTime"))
+    if refreshed_data.get("lastEventImageUrl") and (
+        previous_time is None
+        or (refreshed_time is not None and refreshed_time >= previous_time)
+    ):
+        return
+
+    preserved = {
+        key: previous_data[key]
+        for key in _CAMERA_EVENT_IMAGE_KEYS
+        if previous_data.get(key) not in (None, "")
+    }
+    if not preserved:
+        return
+    set_data = getattr(refreshed, "set_data", None)
+    if callable(set_data):
+        set_data(preserved)
+    else:
+        refreshed_data.update(preserved)
+
+
+def _camera_image_timestamp(value: Any) -> int | None:
+    """Normalize camera image timestamps for freshness comparisons."""
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError):
+        return None
+    if timestamp > 10_000_000_000:
+        timestamp //= 1000
+    return timestamp
 
 
 def _is_no_camera_ipc_registration_error(error: Exception) -> bool:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.3"
+PANEL_ASSET_VERSION = "1.4.20.4"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.3",
+  "version": "1.4.20.4",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -1466,10 +1466,10 @@ class AsyncXSense(XSenseBase):
     async def get_camera_thumbnail(self, camera: Entity) -> bytes | None:
         """Return the freshest preferred camera event image available."""
         try:
-            await self._refresh_camera_push_image(camera)
+            await self._update_camera_push_image_metadata(camera)
         except XSenseError as err:
             LOGGER.debug(
-                "X-Sense camera push image refresh failed: %s",
+                "X-Sense camera push image metadata update failed: %s",
                 {
                     "camera": _masked_identifier(getattr(camera, "sn", "")),
                     "error_type": type(err).__name__,
@@ -1494,8 +1494,8 @@ class AsyncXSense(XSenseBase):
                 return image
         return None
 
-    async def _refresh_camera_push_image(self, camera: Entity) -> None:
-        """Refresh the APK devicePushImage result for one camera."""
+    async def _update_camera_push_image_metadata(self, camera: Entity) -> None:
+        """Read the APK's latest stored push-image metadata for one camera."""
         data = await self._camera_addx_call(camera, "/device/devicePushImage")
         for item in _camera_push_image_rows(data):
             if not camera_matches_identifier(camera, item.get("serialNumber")):
@@ -2886,6 +2886,16 @@ def camera_thumbnail_urls(camera: Entity) -> tuple[str, ...]:
     """Return camera image URLs ordered by freshness and source quality."""
     data = camera.data
     candidates: list[tuple[Any, int | None, int]] = [
+        (
+            data.get("lastEventImageUrl"),
+            _camera_image_epoch_seconds(data.get("lastEventImageTime")),
+            4,
+        ),
+        (
+            data.get("lastEventPackageImageUrl"),
+            _camera_image_epoch_seconds(data.get("lastEventImageTime")),
+            2,
+        ),
         (
             data.get("lastPushImageUrl"),
             _camera_image_epoch_seconds(data.get("lastPushTime")),

--- a/custom_components/xsense/python_xsense/event_parser.py
+++ b/custom_components/xsense/python_xsense/event_parser.py
@@ -360,6 +360,20 @@ def camera_event_history_station_data(record: dict[str, Any]) -> dict[str, Any]:
 
     if playback := camera_event_history_playback_data(record):
         data["playback"] = playback
+        event_image_url = playback.get("image_url")
+        event_package_image_url = playback.get("package_image_url")
+        event_image_time = (
+            playback.get("timestamp_s")
+            or playback.get("start_time_s")
+            or playback.get("timestamp")
+            or playback.get("start_time")
+        )
+        if event_image_url:
+            data["lastEventImageUrl"] = event_image_url
+        if event_package_image_url:
+            data["lastEventPackageImageUrl"] = event_package_image_url
+        if event_image_time is not None:
+            data["lastEventImageTime"] = event_image_time
 
     apply_apk_event_aliases(data)
     return data

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -4882,7 +4882,7 @@ async def test_camera_thumbnail_prefers_full_event_image_to_device_thumbnail():
 
     session = ThumbnailSession()
     client = async_xsense.AsyncXSense(session)
-    client._refresh_camera_push_image = AsyncMock()
+    client._update_camera_push_image_metadata = AsyncMock()
     camera = SimpleNamespace(
         data={
             "thumbImgUrl": "https://example.invalid/current.jpg",
@@ -4904,18 +4904,18 @@ async def test_camera_thumbnail_prefers_full_event_image_to_device_thumbnail():
 @pytest.mark.asyncio
 async def test_camera_thumbnail_without_url_does_not_create_session():
     client = async_xsense.AsyncXSense()
-    client._refresh_camera_push_image = AsyncMock()
+    client._update_camera_push_image_metadata = AsyncMock()
     client._get_session = AsyncMock(
         side_effect=AssertionError("no image URL must not create an HTTP session")
     )
 
     assert await client.get_camera_thumbnail(SimpleNamespace(data={})) is None
-    client._refresh_camera_push_image.assert_awaited_once()
+    client._update_camera_push_image_metadata.assert_awaited_once()
     client._get_session.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_camera_thumbnail_refreshes_apk_push_image_for_matching_camera():
+async def test_camera_thumbnail_reads_apk_push_image_metadata_for_matching_camera():
     class ThumbnailResponse:
         status = 200
 

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -5606,6 +5606,27 @@ def test_camera_thumbnail_urls_prefer_newer_event_image():
     )
 
 
+def test_camera_thumbnail_urls_keep_durable_event_image_ahead_of_stale_push_image():
+    from custom_components.xsense.python_xsense.async_xsense import (
+        camera_thumbnail_urls,
+    )
+
+    camera_entity = entity(
+        "SSC0A",
+        {
+            "lastEventImageUrl": "https://example.invalid/event.jpg",
+            "lastEventImageTime": 1_700_000_100,
+            "lastPushImageUrl": "https://example.invalid/push.jpg",
+            "lastPushTime": 1_700_000_000,
+        },
+    )
+
+    assert camera_thumbnail_urls(camera_entity) == (
+        "https://example.invalid/event.jpg",
+        "https://example.invalid/push.jpg",
+    )
+
+
 async def test_camera_image_uses_adapter_and_keeps_last_good_image():
     from custom_components.xsense.camera import (
         CAMERA_DESCRIPTION,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1131,6 +1131,42 @@ async def test_cached_addx_cameras_remain_in_coordinator_data_when_camera_refres
     assert stations == {"camera-id": camera}
 
 
+def test_camera_metadata_refresh_preserves_latest_motion_event_image():
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Camera:
+        entity_id = "camera-id"
+        type = "SSC0A"
+
+        def __init__(self, data):
+            self.data = data
+
+        def set_data(self, data):
+            self.data.update(data)
+
+    previous = Camera(
+        {
+            "lastEventImageUrl": "https://example.invalid/event.jpg",
+            "lastEventPackageImageUrl": "https://example.invalid/package.jpg",
+            "lastEventImageTime": 1_700_000_100,
+        }
+    )
+    refreshed = Camera({"thumbImgUrl": "https://example.invalid/list.jpg"})
+    house = SimpleNamespace(stations={"camera-id": refreshed})
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = SimpleNamespace(houses={"house-id": house})
+    coordinator._camera_station_cache = {"camera-id": previous}
+
+    coordinator._cache_camera_stations()
+
+    assert coordinator._camera_station_cache == {"camera-id": refreshed}
+    assert refreshed.data["lastEventImageUrl"] == "https://example.invalid/event.jpg"
+    assert refreshed.data["lastEventPackageImageUrl"] == (
+        "https://example.invalid/package.jpg"
+    )
+    assert refreshed.data["lastEventImageTime"] == 1_700_000_100
+
+
 def test_mqtt_camera_motion_event_preserves_apk_event_time():
     from custom_components.xsense.coordinator import _mqtt_reported_data
 
@@ -1838,6 +1874,8 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
                         "startTime": 1781478300,
                         "endTime": 1781478310,
                         "traceId": "trace-id",
+                        "imageUrl": "https://example.invalid/event.jpg",
+                        "packageImageUrl": "https://example.invalid/package.jpg",
                         "tags": "motion",
                     }
                 ]
@@ -1867,8 +1905,15 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
         "end_time_s": 1781478310,
         "timestamp": 1781478300,
         "timestamp_s": 1781478300,
+        "image_url": "https://example.invalid/event.jpg",
+        "package_image_url": "https://example.invalid/package.jpg",
         "tags": "motion",
     }
+    assert parsed[0][1]["lastEventImageUrl"] == "https://example.invalid/event.jpg"
+    assert parsed[0][1]["lastEventPackageImageUrl"] == (
+        "https://example.invalid/package.jpg"
+    )
+    assert parsed[0][1]["lastEventImageTime"] == 1781478300
     assert house.stations["camera-id"].data[CAMERA_AI_SERVICE_AVAILABLE] is False
     assert "isMoved" not in parsed[0][1]
     assert "lastMotionTime" not in parsed[0][1]


### PR DESCRIPTION
## Summary

- retain the newest camera motion-event image across camera metadata refreshes
- prevent an older stored push thumbnail from replacing a newer event image
- prepare the v1.4.20.4 prerelease metadata and release notes

## Validation

- 918 tests passed on Linux with Python 3.14 and Home Assistant 2026.8.3
- Python compilation passed
- frontend JavaScript syntax check passed
- git diff check passed

Addresses the stale camera-image behavior reported in #182.