### PR TITLE
Prepare v1.4.20.7 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.6):
-  (e.g., 1.4.20.6)
+- **X-Sense-Integration Version** (z. B. 1.4.20.7):
+  (e.g., 1.4.20.7)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.7.md
+++ b/.github/release-notes/1.4.20.7.md
@@ -1,0 +1,11 @@
+## X-Sense Home Security v1.4.20.7
+
+### 🔐 Alarm Arming
+- Restores the confirmation prompt when normal Away or Home arming is blocked by an open contact sensor.
+- Keeps force-arm actions available for automations without showing an unnecessary prompt.
+
+### 📷 Camera Motion Events
+- Uses X-Sense event history instead of ordinary playback history for motion updates.
+- Keeps each event tied to the camera that reported it, preventing one camera's history from appearing on another.
+
+Please test normal arming with an open contact sensor and motion events on multi-camera setups after updating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.7](.github/release-notes/1.4.20.7.md)
 - [1.4.20.6](.github/release-notes/1.4.20.6.md)
 - [1.4.20.5](.github/release-notes/1.4.20.5.md)
 - [1.4.20.4](.github/release-notes/1.4.20.4.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.6"
+PANEL_ASSET_VERSION = "1.4.20.7"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.6",
+  "version": "1.4.20.7",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -11,6 +11,7 @@ from .base import XSenseBase, _apply_sbs50_force_arm_prompt, shadow_update_body
 from .entity import Entity
 from .entity_map import EntityType
 from .exceptions import SessionExpired, APIFailure, XSenseError
+from .event_parser import camera_event_history_is_event_record
 from .house import House
 from .mapping import bool_state
 from .station import Station
@@ -242,6 +243,16 @@ def camera_matches_identifier(camera: Entity, identifier: Any) -> bool:
         _normalized_camera_serial(candidate) == normalized
         for candidate in _camera_addx_serial_candidates(camera)
     )
+
+
+def _camera_history_record_matches_serial(
+    record: dict[str, Any], serial: str
+) -> bool:
+    """Return whether a library row belongs to the exact requested camera."""
+    record_serial = (
+        record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
+    )
+    return _normalized_camera_serial(record_serial) == _normalized_camera_serial(serial)
 
 
 def _is_addx_device_no_access(error: Exception) -> bool:
@@ -608,9 +619,10 @@ class AsyncXSense(XSenseBase):
         for camera, house, serials in requests:
             camera_request_succeeded = False
             accepted_serial = None
+            # The APK's event endpoint is authoritative for motion history.
             for serial_index, serial in enumerate(serials):
                 try:
-                    history = await self.get_camera_event_history(
+                    history = await self.get_camera_event_record_history(
                         [serial],
                         start_timestamp,
                         end_timestamp,
@@ -641,16 +653,27 @@ class AsyncXSense(XSenseBase):
                 if not isinstance(group_records, list) or not group_records:
                     continue
 
+                matching_records = [
+                    record
+                    for record in group_records
+                    if isinstance(record, dict)
+                    and _camera_history_record_matches_serial(record, serial)
+                    and camera_event_history_is_event_record(record)
+                ]
+                if not matching_records:
+                    continue
                 accepted_serial = serial
-                records.extend(
-                    record for record in group_records if isinstance(record, dict)
-                )
+                records.extend(matching_records)
                 break
 
+            # Some accounts expose event recordings only through the general
+            # library endpoint. Accept those rows only when the payload itself
+            # identifies an event; ordinary playback rows must never become
+            # Home Assistant motion events.
             if accepted_serial is None:
                 for serial_index, serial in enumerate(serials):
                     try:
-                        history = await self.get_camera_event_record_history(
+                        history = await self.get_camera_event_history(
                             [serial],
                             start_timestamp,
                             end_timestamp,
@@ -662,7 +685,7 @@ class AsyncXSense(XSenseBase):
                         if first_error is None:
                             first_error = err
                         LOGGER.debug(
-                            "X-Sense camera event-library history unavailable: %s",
+                            "X-Sense camera playback-library history unavailable: %s",
                             {
                                 "identity_index": serial_index,
                                 "identity_count": len(serials),
@@ -681,10 +704,15 @@ class AsyncXSense(XSenseBase):
                     if not isinstance(group_records, list) or not group_records:
                         continue
 
-                    accepted_serial = serial
-                    records.extend(
+                    matching_records = [
                         record for record in group_records if isinstance(record, dict)
-                    )
+                        and _camera_history_record_matches_serial(record, serial)
+                        and camera_event_history_is_event_record(record)
+                    ]
+                    if not matching_records:
+                        continue
+                    accepted_serial = serial
+                    records.extend(matching_records)
                     break
 
             if accepted_serial is not None:

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -619,6 +619,29 @@ def _sbs50_force_arm_prompt(
                 "exitDelay": station_data.get("exitDelay"),
             }
 
+    notices = station_data.get("notices")
+    if not isinstance(notices, list):
+        return None
+
+    for notice in notices:
+        if not isinstance(notice, dict):
+            continue
+        event_param = notice.get("eventParam")
+        if not isinstance(event_param, dict):
+            continue
+        safe_mode_aim = event_param.get("safeModeAim")
+        if safe_mode_aim != requested_mode:
+            continue
+        force_reason = event_param.get("forceReason")
+        if not force_reason:
+            continue
+        return {
+            "forceReason": force_reason,
+            "safeModeAim": requested_mode,
+            "requestedSafeMode": requested_mode,
+            "exitDelay": event_param.get("exitDelay"),
+        }
+
     return None
 
 

--- a/custom_components/xsense/python_xsense/event_parser.py
+++ b/custom_components/xsense/python_xsense/event_parser.py
@@ -95,6 +95,7 @@ __all__ = [
     "apply_apk_event_aliases",
     "camera_ai_history_event_key",
     "camera_event_history_event_key",
+    "camera_event_history_is_event_record",
     "camera_event_history_playback_data",
     "camera_event_history_playback_source",
     "camera_event_history_records",
@@ -341,10 +342,22 @@ def camera_event_history_event_key(record: dict[str, Any]) -> str:
     return f"camera-event:{payload}"
 
 
+def camera_event_history_is_event_record(record: dict[str, Any]) -> bool:
+    """Return whether an APK library row is explicitly classified as an event."""
+    return any(
+        value not in (None, "", [], {})
+        for value in (
+            record.get("videoEvent"),
+            record.get("tags"),
+            record.get("eventInfoList"),
+        )
+    )
+
+
 def camera_event_history_station_data(record: dict[str, Any]) -> dict[str, Any]:
     """Return normal camera state keys from an APK ADDX event-history record."""
     serial = record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
-    if not serial:
+    if not serial or not camera_event_history_is_event_record(record):
         return {}
 
     timestamp = record.get("timestamp") or record.get("startTime")
@@ -352,7 +365,7 @@ def camera_event_history_station_data(record: dict[str, Any]) -> dict[str, Any]:
     data: dict[str, Any] = {
         "serialNumber": serial,
         "deviceSN": serial,
-        "eventType": record.get("videoEvent") or record.get("tags") or "motion",
+        "eventType": record.get("videoEvent") or record.get("tags"),
         "eventItems": record.get("eventInfoList"),
         "eventObjectType": record.get("eventInfoList") or record.get("tags"),
         "lastType": record.get("videoEvent") or record.get("tags"),

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5161,9 +5161,9 @@ async def test_camera_event_history_groups_cameras_by_addx_home():
 
     async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
         calls.append((serials, kwargs["house"]))
-        return {"list": [{"serialNumber": serials[0]}]}
+        return {"list": [{"serialNumber": serials[0], "videoEvent": "motion"}]}
 
-    client.get_camera_event_history = get_history
+    client.get_camera_event_record_history = get_history
 
     result = await client.get_camera_event_history_for_cameras(
         [camera_1, camera_2], 1781484300, 1781487900
@@ -5198,9 +5198,9 @@ async def test_camera_event_history_queries_each_camera_without_shared_page_limi
 
     async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
         calls.append((serials, kwargs["house"], kwargs["limit"]))
-        return {"list": [{"serialNumber": serials[0]}]}
+        return {"list": [{"serialNumber": serials[0], "videoEvent": "motion"}]}
 
-    client.get_camera_event_history = get_history
+    client.get_camera_event_record_history = get_history
 
     result = await client.get_camera_event_history_for_cameras(
         cameras, 1781484300, 1781487900, limit=25
@@ -5231,17 +5231,26 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
     async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
         calls.append(serials)
         if serials == ["camera-access-id"]:
-            return {"list": [{"serialNumber": "camera-access-id"}]}
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-access-id",
+                        "videoEvent": "motion",
+                    }
+                ]
+            }
         return {"list": []}
 
-    client.get_camera_event_history = get_history
+    client.get_camera_event_record_history = get_history
 
     result = await client.get_camera_event_history_for_cameras(
         [camera], 1781484300, 1781487900
     )
 
     assert calls == [["camera-list-id"], ["camera-access-id"]]
-    assert result["list"] == [{"serialNumber": "camera-access-id"}]
+    assert result["list"] == [
+        {"serialNumber": "camera-access-id", "videoEvent": "motion"}
+    ]
     assert updates == [
         {
             "addxAccessSerialNumber": "camera-access-id",
@@ -5251,7 +5260,7 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_tries_apk_event_library_after_playback_empty():
+async def test_camera_event_history_prefers_apk_event_library():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
     client.houses = {"house-1": house}
@@ -5290,9 +5299,6 @@ async def test_camera_event_history_tries_apk_event_library_after_playback_empty
     )
 
     assert calls == [
-        ("playback", ["camera-list-id"], house),
-        ("playback", ["camera-access-id"], house),
-        ("playback", ["camera-label"], house),
         ("event", ["camera-list-id"], house),
         ("event", ["camera-access-id"], house),
     ]
@@ -5305,6 +5311,130 @@ async def test_camera_event_history_tries_apk_event_library_after_playback_empty
             "addxSerialNumber": "camera-access-id",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_camera_event_history_fallback_rejects_unclassified_playback_rows():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    camera = SimpleNamespace(
+        sn="camera-sn",
+        entity_id="camera-sn",
+        data={},
+        house=house,
+        set_data=lambda data: None,
+    )
+
+    async def get_event_history(*args, **kwargs):
+        return {"list": []}
+
+    async def get_playback_history(*args, **kwargs):
+        return {
+            "list": [
+                {
+                    "serialNumber": "camera-sn",
+                    "timestamp": 1781484300,
+                    "videoUrl": "https://example.invalid/ordinary.m3u8",
+                }
+            ]
+        }
+
+    client.get_camera_event_record_history = get_event_history
+    client.get_camera_event_history = get_playback_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        [camera], 1781484300, 1781487900
+    )
+
+    assert result == {"list": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_camera_event_history_fallback_accepts_explicit_event_rows():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    camera = SimpleNamespace(
+        sn="camera-sn",
+        entity_id="camera-sn",
+        data={},
+        house=house,
+        set_data=lambda data: None,
+    )
+
+    async def get_event_history(*args, **kwargs):
+        return {"list": []}
+
+    async def get_playback_history(*args, **kwargs):
+        return {
+            "list": [
+                {
+                    "serialNumber": "camera-sn",
+                    "timestamp": 1781484300,
+                    "videoEvent": "motion",
+                }
+            ]
+        }
+
+    client.get_camera_event_record_history = get_event_history
+    client.get_camera_event_history = get_playback_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        [camera], 1781484300, 1781487900
+    )
+
+    assert result == {
+        "list": [
+            {
+                "serialNumber": "camera-sn",
+                "timestamp": 1781484300,
+                "videoEvent": "motion",
+            }
+        ],
+        "total": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_camera_event_history_does_not_cross_route_two_camera_rows():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    cameras = [
+        SimpleNamespace(
+            sn=f"camera-{index}",
+            entity_id=f"camera-{index}",
+            data={},
+            house=house,
+            set_data=lambda data: None,
+        )
+        for index in (1, 2)
+    ]
+
+    async def get_event_history(serials, *args, **kwargs):
+        other_serial = "camera-2" if serials == ["camera-1"] else "camera-1"
+        return {
+            "list": [
+                {
+                    "serialNumber": other_serial,
+                    "timestamp": 1781484300,
+                    "videoEvent": "motion",
+                }
+            ]
+        }
+
+    async def get_playback_history(*args, **kwargs):
+        return {"list": []}
+
+    client.get_camera_event_record_history = get_event_history
+    client.get_camera_event_history = get_playback_history
+
+    result = await client.get_camera_event_history_for_cameras(
+        cameras, 1781484300, 1781487900
+    )
+
+    assert result == {"list": [], "total": 0}
 
 
 def test_camera_addx_serial_candidates_keep_proven_access_identity_first():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2339,6 +2339,21 @@ def test_camera_record_history_item_preserves_event_time_without_live_motion():
     assert "lastMotionTime" not in data
 
 
+def test_camera_record_history_rejects_unclassified_playback_row():
+    from custom_components.xsense.coordinator import _camera_event_history_station_data
+
+    data = _camera_event_history_station_data(
+        {
+            "serialNumber": "camera-sn",
+            "timestamp": 1782049304,
+            "traceId": "trace-id",
+            "videoUrl": "https://example.invalid/ordinary.m3u8",
+        }
+    )
+
+    assert data == {}
+
+
 async def test_assure_subscriptions_includes_apk_ai_plan_topic():
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -769,6 +769,68 @@ def test_mqtt_skp0a_safenotice_fires_keypad_code_event(caplog):
     assert "1234" not in caplog.text
 
 
+@pytest.mark.parametrize("requested_mode", ["Home", "Away"])
+def test_mqtt_safenotice_exposes_force_arm_prompt_for_pending_request(
+    requested_mode,
+):
+    from custom_components.xsense.alarm_control_panel import pending_force_arm_mode
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+    from custom_components.xsense.python_xsense.base import XSenseBase
+    from custom_components.xsense.python_xsense.station import Station
+
+    station = Station(
+        None,
+        stationId="station-id",
+        stationName="Base Station",
+        stationSn="15A9862E",
+        category="SBS50",
+    )
+    station.set_alarm_data({"requestedSafeMode": requested_mode})
+    station.safe_mode = "Disarmed"
+
+    class Bus:
+        def __init__(self):
+            self.events = []
+
+        def async_fire(self, event_type, payload):
+            self.events.append((event_type, payload))
+
+    bus = Bus()
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.hass = SimpleNamespace(bus=bus)
+    coordinator.xsense = XSenseBase.__new__(XSenseBase)
+    coordinator.xsense.houses = {"house-id": PresenceHouse(station)}
+    coordinator.async_update_listeners = lambda: None
+
+    coordinator.async_event_received(
+        "$aws/things/SBS50-15A9862E/shadow/name/2nd_safenotice/update",
+        json.dumps(
+            {
+                "state": {
+                    "reported": {
+                        "stationSN": station.sn,
+                        "safeMode": "Disarmed",
+                        "notices": [
+                            {
+                                "type": "SDS0A",
+                                "eventId": "blocked-arm-1",
+                                "eventParam": {
+                                    "safeModeAim": requested_mode,
+                                    "forceReason": [{"deviceSN": "door-sn"}],
+                                    "exitDelay": "0",
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        ).encode(),
+    )
+
+    assert pending_force_arm_mode(station) == requested_mode
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+
+
 def test_mqtt_skp0a_safenotice_skips_keypad_notice_without_code(caplog):
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
 

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1259,7 +1259,7 @@ def test_force_arm_prompt_ignores_stale_reason_without_local_request():
     assert station.alarm_data.get("forceReason") is None
 
 
-def test_force_arm_prompt_ignores_historical_notices_during_local_request():
+def test_force_arm_prompt_uses_matching_notice_during_local_request():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data({"requestedSafeMode": "Away"})
@@ -1274,7 +1274,68 @@ def test_force_arm_prompt_ignores_historical_notices_during_local_request():
                     "type": "SKP0A",
                     "eventParam": {
                         "safeModeAim": "Away",
+                        "forceReason": [{"deviceSN": "door-sn"}],
+                        "exitDelay": "0",
+                    },
+                }
+            ],
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Away"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data["exitDelay"] == "0"
+
+
+def test_force_arm_prompt_ignores_notice_for_different_local_request():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Home"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "notices": [
+                {
+                    "type": "SKP0A",
+                    "eventParam": {
+                        "safeModeAim": "Away",
                         "forceReason": [{"deviceSN": "old-door-sn"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
+    assert station.alarm_data["requestedSafeMode"] == "Home"
+
+
+def test_force_arm_prompt_does_not_return_after_request_is_cleared():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data(
+        {
+            "requestedSafeMode": None,
+            "safeModeAim": None,
+            "forceReason": None,
+        }
+    )
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "notices": [
+                {
+                    "type": "SDS0A",
+                    "eventParam": {
+                        "safeModeAim": "Away",
+                        "forceReason": [{"deviceSN": "door-sn"}],
                     },
                 }
             ],


### PR DESCRIPTION
## Summary

- Restore the blocked-arm confirmation prompt for normal Away and Home arming while keeping force-arm automation actions prompt-free.
- Use the APK event-history endpoint as the authoritative camera motion source.
- Reject unclassified playback rows and camera events whose serial does not match the requested camera.
- Prepare the `v1.4.20.7` prerelease metadata and release notes.

Addresses #182 and #284.

## Validation

- Full test suite passes on Windows and Linux with Python 3.14.
- Fork CI passes on Python 3.13 and Python 3.14.
- HACS validation and hassfest pass.
- CodeQL passes for Actions, Python, and JavaScript/TypeScript.