### PR TITLE
Preserve SBS50 blocked-arm prompts

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.7):
-  (e.g., 1.4.20.7)
+- **X-Sense-Integration Version** (z. B. 1.4.20.8):
+  (e.g., 1.4.20.8)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.8.md
+++ b/.github/release-notes/1.4.20.8.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.8
+
+### 🔐 Alarm Arming
+- Keeps blocked Home and Away arming requests active while the SBS50 processes the request.
+- Prevents routine station updates from dismissing the force-arm prompt before it can be used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.8](.github/release-notes/1.4.20.8.md)
 - [1.4.20.7](.github/release-notes/1.4.20.7.md)
 - [1.4.20.6](.github/release-notes/1.4.20.6.md)
 - [1.4.20.5](.github/release-notes/1.4.20.5.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.7"
+PANEL_ASSET_VERSION = "1.4.20.8"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.7",
+  "version": "1.4.20.8",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -591,6 +591,12 @@ def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
 
     force_reason_reported = "forceReason" in station_data
     if force_reason_reported:
+        # The SBS50 can acknowledge the normal arm request with an empty
+        # forceReason before publishing the blocked result, and later routine
+        # state updates can report it empty again. The APK ignores empty reasons
+        # throughout the active request instead of dismissing its bypass dialog.
+        if requested_mode in ("Home", "Away"):
+            return
         station.set_alarm_data(
             {
                 "forceReason": None,
@@ -630,7 +636,7 @@ def _sbs50_force_arm_prompt(
         if not isinstance(event_param, dict):
             continue
         safe_mode_aim = event_param.get("safeModeAim")
-        if safe_mode_aim != requested_mode:
+        if safe_mode_aim not in (None, "", requested_mode):
             continue
         force_reason = event_param.get("forceReason")
         if not force_reason:

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -908,6 +908,85 @@ async def test_force_arm_prompt_stops_request_timeout(monkeypatch):
     assert pending_force_arm_mode(station) == "Home"
 
 
+@pytest.mark.parametrize("requested_mode", ["Home", "Away"])
+async def test_blocked_arm_prompt_survives_empty_acknowledgement_end_to_end(
+    monkeypatch, requested_mode
+):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    calls = []
+    cancelled = []
+    created = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            calls.append((safe_mode, force_arm))
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.entity_id = "alarm_control_panel.base_station_alarm"
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: cancelled.append(True)
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
+        lambda hass, message, title=None, notification_id=None: created.append(
+            (message, title, notification_id)
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    if requested_mode == "Home":
+        await panel.async_alarm_arm_home()
+    else:
+        await panel.async_alarm_arm_away()
+
+    api = XSenseBase.__new__(XSenseBase)
+    api.parse_get_state(
+        station,
+        {"safeMode": "Disarmed", "forceReason": []},
+    )
+    panel._handle_coordinator_update()
+
+    assert calls == [(requested_mode, "0")]
+    assert station.alarm_data["requestedSafeMode"] == requested_mode
+    assert panel._cancel_arm_request_timeout is not None
+    assert created == []
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        },
+    )
+    panel._handle_coordinator_update()
+
+    assert pending_force_arm_mode(station) == requested_mode
+    assert panel._cancel_arm_request_timeout is None
+    assert cancelled == [True]
+    assert len(created) == 1
+    assert f"mode={requested_mode}" in created[0][0]
+
+    api.parse_get_state(station, {"safeMode": "Disarmed", "forceReason": []})
+    panel._handle_coordinator_update()
+
+    assert pending_force_arm_mode(station) == requested_mode
+    assert len(created) == 1
+
+    await panel.async_force_arm(requested_mode)
+
+    assert calls == [(requested_mode, "0"), (requested_mode, "1")]
+    assert pending_force_arm_mode(station) is None
+
+
 async def test_normal_arm_is_noop_when_station_already_reports_target_mode(
     monkeypatch,
 ):
@@ -1287,6 +1366,33 @@ def test_force_arm_prompt_uses_matching_notice_during_local_request():
     assert station.alarm_data["exitDelay"] == "0"
 
 
+def test_force_arm_prompt_uses_unscoped_notice_during_local_request():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Home"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "notices": [
+                {
+                    "type": "SKP0A",
+                    "eventParam": {
+                        "forceReason": [{"deviceSN": "door-sn"}],
+                        "exitDelay": "0",
+                    },
+                }
+            ],
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Home"
+    assert station.alarm_data["safeModeAim"] == "Home"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+
+
 def test_force_arm_prompt_ignores_notice_for_different_local_request():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
@@ -1312,6 +1418,36 @@ def test_force_arm_prompt_ignores_notice_for_different_local_request():
     assert pending_force_arm_mode(station) is None
     assert station.alarm_data.get("forceReason") is None
     assert station.alarm_data["requestedSafeMode"] == "Home"
+
+
+def test_empty_force_reason_ack_keeps_normal_arm_request_for_blocked_result():
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({"requestedSafeMode": "Away"})
+    api = XSenseBase.__new__(XSenseBase)
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [],
+        },
+    )
+
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data["requestedSafeMode"] == "Away"
+
+    api.parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        },
+    )
+
+    assert pending_force_arm_mode(station) == "Away"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
 
 
 def test_force_arm_prompt_does_not_return_after_request_is_cleared():
@@ -1365,7 +1501,7 @@ def test_successful_normal_arm_ignores_stale_force_reason():
     assert station.alarm_data["requestedSafeMode"] is None
 
 
-def test_empty_force_arm_reason_clears_pending_request_without_mode_change():
+def test_empty_force_arm_reason_does_not_dismiss_active_prompt():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data(
@@ -1379,8 +1515,9 @@ def test_empty_force_arm_reason_clears_pending_request_without_mode_change():
 
     api.parse_get_state(station, {"forceReason": []})
 
-    assert pending_force_arm_mode(station) is None
-    assert station.alarm_data["requestedSafeMode"] is None
+    assert pending_force_arm_mode(station) == "Home"
+    assert station.alarm_data["requestedSafeMode"] == "Home"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
 
 
 def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve pending Home and Away requests through empty SBS50 acknowledgements
- keep an active force-arm prompt from being dismissed by routine station updates
- retain the existing 60-second request timeout and prompt-free direct force-arm actions
- prepare the v1.4.20.8 prerelease metadata

## Verification
- compared against the APK 1400 SBS50 mode-result lifecycle
- 934 tests passed on Windows
- 934 tests passed on Linux with Python 3.14
- compile, frontend syntax, and diff checks passed