### PR TITLE
Prepare v1.4.20.6 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.5):
-  (e.g., 1.4.20.5)
+- **X-Sense-Integration Version** (z. B. 1.4.20.6):
+  (e.g., 1.4.20.6)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.6.md
+++ b/.github/release-notes/1.4.20.6.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.20.6
+
+### 📷 Camera Motion Events
+- Prevents one physical camera motion event from being reported more than once when MQTT and recording history provide different playback details.
+- Keeps refreshed recording links and trace information from appearing as new motion.
+- Replaces the numeric camera motion sensitivity choices with the APK-aligned High, Medium, and Low levels, with Auto shown when the camera supports it.
+
+Please test camera motion events and sensitivity controls after updating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.6](.github/release-notes/1.4.20.6.md)
 - [1.4.20.5](.github/release-notes/1.4.20.5.md)
 - [1.4.20.4](.github/release-notes/1.4.20.4.md)
 - [1.4.20.3](.github/release-notes/1.4.20.3.md)

--- a/custom_components/xsense/event.py
+++ b/custom_components/xsense/event.py
@@ -513,9 +513,8 @@ def motion_fingerprint(
     """Return a stable duplicate-detection fingerprint for motion events."""
     if event_data is None:
         return None
-    playback = event_data.get("playback")
-    trace = playback.get("trace_id") if isinstance(playback, dict) else None
-    return (event_data.get("time"), trace)
+    # MQTT and history describe the same event with different playback metadata.
+    return (event_data.get("time"),)
 
 
 def _trigger_event_after_recording_cache(

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.5"
+PANEL_ASSET_VERSION = "1.4.20.6"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.5",
+  "version": "1.4.20.6",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/event_parser.py
+++ b/custom_components/xsense/python_xsense/event_parser.py
@@ -324,10 +324,13 @@ def camera_event_history_records(history: dict[str, Any]) -> list[dict[str, Any]
 def camera_event_history_event_key(record: dict[str, Any]) -> str:
     """Return a stable key for one APK ADDX camera event record."""
     serial = record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
-    trace = record.get("traceId") or record.get("traceIds")
     timestamp = record.get("timestamp") or record.get("startTime") or record.get("date")
-    if serial and (trace or timestamp):
-        return f"camera-event:{serial}:{trace or timestamp}"
+    # Playback traces can be refreshed while the physical event remains unchanged.
+    if serial and timestamp:
+        return f"camera-event:{serial}:{timestamp}"
+    trace = record.get("traceId") or record.get("traceIds")
+    if serial and trace:
+        return f"camera-event:{serial}:{trace}"
     payload = json.dumps(
         record,
         ensure_ascii=False,

--- a/custom_components/xsense/select.py
+++ b/custom_components/xsense/select.py
@@ -27,6 +27,14 @@ from .entity import (
 from .errors import xsense_error
 
 
+CAMERA_MOTION_SENSITIVITY_VALUES: dict[str, int] = {
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+    "auto": 4,
+}
+
+
 def has_data(*keys: str) -> Callable[[Entity], bool]:
     """Return an exists function for required X-Sense data keys."""
     return lambda entity: (
@@ -301,7 +309,7 @@ SELECTS: tuple[XSenseSelectEntityDescription, ...] = (
         data_key="motionSensitivity",
         addx_key="motionSensitivity",
         options_key="motionSensitivityOptionList",
-        fixed_options=(0, 1, 2, 3),
+        fixed_options=("high", "medium", "low"),
         translation_key="camera_motion_sensitivity",
         icon="mdi:motion-sensor",
         exists_fn=has_camera_motion_sensitivity,
@@ -467,7 +475,7 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
         if self.entity_description.key == "camera_motion_sensitivity":
             options = entity.data.get("motionSensitivityOptionList")
             if isinstance(options, list) and len(options) == 4:
-                return option_strings(options)
+                return list(CAMERA_MOTION_SENSITIVITY_VALUES)
         if not is_camera_entity(entity):
             return shadow_select_options(entity, self.entity_description)
         if self.entity_description.fixed_options is not None:
@@ -481,6 +489,21 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
         if entity is None:
             return None
         value = entity.data.get(self.entity_description.data_key)
+        if self.entity_description.key == "camera_motion_sensitivity":
+            try:
+                sensitivity = int(value)
+            except (TypeError, ValueError):
+                return None
+            if sensitivity == 0:
+                sensitivity = 1
+            return next(
+                (
+                    option
+                    for option, api_value in CAMERA_MOTION_SENSITIVITY_VALUES.items()
+                    if api_value == sensitivity and option in self.options
+                ),
+                None,
+            )
         return None if value is None else str(value)
 
     async def async_select_option(self, option: str) -> None:
@@ -491,6 +514,14 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
         if option not in self.options:
             raise xsense_error("unsupported_option", option=option)
 
+        if self.entity_description.key == "camera_motion_sensitivity":
+            api_value = CAMERA_MOTION_SENSITIVITY_VALUES[option]
+            await self.coordinator.xsense.update_camera_config(
+                entity, motionSensitivity=api_value
+            )
+            entity.data[self.entity_description.data_key] = api_value
+            self.coordinator.async_update_listeners()
+            return
         if self.entity_description.data_key == "recResolution":
             await self.coordinator.xsense.update_camera_recording_resolution(
                 entity, option
@@ -503,8 +534,9 @@ class XSenseSelectEntity(XSenseEntity, SelectEntity):
                 user_enable=_required_bool_state(entity.data.get("cooldownEnabled")),
                 value=int(_typed_option(option)),
             )
-        elif self.entity_description.addx_key and self.entity_description.addx_key.startswith(
-            "audio."
+        elif (
+            self.entity_description.addx_key
+            and self.entity_description.addx_key.startswith("audio.")
         ):
             await self.coordinator.xsense.update_camera_audio(
                 entity,

--- a/custom_components/xsense/strings.json
+++ b/custom_components/xsense/strings.json
@@ -532,7 +532,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "low": "Low",
+          "auto": "Auto"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/ar.json
+++ b/custom_components/xsense/translations/ar.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "عالية",
+          "medium": "متوسطة",
+          "low": "منخفضة",
+          "auto": "تلقائية"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/as.json
+++ b/custom_components/xsense/translations/as.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "উচ্চ",
+          "medium": "মধ্যম",
+          "low": "নিম্ন",
+          "auto": "স্বয়ংক্ৰিয়"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/cs.json
+++ b/custom_components/xsense/translations/cs.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Vysoká",
+          "medium": "Střední",
+          "low": "Nízká",
+          "auto": "Automatická"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/da.json
+++ b/custom_components/xsense/translations/da.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Høj",
+          "medium": "Mellem",
+          "low": "Lav",
+          "auto": "Automatisk"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/de.json
+++ b/custom_components/xsense/translations/de.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Hoch",
+          "medium": "Mittel",
+          "low": "Niedrig",
+          "auto": "Automatisch"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/el.json
+++ b/custom_components/xsense/translations/el.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Υψηλή",
+          "medium": "Μέτρια",
+          "low": "Χαμηλή",
+          "auto": "Αυτόματη"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/en.json
+++ b/custom_components/xsense/translations/en.json
@@ -532,7 +532,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "low": "Low",
+          "auto": "Auto"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/es.json
+++ b/custom_components/xsense/translations/es.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Alta",
+          "medium": "Media",
+          "low": "Baja",
+          "auto": "Automática"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/et.json
+++ b/custom_components/xsense/translations/et.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Kõrge",
+          "medium": "Keskmine",
+          "low": "Madal",
+          "auto": "Automaatne"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/fa.json
+++ b/custom_components/xsense/translations/fa.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "زیاد",
+          "medium": "متوسط",
+          "low": "کم",
+          "auto": "خودکار"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/fi.json
+++ b/custom_components/xsense/translations/fi.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Korkea",
+          "medium": "Keskitaso",
+          "low": "Matala",
+          "auto": "Automaattinen"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/fr.json
+++ b/custom_components/xsense/translations/fr.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Élevée",
+          "medium": "Moyenne",
+          "low": "Faible",
+          "auto": "Automatique"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/he.json
+++ b/custom_components/xsense/translations/he.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "גבוהה",
+          "medium": "בינונית",
+          "low": "נמוכה",
+          "auto": "אוטומטית"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/hi.json
+++ b/custom_components/xsense/translations/hi.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "उच्च",
+          "medium": "मध्यम",
+          "low": "निम्न",
+          "auto": "स्वचालित"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/hr.json
+++ b/custom_components/xsense/translations/hr.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Visoka",
+          "medium": "Srednja",
+          "low": "Niska",
+          "auto": "Automatska"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/hu.json
+++ b/custom_components/xsense/translations/hu.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Magas",
+          "medium": "Közepes",
+          "low": "Alacsony",
+          "auto": "Automatikus"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/id.json
+++ b/custom_components/xsense/translations/id.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Tinggi",
+          "medium": "Sedang",
+          "low": "Rendah",
+          "auto": "Otomatis"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/it.json
+++ b/custom_components/xsense/translations/it.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Alta",
+          "medium": "Media",
+          "low": "Bassa",
+          "auto": "Automatica"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/ja.json
+++ b/custom_components/xsense/translations/ja.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低",
+          "auto": "自動"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/ko.json
+++ b/custom_components/xsense/translations/ko.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "높음",
+          "medium": "중간",
+          "low": "낮음",
+          "auto": "자동"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/lt.json
+++ b/custom_components/xsense/translations/lt.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Didelis",
+          "medium": "Vidutinis",
+          "low": "Mažas",
+          "auto": "Automatinis"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/lv.json
+++ b/custom_components/xsense/translations/lv.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Augsta",
+          "medium": "Vidēja",
+          "low": "Zema",
+          "auto": "Automātiska"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/nb.json
+++ b/custom_components/xsense/translations/nb.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Høy",
+          "medium": "Middels",
+          "low": "Lav",
+          "auto": "Automatisk"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/nl.json
+++ b/custom_components/xsense/translations/nl.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Hoog",
+          "medium": "Gemiddeld",
+          "low": "Laag",
+          "auto": "Automatisch"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/no.json
+++ b/custom_components/xsense/translations/no.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Høy",
+          "medium": "Middels",
+          "low": "Lav",
+          "auto": "Automatisk"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/pl.json
+++ b/custom_components/xsense/translations/pl.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Wysoka",
+          "medium": "Średnia",
+          "low": "Niska",
+          "auto": "Automatyczna"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/pt-BR.json
+++ b/custom_components/xsense/translations/pt-BR.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Alta",
+          "medium": "Média",
+          "low": "Baixa",
+          "auto": "Automática"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/pt.json
+++ b/custom_components/xsense/translations/pt.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Alta",
+          "medium": "Média",
+          "low": "Baixa",
+          "auto": "Automática"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/ro.json
+++ b/custom_components/xsense/translations/ro.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Ridicată",
+          "medium": "Medie",
+          "low": "Scăzută",
+          "auto": "Automată"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/ru.json
+++ b/custom_components/xsense/translations/ru.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Высокая",
+          "medium": "Средняя",
+          "low": "Низкая",
+          "auto": "Автоматическая"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/sk.json
+++ b/custom_components/xsense/translations/sk.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Vysoká",
+          "medium": "Stredná",
+          "low": "Nízka",
+          "auto": "Automatická"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/sl.json
+++ b/custom_components/xsense/translations/sl.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Visoka",
+          "medium": "Srednja",
+          "low": "Nizka",
+          "auto": "Samodejna"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/sv.json
+++ b/custom_components/xsense/translations/sv.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Hög",
+          "medium": "Medel",
+          "low": "Låg",
+          "auto": "Automatisk"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/th.json
+++ b/custom_components/xsense/translations/th.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "สูง",
+          "medium": "ปานกลาง",
+          "low": "ต่ำ",
+          "auto": "อัตโนมัติ"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/tr.json
+++ b/custom_components/xsense/translations/tr.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Yüksek",
+          "medium": "Orta",
+          "low": "Düşük",
+          "auto": "Otomatik"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/uk.json
+++ b/custom_components/xsense/translations/uk.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Висока",
+          "medium": "Середня",
+          "low": "Низька",
+          "auto": "Автоматична"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/vi.json
+++ b/custom_components/xsense/translations/vi.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "Cao",
+          "medium": "Trung bình",
+          "low": "Thấp",
+          "auto": "Tự động"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/zh-CN.json
+++ b/custom_components/xsense/translations/zh-CN.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低",
+          "auto": "自动"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/zh-Hans.json
+++ b/custom_components/xsense/translations/zh-Hans.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低",
+          "auto": "自动"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/zh-Hant.json
+++ b/custom_components/xsense/translations/zh-Hant.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低",
+          "auto": "自動"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/custom_components/xsense/translations/zh-TW.json
+++ b/custom_components/xsense/translations/zh-TW.json
@@ -531,7 +531,13 @@
         "name": "Recording Resolution"
       },
       "camera_motion_sensitivity": {
-        "name": "Detection Sensitivity"
+        "name": "Detection Sensitivity",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低",
+          "auto": "自動"
+        }
       },
       "camera_video_seconds": {
         "name": "Video Duration"

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -570,6 +570,71 @@ def test_camera_selects_survive_unknown_current_setting_values():
     assert descriptions["camera_video_seconds"].exists_fn(camera)
 
 
+def test_camera_motion_sensitivity_matches_apk_labels_and_values():
+    description = next(
+        item for item in select.SELECTS if item.key == "camera_motion_sensitivity"
+    )
+    three_level_camera = entity("SSC0A", {"isAdmin": True, "motionSensitivity": 0})
+    auto_camera = entity(
+        "SSC0A",
+        {
+            "isAdmin": True,
+            "motionSensitivity": 4,
+            "motionSensitivityOptionList": [1, 2, 3, 4],
+        },
+    )
+
+    three_level_select = SimpleNamespace(
+        entity_description=description,
+        _current_entity=lambda: three_level_camera,
+        options=["high", "medium", "low"],
+    )
+    auto_select = SimpleNamespace(
+        entity_description=description,
+        _current_entity=lambda: auto_camera,
+        options=["high", "medium", "low", "auto"],
+    )
+
+    assert select.XSenseSelectEntity.options.fget(three_level_select) == [
+        "high",
+        "medium",
+        "low",
+    ]
+    assert select.XSenseSelectEntity.current_option.fget(three_level_select) == "high"
+    assert select.XSenseSelectEntity.options.fget(auto_select) == [
+        "high",
+        "medium",
+        "low",
+        "auto",
+    ]
+    assert select.XSenseSelectEntity.current_option.fget(auto_select) == "auto"
+
+
+async def test_camera_motion_sensitivity_writes_apk_value():
+    camera = entity("SSC0A", {"isAdmin": True, "motionSensitivity": 1})
+    xsense = SimpleNamespace(update_camera_config=AsyncMock())
+    coordinator = SimpleNamespace(
+        xsense=xsense,
+        async_update_listeners=MagicMock(),
+    )
+    select_entity = SimpleNamespace(
+        coordinator=coordinator,
+        entity_description=next(
+            item
+            for item in select.SELECTS
+            if item.key == "camera_motion_sensitivity"
+        ),
+        _current_entity=lambda: camera,
+        options=["high", "medium", "low"],
+    )
+
+    await select.XSenseSelectEntity.async_select_option(select_entity, "low")
+
+    xsense.update_camera_config.assert_awaited_once_with(camera, motionSensitivity=3)
+    assert camera.data["motionSensitivity"] == 3
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
 def test_camera_person_detection_switch_follows_apk_support_flag():
     descriptions = {description.key: description for description in switch.SWITCHES}
     description = descriptions["camera_person_detection"]

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -1297,7 +1297,7 @@ def test_motion_event_data_uses_apk_history_record_time():
     )
 
     assert event_data == {"time": "20260621134144"}
-    assert event.motion_fingerprint(event_data) == ("20260621134144", None)
+    assert event.motion_fingerprint(event_data) == ("20260621134144",)
 
 
 def test_motion_event_data_includes_apk_playback_metadata():
@@ -1325,7 +1325,24 @@ def test_motion_event_data_includes_apk_playback_metadata():
         },
         "snapshot_url": "https://example.invalid/snap.jpg",
     }
-    assert event.motion_fingerprint(event_data) == ("20260621134144", "trace-id")
+    assert event.motion_fingerprint(event_data) == ("20260621134144",)
+
+
+def test_motion_fingerprint_ignores_playback_enrichment_for_same_event():
+    mqtt_event = event.motion_event_data({"eventTime": "20260621134144"})
+    history_event = event.motion_event_data(
+        {
+            "eventTime": "20260621134144",
+            "playback": {
+                "trace_id": "refreshed-trace-id",
+                "video_url": "https://example.invalid/refreshed.m3u8",
+            },
+        }
+    )
+
+    assert event.motion_fingerprint(mqtt_event) == event.motion_fingerprint(
+        history_event
+    )
 
 
 def test_motion_event_entity_adds_ha_sd_playback_url(monkeypatch):
@@ -1538,7 +1555,7 @@ def test_motion_event_entity_caches_recording_before_trigger(monkeypatch, caplog
         event.XSenseMotionEventEntity
     )
     event_entity._motion_initialized = True
-    event_entity._last_motion_fingerprint = ("20260621134000", "old-trace")
+    event_entity._last_motion_fingerprint = ("20260621134000",)
     scheduled = []
     order = []
     event_entity.hass = SimpleNamespace(
@@ -1703,7 +1720,7 @@ def test_motion_event_entity_updates_state_only_when_recording_cache_returns_no_
         event.XSenseMotionEventEntity
     )
     event_entity._motion_initialized = True
-    event_entity._last_motion_fingerprint = ("20260621134000", "old-trace")
+    event_entity._last_motion_fingerprint = ("20260621134000",)
     scheduled = []
     triggered = []
     event_entity.hass = SimpleNamespace(
@@ -4989,7 +5006,7 @@ def test_motion_event_data_exposes_direct_recording_url_aliases():
         "snapshot_url": "https://example.invalid/still.jpg",
         "recording_source": "video_url",
     }
-    assert event.motion_fingerprint(event_data) == ("20260621134144", "trace-id")
+    assert event.motion_fingerprint(event_data) == ("20260621134144",)
 
 
 def test_motion_event_entity_triggers_repeated_motion_with_new_time():
@@ -5014,6 +5031,32 @@ def test_motion_event_entity_triggers_repeated_motion_with_new_time():
     event_entity._handle_coordinator_update()
 
     assert triggered == [("motion", "20260621134200")]
+
+
+def test_motion_event_entity_does_not_retrigger_when_history_enriches_mqtt_event():
+    camera_entity = entity("SSC0A", {"eventTime": "20260621134144"})
+    event_entity = event.XSenseMotionEventEntity.__new__(
+        event.XSenseMotionEventEntity
+    )
+    event_entity._motion_initialized = False
+    event_entity._last_motion_fingerprint = None
+    event_entity.hass = object()
+    event_entity.platform = object()
+    event_entity._current_entity = lambda: camera_entity
+    triggered = []
+    event_entity._trigger_event = lambda event_type, data: triggered.append(
+        (event_type, data["time"])
+    )
+    event_entity.async_write_ha_state = lambda: None
+
+    event_entity._handle_coordinator_update()
+    camera_entity.data["playback"] = {
+        "trace_id": "history-trace-id",
+        "video_url": "https://example.invalid/history.m3u8",
+    }
+    event_entity._handle_coordinator_update()
+
+    assert triggered == []
 
 
 def test_ai_detection_event_data_uses_apk_detection_payload():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1903,7 +1903,9 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
                     "timestamp": 1781478300,
                     "startTime": 1781478300,
                     "endTime": 1781478310,
-                    "traceId": "trace-id",
+                    "traceId": (
+                        "refreshed-trace-id" if self.history_calls > 2 else "trace-id"
+                    ),
                     "imageUrl": "https://example.invalid/event.jpg",
                     "packageImageUrl": "https://example.invalid/package.jpg",
                     "tags": "motion",
@@ -1917,7 +1919,11 @@ async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty(
                         "timestamp": 1781478360,
                         "startTime": 1781478360,
                         "endTime": 1781478370,
-                        "traceId": "new-trace-id",
+                        "traceId": (
+                            "refreshed-new-trace-id"
+                            if self.history_calls > 2
+                            else "new-trace-id"
+                        ),
                         "imageUrl": "https://example.invalid/new-event.jpg",
                         "packageImageUrl": "https://example.invalid/new-package.jpg",
                         "tags": "motion",


### PR DESCRIPTION
## Summary

- align camera motion sensitivity labels and values with the X-Sense APK
- prevent one physical motion event from being emitted again when MQTT and camera history attach different playback metadata
- prepare the v1.4.20.6 prerelease metadata and release notes

## Validation

- full Linux server suite: 922 passed
- fork CI: Python 3.13 and Python 3.14 passed
- HACS and hassfest validation passed