### PR TITLE
Tighten v1.4.20.7 release notes

### DIFF
--- a/.github/release-notes/1.4.20.7.md
+++ b/.github/release-notes/1.4.20.7.md
@@ -7,5 +7,3 @@
 ### 📷 Camera Motion Events
 - Uses X-Sense event history instead of ordinary playback history for motion updates.
 - Keeps each event tied to the camera that reported it, preventing one camera's history from appearing on another.
-
-Please test normal arming with an open contact sensor and motion events on multi-camera setups after updating.


### PR DESCRIPTION
## Summary

Remove the testing request from the published `v1.4.20.7` release notes so they end with the user-facing changes.