### PR TITLE
Do not replay camera history on startup

### DIFF
--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -509,6 +509,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Poll APK AI service history for camera events."""
         first_poll = not self._camera_ai_history_seen
         applied = 0
+        baselined = 0
         skipped = 0
         seen_now: set[str] = set()
         for server_id in server_ids:
@@ -528,6 +529,21 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if not isinstance(alarm_item, dict):
                     continue
                 event_key = _camera_ai_history_event_key(server_id, alarm_item)
+                if first_poll:
+                    payload = dict(alarm_item)
+                    payload.setdefault("serverId", server_id)
+                    if create_time := alarm_item.get("createTime"):
+                        payload.setdefault("eventTime", create_time)
+                    station_data = _mqtt_reported_data(payload)
+                    station = _camera_station_for_ai_server(self, server_id)
+                    if station is None and isinstance(station_data, dict):
+                        station = _camera_station_for_event_data(
+                            self, station_data, payload
+                        )
+                    if station is not None and station_data:
+                        seen_now.add(event_key)
+                        baselined += 1
+                    continue
                 if event_key in self._camera_ai_history_seen and not first_poll:
                     skipped += 1
                     continue
@@ -537,10 +553,11 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._camera_ai_history_seen.update(seen_now)
         LOGGER.debug(
-            "X-Sense camera AI history poll: services=%s seen=%s applied=%s skipped=%s first_poll=%s",
+            "X-Sense camera AI history poll: services=%s seen=%s applied=%s baselined=%s skipped=%s first_poll=%s",
             len(server_ids),
             len(self._camera_ai_history_seen),
             applied,
+            baselined,
             skipped,
             first_poll,
         )
@@ -558,6 +575,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         first_poll = not getattr(self, "_camera_event_history_initialized", False)
         applied = 0
+        baselined = 0
         skipped = 0
         seen_now: set[str] = set()
         now = int(datetime.now(timezone.utc).timestamp())
@@ -578,6 +596,22 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         records = _camera_event_history_records(history)
         for record in reversed(records):
             event_key = _camera_event_history_event_key(record)
+            if first_poll:
+                station_data = _camera_event_history_station_data(record)
+                station = (
+                    _camera_station_for_event_data(self, station_data, record)
+                    if station_data
+                    else None
+                )
+                if station is not None:
+                    seen_now.add(event_key)
+                    baselined += 1
+                else:
+                    LOGGER.debug(
+                        "X-Sense camera record history item was not applied: %s",
+                        _camera_record_history_debug_context(record, event_key),
+                    )
+                continue
             if event_key in self._camera_ai_history_seen and not first_poll:
                 skipped += 1
                 continue
@@ -592,11 +626,12 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._camera_ai_history_seen.update(seen_now)
         LOGGER.debug(
-            "X-Sense camera record history poll: cameras=%s records=%s seen=%s applied=%s skipped=%s first_poll=%s window_s=%s",
+            "X-Sense camera record history poll: cameras=%s records=%s seen=%s applied=%s baselined=%s skipped=%s first_poll=%s window_s=%s",
             len(serial_numbers),
             len(records),
             len(self._camera_ai_history_seen),
             applied,
+            baselined,
             skipped,
             first_poll,
             end_timestamp - start_timestamp,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1771,16 +1771,39 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
     class Client:
         houses = {"house-id": house}
 
+        def __init__(self):
+            self.history_calls = 0
+
         async def get_ai_service_list(self):
             return [{"serverId": "service-id"}]
 
         async def get_ai_service_history(self, server_id):
             assert server_id == "service-id"
-            return {
-                "alarmItems": [
+            self.history_calls += 1
+            items = [
+                {
+                    "eventId": "event-id",
+                    "createTime": "20260614230500",
+                    "dispatchDevs": [
+                        {
+                            "stationSn": "station-sn",
+                            "deviceSn": "camera-sn",
+                        }
+                    ],
+                    "eventItems": [
+                        {
+                            "eventType": "person",
+                            "eventTime": "20260614230501",
+                        }
+                    ],
+                }
+            ]
+            if self.history_calls > 1:
+                items.insert(
+                    0,
                     {
-                        "eventId": "event-id",
-                        "createTime": "20260614230500",
+                        "eventId": "new-event-id",
+                        "createTime": "20260614230600",
                         "dispatchDevs": [
                             {
                                 "stationSn": "station-sn",
@@ -1789,12 +1812,14 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
                         ],
                         "eventItems": [
                             {
-                                "eventType": "person",
-                                "eventTime": "20260614230501",
+                                "eventType": "vehicle",
+                                "eventTime": "20260614230601",
                             }
                         ],
-                    }
-                ]
+                    },
+                )
+            return {
+                "alarmItems": items
             }
 
         async def get_camera_event_history_for_cameras(
@@ -1813,13 +1838,15 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
     coordinator._camera_ai_history_lock = asyncio.Lock()
     coordinator.async_update_listeners = lambda: updates.append(True)
 
+    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
+    assert parsed == []
     assert await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
     assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
 
     assert parsed[0][0] is house.stations["camera-id"]
-    assert parsed[0][1]["lastAiDetection"] == "person"
-    assert parsed[0][1]["lastPersonDetectionTime"] == "20260614230501"
-    assert parsed[0][1]["eventTime"] == "20260614230500"
+    assert parsed[0][1]["lastAiDetection"] == "vehicle"
+    assert parsed[0][1]["lastVehicleDetectionTime"] == "20260614230601"
+    assert parsed[0][1]["eventTime"] == "20260614230600"
     assert house.stations["camera-id"].data[CAMERA_AI_SERVICE_AVAILABLE] is True
     assert "isMoved" not in parsed[0][1]
     assert "lastMotionTime" not in parsed[0][1]
@@ -1858,6 +1885,9 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
     class Client:
         houses = {"house-id": house}
 
+        def __init__(self):
+            self.history_calls = 0
+
         async def get_ai_service_list(self):
             return []
 
@@ -1866,19 +1896,35 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
         ):
             assert cameras == [house.stations["camera-id"]]
             assert end_timestamp > start_timestamp
-            return {
-                "list": [
+            self.history_calls += 1
+            records = [
+                {
+                    "serialNumber": "addx-camera-id",
+                    "timestamp": 1781478300,
+                    "startTime": 1781478300,
+                    "endTime": 1781478310,
+                    "traceId": "trace-id",
+                    "imageUrl": "https://example.invalid/event.jpg",
+                    "packageImageUrl": "https://example.invalid/package.jpg",
+                    "tags": "motion",
+                }
+            ]
+            if self.history_calls > 1:
+                records.insert(
+                    0,
                     {
                         "serialNumber": "addx-camera-id",
-                        "timestamp": 1781478300,
-                        "startTime": 1781478300,
-                        "endTime": 1781478310,
-                        "traceId": "trace-id",
-                        "imageUrl": "https://example.invalid/event.jpg",
-                        "packageImageUrl": "https://example.invalid/package.jpg",
+                        "timestamp": 1781478360,
+                        "startTime": 1781478360,
+                        "endTime": 1781478370,
+                        "traceId": "new-trace-id",
+                        "imageUrl": "https://example.invalid/new-event.jpg",
+                        "packageImageUrl": "https://example.invalid/new-package.jpg",
                         "tags": "motion",
-                    }
-                ]
+                    },
+                )
+            return {
+                "list": records
             }
 
         def parse_get_state(self, station_arg, data):
@@ -1892,28 +1938,32 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
     coordinator._camera_event_history_last_poll = None
     coordinator._camera_ai_history_lock = asyncio.Lock()
 
+    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
+    assert parsed == []
     assert await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
     assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
 
     assert parsed[0][0] is house.stations["camera-id"]
-    assert parsed[0][1]["eventTime"] == "20260614230500"
+    assert parsed[0][1]["eventTime"] == "20260614230600"
     assert parsed[0][1]["playback"] == {
-        "trace_id": "trace-id",
-        "start_time": 1781478300,
-        "start_time_s": 1781478300,
-        "end_time": 1781478310,
-        "end_time_s": 1781478310,
-        "timestamp": 1781478300,
-        "timestamp_s": 1781478300,
-        "image_url": "https://example.invalid/event.jpg",
-        "package_image_url": "https://example.invalid/package.jpg",
+        "trace_id": "new-trace-id",
+        "start_time": 1781478360,
+        "start_time_s": 1781478360,
+        "end_time": 1781478370,
+        "end_time_s": 1781478370,
+        "timestamp": 1781478360,
+        "timestamp_s": 1781478360,
+        "image_url": "https://example.invalid/new-event.jpg",
+        "package_image_url": "https://example.invalid/new-package.jpg",
         "tags": "motion",
     }
-    assert parsed[0][1]["lastEventImageUrl"] == "https://example.invalid/event.jpg"
-    assert parsed[0][1]["lastEventPackageImageUrl"] == (
-        "https://example.invalid/package.jpg"
+    assert parsed[0][1]["lastEventImageUrl"] == (
+        "https://example.invalid/new-event.jpg"
     )
-    assert parsed[0][1]["lastEventImageTime"] == 1781478300
+    assert parsed[0][1]["lastEventPackageImageUrl"] == (
+        "https://example.invalid/new-package.jpg"
+    )
+    assert parsed[0][1]["lastEventImageTime"] == 1781478360
     assert house.stations["camera-id"].data[CAMERA_AI_SERVICE_AVAILABLE] is False
     assert "isMoved" not in parsed[0][1]
     assert "lastMotionTime" not in parsed[0][1]


### PR DESCRIPTION
## Summary
- treat the first camera AI and recording-history response after setup as a deduplication baseline
- stop historical cloud records from being emitted as fresh Home Assistant motion or AI events after restart/reload
- continue routing genuinely new records on subsequent polls
- leave WebRTC live view, camera thumbnails, and HLS recording playback unchanged

## Validation
- Linux server, Python 3.14 / Home Assistant 2026.8.3 environment
- `python -m compileall -q custom_components tests`
- `pytest -q` (918 passed)
- `git diff --check`