### PR TITLE
Stop recording refreshes from creating camera motion events

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.8):
-  (e.g., 1.4.20.8)
+- **X-Sense-Integration Version** (z. B. 1.4.20.9):
+  (e.g., 1.4.20.9)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.9.md
+++ b/.github/release-notes/1.4.20.9.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.9
+
+### 📷 Camera Events
+- Stops recording-library refreshes from appearing as new motion every minute.
+- Keeps camera recordings separate from real-time motion and AI detection events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.9](.github/release-notes/1.4.20.9.md)
 - [1.4.20.8](.github/release-notes/1.4.20.8.md)
 - [1.4.20.7](.github/release-notes/1.4.20.7.md)
 - [1.4.20.6](.github/release-notes/1.4.20.6.md)

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
-import hashlib
 import json
 from typing import Any
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, EVENT_HOMEASSISTANT_STARTED
@@ -22,15 +20,11 @@ from homeassistant.util.logging import catch_log_exception
 from .python_xsense import (
     AsyncXSense,
     House,
-    camera_addx_serial,
     camera_matches_identifier,
 )
 from .python_xsense.async_xsense import is_camera_entity
 from .python_xsense.event_parser import (
     camera_ai_history_event_key as _camera_ai_history_event_key,
-    camera_event_history_event_key as _camera_event_history_event_key,
-    camera_event_history_records as _camera_event_history_records,
-    camera_event_history_station_data as _camera_event_history_station_data,
     is_presence_topic as _is_presence_topic,
     is_self_test_topic as _is_self_test_topic,
     mqtt_identifier_candidates as _mqtt_identifier_candidates,
@@ -76,8 +70,6 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_camera_update_attempt: datetime | None = None
         self._camera_station_cache: dict[str, Any] = {}
         self._camera_ai_history_seen: set[str] = set()
-        self._camera_event_history_initialized = False
-        self._camera_event_history_last_poll: int | None = None
         self._camera_ai_service_houses: dict[str, set[str]] = {}
         self._camera_ai_history_unsub = None
         self._camera_ai_history_lock = asyncio.Lock()
@@ -503,7 +495,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             updated = await self._update_camera_ai_service_history(server_ids)
 
-        return await self._update_camera_event_history(cameras) or updated
+        return updated
 
     async def _update_camera_ai_service_history(self, server_ids: list[str]) -> bool:
         """Poll APK AI service history for camera events."""
@@ -563,81 +555,6 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         return applied > 0
 
-    async def _update_camera_event_history(self, cameras: list[Any]) -> bool:
-        """Poll APK ADDX camera record history for regular motion events."""
-        serial_numbers = [camera_addx_serial(camera) for camera in cameras]
-        serial_numbers = [serial for serial in serial_numbers if serial]
-        if not serial_numbers:
-            LOGGER.debug(
-                "X-Sense camera record history poll skipped: no serial numbers"
-            )
-            return False
-
-        first_poll = not getattr(self, "_camera_event_history_initialized", False)
-        applied = 0
-        baselined = 0
-        skipped = 0
-        seen_now: set[str] = set()
-        now = int(datetime.now(timezone.utc).timestamp())
-        start_timestamp, end_timestamp = _apk_camera_history_day_window(self, now)
-        try:
-            history = await self.xsense.get_camera_event_history_for_cameras(
-                cameras,
-                start_timestamp,
-                end_timestamp,
-            )
-        except APIFailure as ex:
-            LOGGER.debug("Could not update X-Sense camera record history: %s", ex)
-            return False
-
-        self._camera_event_history_initialized = True
-        self._camera_event_history_last_poll = now
-
-        records = _camera_event_history_records(history)
-        for record in reversed(records):
-            event_key = _camera_event_history_event_key(record)
-            if first_poll:
-                station_data = _camera_event_history_station_data(record)
-                station = (
-                    _camera_station_for_event_data(self, station_data, record)
-                    if station_data
-                    else None
-                )
-                if station is not None:
-                    seen_now.add(event_key)
-                    baselined += 1
-                else:
-                    LOGGER.debug(
-                        "X-Sense camera record history item was not applied: %s",
-                        _camera_record_history_debug_context(record, event_key),
-                    )
-                continue
-            if event_key in self._camera_ai_history_seen and not first_poll:
-                skipped += 1
-                continue
-            if self._apply_camera_event_history_item(record):
-                applied += 1
-                seen_now.add(event_key)
-            else:
-                LOGGER.debug(
-                    "X-Sense camera record history item was not applied: %s",
-                    _camera_record_history_debug_context(record, event_key),
-                )
-
-        self._camera_ai_history_seen.update(seen_now)
-        LOGGER.debug(
-            "X-Sense camera record history poll: cameras=%s records=%s seen=%s applied=%s baselined=%s skipped=%s first_poll=%s window_s=%s",
-            len(serial_numbers),
-            len(records),
-            len(self._camera_ai_history_seen),
-            applied,
-            baselined,
-            skipped,
-            first_poll,
-            end_timestamp - start_timestamp,
-        )
-        return applied > 0
-
     def _apply_camera_ai_history_item(
         self, server_id: str, alarm_item: dict[str, Any]
     ) -> bool:
@@ -666,35 +583,6 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         LOGGER.debug(
             "X-Sense camera AI history event routed: %s",
-            {
-                "station_type": station.type,
-                "station_data_keys": sorted(str(key) for key in station_data),
-                "has_ai_detection": "lastAiDetection" in station_data,
-                "has_motion_event_time": "eventTime" in station_data,
-            },
-        )
-        self.xsense.parse_get_state(station, station_data)
-        return True
-
-    def _apply_camera_event_history_item(self, record: dict[str, Any]) -> bool:
-        """Apply one APK ADDX camera record to the matching camera entity."""
-        station_data = _camera_event_history_station_data(record)
-        if not station_data:
-            return False
-
-        station = _camera_station_for_event_data(self, station_data, record)
-        if station is None:
-            LOGGER.debug(
-                "No X-Sense camera found for record history item: %s",
-                {
-                    "payload_keys": sorted(str(key) for key in record),
-                    "station_data_keys": sorted(str(key) for key in station_data),
-                },
-            )
-            return False
-
-        LOGGER.debug(
-            "X-Sense camera record history item routed: %s",
             {
                 "station_type": station.type,
                 "station_data_keys": sorted(str(key) for key in station_data),
@@ -1127,50 +1015,6 @@ def _set_camera_ai_service_available(cameras: list[Any], available: bool) -> Non
         data = getattr(camera, "data", None)
         if isinstance(data, dict):
             data[CAMERA_AI_SERVICE_AVAILABLE] = available
-
-
-def _apk_camera_history_day_window(
-    coordinator: XSenseDataUpdateCoordinator, now: int
-) -> tuple[int, int]:
-    """Return the local calendar-day epoch window used by the X-Sense app."""
-    time_zone = "UTC"
-    hass = getattr(coordinator, "hass", None)
-    config = getattr(hass, "config", None)
-    if configured_time_zone := getattr(config, "time_zone", None):
-        time_zone = configured_time_zone
-    try:
-        zone = ZoneInfo(time_zone)
-    except ZoneInfoNotFoundError:
-        zone = timezone.utc
-    local_now = datetime.fromtimestamp(now, zone)
-    day_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
-    next_day_start = day_start + timedelta(days=1)
-    start_timestamp = int(day_start.timestamp())
-    return start_timestamp, int(next_day_start.timestamp())
-
-
-def _camera_record_history_debug_context(
-    record: dict[str, Any], event_key: str
-) -> dict[str, Any]:
-    """Return redacted debug context for one ADDX camera history record."""
-    timestamp = record.get("timestamp") or record.get("startTime") or record.get("date")
-    return {
-        "event_key_hash": hashlib.sha256(event_key.encode()).hexdigest()[:12],
-        "record_keys": sorted(str(key) for key in record),
-        "serial_present": bool(
-            record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
-        ),
-        "trace_present": bool(record.get("traceId") or record.get("traceIds")),
-        "timestamp": timestamp,
-        "tags_present": "tags" in record,
-        "video_event_present": "videoEvent" in record,
-        "video_url_present": bool(record.get("videoUrl")),
-        "start_time_present": record.get("startTime") not in (None, ""),
-        "end_time_present": record.get("endTime") not in (None, ""),
-        "event_info_count": len(record.get("eventInfoList") or [])
-        if isinstance(record.get("eventInfoList"), list)
-        else None,
-    }
 
 
 def _camera_station_for_event_data(

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.8"
+PANEL_ASSET_VERSION = "1.4.20.9"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.8",
+  "version": "1.4.20.9",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -11,7 +11,6 @@ from .base import XSenseBase, _apply_sbs50_force_arm_prompt, shadow_update_body
 from .entity import Entity
 from .entity_map import EntityType
 from .exceptions import SessionExpired, APIFailure, XSenseError
-from .event_parser import camera_event_history_is_event_record
 from .house import House
 from .mapping import bool_state
 from .station import Station
@@ -556,7 +555,7 @@ class AsyncXSense(XSenseBase):
         data = await self.ai_service_call("701008", **payload)
         return data if isinstance(data, dict) else {}
 
-    async def get_camera_event_history(
+    async def get_camera_library_history(
         self,
         serial_numbers: list[str],
         start_timestamp: int,
@@ -587,7 +586,7 @@ class AsyncXSense(XSenseBase):
         )
         return data if isinstance(data, dict) else {}
 
-    async def get_camera_event_history_for_cameras(
+    async def get_camera_library_history_for_cameras(
         self,
         cameras: list[Entity],
         start_timestamp: int,
@@ -596,33 +595,25 @@ class AsyncXSense(XSenseBase):
         start: int = 0,
         limit: int = 20,
     ) -> dict:
-        """Return camera records through each camera's APK ADDX Home context."""
-        requests: list[tuple[Entity, House | None, list[str]]] = []
+        """Return APK playback-library rows in each camera's ADDX Home context."""
+        records: list[dict[str, Any]] = []
+        first_error: APIFailure | None = None
+        successful_requests = 0
         seen_cameras: set[str] = set()
         for camera in cameras:
-            serials = [
-                serial
-                for serial in _camera_addx_serial_candidates(camera)
-                if serial
-            ]
+            serials = _camera_addx_serial_candidates(camera)
             if not serials:
                 continue
             camera_key = _normalized_camera_serial(serials[0]) or serials[0]
             if camera_key in seen_cameras:
                 continue
             seen_cameras.add(camera_key)
-            requests.append((camera, self._camera_addx_house(camera), serials))
-
-        records: list[dict[str, Any]] = []
-        first_error: APIFailure | None = None
-        successful_requests = 0
-        for camera, house, serials in requests:
+            house = self._camera_addx_house(camera)
             camera_request_succeeded = False
             accepted_serial = None
-            # The APK's event endpoint is authoritative for motion history.
             for serial_index, serial in enumerate(serials):
                 try:
-                    history = await self.get_camera_event_record_history(
+                    history = await self.get_camera_library_history(
                         [serial],
                         start_timestamp,
                         end_timestamp,
@@ -634,7 +625,7 @@ class AsyncXSense(XSenseBase):
                     if first_error is None:
                         first_error = err
                     LOGGER.debug(
-                        "X-Sense camera record history unavailable: %s",
+                        "X-Sense camera playback-library history unavailable: %s",
                         {
                             "identity_index": serial_index,
                             "identity_count": len(serials),
@@ -642,7 +633,6 @@ class AsyncXSense(XSenseBase):
                         },
                     )
                     continue
-
                 camera_request_succeeded = True
                 data = (
                     history.get("data")
@@ -652,69 +642,17 @@ class AsyncXSense(XSenseBase):
                 group_records = data.get("list") if isinstance(data, dict) else None
                 if not isinstance(group_records, list) or not group_records:
                     continue
-
                 matching_records = [
                     record
                     for record in group_records
                     if isinstance(record, dict)
                     and _camera_history_record_matches_serial(record, serial)
-                    and camera_event_history_is_event_record(record)
                 ]
                 if not matching_records:
                     continue
                 accepted_serial = serial
                 records.extend(matching_records)
                 break
-
-            # Some accounts expose event recordings only through the general
-            # library endpoint. Accept those rows only when the payload itself
-            # identifies an event; ordinary playback rows must never become
-            # Home Assistant motion events.
-            if accepted_serial is None:
-                for serial_index, serial in enumerate(serials):
-                    try:
-                        history = await self.get_camera_event_history(
-                            [serial],
-                            start_timestamp,
-                            end_timestamp,
-                            house=house,
-                            start=start,
-                            limit=limit,
-                        )
-                    except APIFailure as err:
-                        if first_error is None:
-                            first_error = err
-                        LOGGER.debug(
-                            "X-Sense camera playback-library history unavailable: %s",
-                            {
-                                "identity_index": serial_index,
-                                "identity_count": len(serials),
-                                "error_type": type(err).__name__,
-                            },
-                        )
-                        continue
-
-                    camera_request_succeeded = True
-                    data = (
-                        history.get("data")
-                        if isinstance(history.get("data"), dict)
-                        else history
-                    )
-                    group_records = data.get("list") if isinstance(data, dict) else None
-                    if not isinstance(group_records, list) or not group_records:
-                        continue
-
-                    matching_records = [
-                        record for record in group_records if isinstance(record, dict)
-                        and _camera_history_record_matches_serial(record, serial)
-                        and camera_event_history_is_event_record(record)
-                    ]
-                    if not matching_records:
-                        continue
-                    accepted_serial = serial
-                    records.extend(matching_records)
-                    break
-
             if accepted_serial is not None:
                 camera.set_data(
                     {
@@ -722,10 +660,8 @@ class AsyncXSense(XSenseBase):
                         "addxSerialNumber": accepted_serial,
                     }
                 )
-
             if camera_request_succeeded:
                 successful_requests += 1
-
         if successful_requests == 0 and first_error is not None:
             raise first_error
         return {"list": records, "total": len(records)}

--- a/custom_components/xsense/python_xsense/event_parser.py
+++ b/custom_components/xsense/python_xsense/event_parser.py
@@ -94,12 +94,9 @@ __all__ = [
     "apply_apk_dispatch_aliases",
     "apply_apk_event_aliases",
     "camera_ai_history_event_key",
-    "camera_event_history_event_key",
-    "camera_event_history_is_event_record",
     "camera_event_history_playback_data",
     "camera_event_history_playback_source",
-    "camera_event_history_records",
-    "camera_event_history_station_data",
+    "camera_library_records",
     "camera_event_history_time",
     "camera_playback_epoch_seconds",
     "latest_apk_detection_time",
@@ -313,86 +310,13 @@ def camera_ai_history_event_key(server_id: str, alarm_item: dict[str, Any]) -> s
     return f"{server_id}:{payload}"
 
 
-def camera_event_history_records(history: dict[str, Any]) -> list[dict[str, Any]]:
-    """Return ADDX camera event records from the APK event-history response."""
+def camera_library_records(history: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return ADDX recording rows from the APK playback-library response."""
     data = history.get("data") if isinstance(history.get("data"), dict) else history
     records = data.get("list") if isinstance(data, dict) else None
     if not isinstance(records, list):
         return []
     return [record for record in records if isinstance(record, dict)]
-
-
-def camera_event_history_event_key(record: dict[str, Any]) -> str:
-    """Return a stable key for one APK ADDX camera event record."""
-    serial = record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
-    timestamp = record.get("timestamp") or record.get("startTime") or record.get("date")
-    # Playback traces can be refreshed while the physical event remains unchanged.
-    if serial and timestamp:
-        return f"camera-event:{serial}:{timestamp}"
-    trace = record.get("traceId") or record.get("traceIds")
-    if serial and trace:
-        return f"camera-event:{serial}:{trace}"
-    payload = json.dumps(
-        record,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    )
-    return f"camera-event:{payload}"
-
-
-def camera_event_history_is_event_record(record: dict[str, Any]) -> bool:
-    """Return whether an APK library row is explicitly classified as an event."""
-    return any(
-        value not in (None, "", [], {})
-        for value in (
-            record.get("videoEvent"),
-            record.get("tags"),
-            record.get("eventInfoList"),
-        )
-    )
-
-
-def camera_event_history_station_data(record: dict[str, Any]) -> dict[str, Any]:
-    """Return normal camera state keys from an APK ADDX event-history record."""
-    serial = record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
-    if not serial or not camera_event_history_is_event_record(record):
-        return {}
-
-    timestamp = record.get("timestamp") or record.get("startTime")
-    event_time = camera_event_history_time(timestamp)
-    data: dict[str, Any] = {
-        "serialNumber": serial,
-        "deviceSN": serial,
-        "eventType": record.get("videoEvent") or record.get("tags"),
-        "eventItems": record.get("eventInfoList"),
-        "eventObjectType": record.get("eventInfoList") or record.get("tags"),
-        "lastType": record.get("videoEvent") or record.get("tags"),
-    }
-    if event_time:
-        data["time"] = event_time
-        data["eventTime"] = event_time
-
-    if playback := camera_event_history_playback_data(record):
-        data["playback"] = playback
-        event_image_url = playback.get("image_url")
-        event_package_image_url = playback.get("package_image_url")
-        event_image_time = (
-            playback.get("timestamp_s")
-            or playback.get("start_time_s")
-            or playback.get("timestamp")
-            or playback.get("start_time")
-        )
-        if event_image_url:
-            data["lastEventImageUrl"] = event_image_url
-        if event_package_image_url:
-            data["lastEventPackageImageUrl"] = event_package_image_url
-        if event_image_time is not None:
-            data["lastEventImageTime"] = event_image_time
-
-    apply_apk_event_aliases(data)
-    return data
 
 
 def camera_event_history_playback_data(record: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -56,7 +56,7 @@ from .const import (
 )
 from .python_xsense.event_parser import (
     camera_event_history_playback_data,
-    camera_event_history_records,
+    camera_library_records,
 )
 
 MIME_TYPE = "video/mp4"
@@ -1837,13 +1837,13 @@ class XSenseRecordingIndex:
 
         end = datetime.now(timezone.utc)
         start = end - timedelta(days=RECORDING_LOOKBACK_DAYS)
-        history = await self.coordinator.xsense.get_camera_event_history_for_cameras(
+        history = await self.coordinator.xsense.get_camera_library_history_for_cameras(
             camera_entities,
             int(start.timestamp()),
             int(end.timestamp()),
             limit=RECORDING_PAGE_LIMIT,
         )
-        records = camera_event_history_records(history)
+        records = camera_library_records(history)
         clips_by_serial: dict[str, list[dict[str, Any]]] = {serial: [] for serial in serials}
         media_root = _recording_media_root(self.hass, self.entry_id)
         for record in records:

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5082,7 +5082,7 @@ async def test_ai_service_history_uses_apk_701008_server_id():
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_uses_apk_addx_library_record_path():
+async def test_camera_library_history_uses_apk_addx_library_record_path():
     client = async_xsense.AsyncXSense()
     calls = []
 
@@ -5092,7 +5092,7 @@ async def test_camera_event_history_uses_apk_addx_library_record_path():
 
     client.addx_call = addx_call
 
-    data = await client.get_camera_event_history(
+    data = await client.get_camera_library_history(
         ["camera-sn"],
         1781484300,
         1781487900,
@@ -5116,7 +5116,7 @@ async def test_camera_event_history_uses_apk_addx_library_record_path():
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_uses_requested_addx_home():
+async def test_camera_library_history_uses_requested_addx_home():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-2", mqtt_region="eu-west-1")
     calls = []
@@ -5127,7 +5127,7 @@ async def test_camera_event_history_uses_requested_addx_home():
 
     client.addx_call = addx_call
 
-    await client.get_camera_event_history(
+    await client.get_camera_library_history(
         ["camera-sn"],
         1781484300,
         1781487900,
@@ -5138,7 +5138,7 @@ async def test_camera_event_history_uses_requested_addx_home():
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_groups_cameras_by_addx_home():
+async def test_camera_library_history_groups_cameras_by_addx_home():
     client = async_xsense.AsyncXSense()
     house_1 = SimpleNamespace(house_id="house-1", mqtt_region="us-east-1")
     house_2 = SimpleNamespace(house_id="house-2", mqtt_region="eu-west-1")
@@ -5163,9 +5163,9 @@ async def test_camera_event_history_groups_cameras_by_addx_home():
         calls.append((serials, kwargs["house"]))
         return {"list": [{"serialNumber": serials[0], "videoEvent": "motion"}]}
 
-    client.get_camera_event_record_history = get_history
+    client.get_camera_library_history = get_history
 
-    result = await client.get_camera_event_history_for_cameras(
+    result = await client.get_camera_library_history_for_cameras(
         [camera_1, camera_2], 1781484300, 1781487900
     )
 
@@ -5180,7 +5180,7 @@ async def test_camera_event_history_groups_cameras_by_addx_home():
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_queries_each_camera_without_shared_page_limit():
+async def test_camera_library_history_queries_each_camera_without_shared_page_limit():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="us-east-1")
     client.houses = {"house-1": house}
@@ -5200,9 +5200,9 @@ async def test_camera_event_history_queries_each_camera_without_shared_page_limi
         calls.append((serials, kwargs["house"], kwargs["limit"]))
         return {"list": [{"serialNumber": serials[0], "videoEvent": "motion"}]}
 
-    client.get_camera_event_record_history = get_history
+    client.get_camera_library_history = get_history
 
-    result = await client.get_camera_event_history_for_cameras(
+    result = await client.get_camera_library_history_for_cameras(
         cameras, 1781484300, 1781487900, limit=25
     )
 
@@ -5214,7 +5214,7 @@ async def test_camera_event_history_queries_each_camera_without_shared_page_limi
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_tries_apk_identity_alias_after_empty_result():
+async def test_camera_library_history_tries_apk_identity_alias_after_empty_result():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
     client.houses = {"house-1": house}
@@ -5241,9 +5241,9 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
             }
         return {"list": []}
 
-    client.get_camera_event_record_history = get_history
+    client.get_camera_library_history = get_history
 
-    result = await client.get_camera_event_history_for_cameras(
+    result = await client.get_camera_library_history_for_cameras(
         [camera], 1781484300, 1781487900
     )
 
@@ -5260,61 +5260,7 @@ async def test_camera_event_history_tries_apk_identity_alias_after_empty_result(
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_prefers_apk_event_library():
-    client = async_xsense.AsyncXSense()
-    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
-    client.houses = {"house-1": house}
-    updates = []
-    camera = SimpleNamespace(
-        sn="camera-label",
-        entity_id="camera-access-id",
-        data={"addxSerialNumber": "camera-list-id"},
-        house=house,
-        set_data=lambda data: updates.append(data),
-    )
-    calls = []
-
-    async def get_history(serials, start_timestamp, end_timestamp, **kwargs):
-        calls.append(("playback", serials, kwargs["house"]))
-        return {"list": []}
-
-    async def get_event_history(serials, start_timestamp, end_timestamp, **kwargs):
-        calls.append(("event", serials, kwargs["house"]))
-        if serials == ["camera-access-id"]:
-            return {
-                "list": [
-                    {
-                        "serialNumber": "camera-access-id",
-                        "videoEvent": "motion",
-                    }
-                ]
-            }
-        return {"list": []}
-
-    client.get_camera_event_history = get_history
-    client.get_camera_event_record_history = get_event_history
-
-    result = await client.get_camera_event_history_for_cameras(
-        [camera], 1781484300, 1781487900
-    )
-
-    assert calls == [
-        ("event", ["camera-list-id"], house),
-        ("event", ["camera-access-id"], house),
-    ]
-    assert result["list"] == [
-        {"serialNumber": "camera-access-id", "videoEvent": "motion"}
-    ]
-    assert updates == [
-        {
-            "addxAccessSerialNumber": "camera-access-id",
-            "addxSerialNumber": "camera-access-id",
-        }
-    ]
-
-
-@pytest.mark.asyncio
-async def test_camera_event_history_fallback_rejects_unclassified_playback_rows():
+async def test_camera_library_history_keeps_playback_rows_separate_from_events():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
     client.houses = {"house-1": house}
@@ -5325,9 +5271,6 @@ async def test_camera_event_history_fallback_rejects_unclassified_playback_rows(
         house=house,
         set_data=lambda data: None,
     )
-
-    async def get_event_history(*args, **kwargs):
-        return {"list": []}
 
     async def get_playback_history(*args, **kwargs):
         return {
@@ -5340,47 +5283,9 @@ async def test_camera_event_history_fallback_rejects_unclassified_playback_rows(
             ]
         }
 
-    client.get_camera_event_record_history = get_event_history
-    client.get_camera_event_history = get_playback_history
+    client.get_camera_library_history = get_playback_history
 
-    result = await client.get_camera_event_history_for_cameras(
-        [camera], 1781484300, 1781487900
-    )
-
-    assert result == {"list": [], "total": 0}
-
-
-@pytest.mark.asyncio
-async def test_camera_event_history_fallback_accepts_explicit_event_rows():
-    client = async_xsense.AsyncXSense()
-    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
-    client.houses = {"house-1": house}
-    camera = SimpleNamespace(
-        sn="camera-sn",
-        entity_id="camera-sn",
-        data={},
-        house=house,
-        set_data=lambda data: None,
-    )
-
-    async def get_event_history(*args, **kwargs):
-        return {"list": []}
-
-    async def get_playback_history(*args, **kwargs):
-        return {
-            "list": [
-                {
-                    "serialNumber": "camera-sn",
-                    "timestamp": 1781484300,
-                    "videoEvent": "motion",
-                }
-            ]
-        }
-
-    client.get_camera_event_record_history = get_event_history
-    client.get_camera_event_history = get_playback_history
-
-    result = await client.get_camera_event_history_for_cameras(
+    result = await client.get_camera_library_history_for_cameras(
         [camera], 1781484300, 1781487900
     )
 
@@ -5389,7 +5294,7 @@ async def test_camera_event_history_fallback_accepts_explicit_event_rows():
             {
                 "serialNumber": "camera-sn",
                 "timestamp": 1781484300,
-                "videoEvent": "motion",
+                "videoUrl": "https://example.invalid/ordinary.m3u8",
             }
         ],
         "total": 1,
@@ -5397,7 +5302,7 @@ async def test_camera_event_history_fallback_accepts_explicit_event_rows():
 
 
 @pytest.mark.asyncio
-async def test_camera_event_history_does_not_cross_route_two_camera_rows():
+async def test_camera_library_history_does_not_cross_route_two_camera_rows():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
     client.houses = {"house-1": house}
@@ -5424,13 +5329,9 @@ async def test_camera_event_history_does_not_cross_route_two_camera_rows():
             ]
         }
 
-    async def get_playback_history(*args, **kwargs):
-        return {"list": []}
+    client.get_camera_library_history = get_event_history
 
-    client.get_camera_event_record_history = get_event_history
-    client.get_camera_event_history = get_playback_history
-
-    result = await client.get_camera_event_history_for_cameras(
+    result = await client.get_camera_library_history_for_cameras(
         cameras, 1781484300, 1781487900
     )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,10 +1,8 @@
 import asyncio
-from datetime import datetime, timezone
 import inspect
 import json
 import logging
 from types import SimpleNamespace
-from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -1884,11 +1882,10 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
                 "alarmItems": items
             }
 
-        async def get_camera_event_history_for_cameras(
-            self, cameras, start_timestamp, end_timestamp
+        async def get_camera_library_history_for_cameras(
+            self, *args, **kwargs
         ):
-            assert cameras == [house.stations["camera-id"]]
-            return {}
+            raise AssertionError("recording history must not drive live motion")
 
         def parse_get_state(self, station_arg, data):
             parsed.append((station_arg, data))
@@ -1916,320 +1913,27 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
     assert updates == []
 
 
-async def test_camera_event_history_routes_motion_when_ai_service_list_is_empty():
-    from custom_components.xsense.const import CAMERA_AI_SERVICE_AVAILABLE
+async def test_camera_ai_history_does_not_poll_recording_library():
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
 
-    class Camera:
-        sn = "camera-sn"
-        type = "SSC0A"
-        shadow_name = "SSC0Acamera-sn"
-
-        def __init__(self):
-            self.data = {"addxSerialNumber": "addx-camera-id"}
-
-        def get_device_by_sn(self, _identifier):
-            return None
-
-        def set_data(self, data):
-            self.data.update(data)
-
-    class House:
-        stations = {"camera-id": Camera()}
-
-        def get_station_by_sn(self, identifier):
-            camera = self.stations["camera-id"]
-            return camera if identifier == camera.sn else None
-
-    parsed = []
-    house = House()
+    camera = SimpleNamespace(type="SSC0A", data={})
+    house = SimpleNamespace(stations={"camera-id": camera})
 
     class Client:
         houses = {"house-id": house}
 
-        def __init__(self):
-            self.history_calls = 0
-
         async def get_ai_service_list(self):
             return []
 
-        async def get_camera_event_history_for_cameras(
-            self, cameras, start_timestamp, end_timestamp
-        ):
-            assert cameras == [house.stations["camera-id"]]
-            assert end_timestamp > start_timestamp
-            self.history_calls += 1
-            records = [
-                {
-                    "serialNumber": "addx-camera-id",
-                    "timestamp": 1781478300,
-                    "startTime": 1781478300,
-                    "endTime": 1781478310,
-                    "traceId": (
-                        "refreshed-trace-id" if self.history_calls > 2 else "trace-id"
-                    ),
-                    "imageUrl": "https://example.invalid/event.jpg",
-                    "packageImageUrl": "https://example.invalid/package.jpg",
-                    "tags": "motion",
-                }
-            ]
-            if self.history_calls > 1:
-                records.insert(
-                    0,
-                    {
-                        "serialNumber": "addx-camera-id",
-                        "timestamp": 1781478360,
-                        "startTime": 1781478360,
-                        "endTime": 1781478370,
-                        "traceId": (
-                            "refreshed-new-trace-id"
-                            if self.history_calls > 2
-                            else "new-trace-id"
-                        ),
-                        "imageUrl": "https://example.invalid/new-event.jpg",
-                        "packageImageUrl": "https://example.invalid/new-package.jpg",
-                        "tags": "motion",
-                    },
-                )
-            return {
-                "list": records
-            }
-
-        def parse_get_state(self, station_arg, data):
-            parsed.append((station_arg, data))
-            station_arg.set_data(data)
-
-    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
-    coordinator.xsense = Client()
-    coordinator._camera_ai_history_seen = set()
-    coordinator._camera_event_history_initialized = False
-    coordinator._camera_event_history_last_poll = None
-    coordinator._camera_ai_history_lock = asyncio.Lock()
-
-    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-    assert parsed == []
-    assert await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-
-    assert parsed[0][0] is house.stations["camera-id"]
-    assert parsed[0][1]["eventTime"] == "20260614230600"
-    assert parsed[0][1]["playback"] == {
-        "trace_id": "new-trace-id",
-        "start_time": 1781478360,
-        "start_time_s": 1781478360,
-        "end_time": 1781478370,
-        "end_time_s": 1781478370,
-        "timestamp": 1781478360,
-        "timestamp_s": 1781478360,
-        "image_url": "https://example.invalid/new-event.jpg",
-        "package_image_url": "https://example.invalid/new-package.jpg",
-        "tags": "motion",
-    }
-    assert parsed[0][1]["lastEventImageUrl"] == (
-        "https://example.invalid/new-event.jpg"
-    )
-    assert parsed[0][1]["lastEventPackageImageUrl"] == (
-        "https://example.invalid/new-package.jpg"
-    )
-    assert parsed[0][1]["lastEventImageTime"] == 1781478360
-    assert house.stations["camera-id"].data[CAMERA_AI_SERVICE_AVAILABLE] is False
-    assert "isMoved" not in parsed[0][1]
-    assert "lastMotionTime" not in parsed[0][1]
-    assert len(parsed) == 1
-    assert coordinator._camera_event_history_initialized is True
-    assert coordinator._camera_event_history_last_poll is not None
-
-
-async def test_camera_event_history_keeps_apk_calendar_day_window():
-    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
-
-    class Camera:
-        sn = "camera-sn"
-        type = "SSC0A"
-        shadow_name = "SSC0Acamera-sn"
-        data = {"addxSerialNumber": "camera-sn"}
-
-        def get_device_by_sn(self, _identifier):
-            return None
-
-    class House:
-        stations = {"camera-id": Camera()}
-
-        def get_station_by_sn(self, _identifier):
-            return None
-
-    windows = []
-
-    class Client:
-        houses = {"house-id": House()}
-
-        async def get_ai_service_list(self):
-            return []
-
-        async def get_camera_event_history_for_cameras(
-            self, cameras, start_timestamp, end_timestamp
-        ):
-            windows.append((start_timestamp, end_timestamp))
-            return {"list": []}
-
-    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
-    coordinator.xsense = Client()
-    coordinator._camera_ai_history_seen = set()
-    coordinator._camera_event_history_initialized = False
-    coordinator._camera_event_history_last_poll = None
-    coordinator._camera_ai_history_lock = asyncio.Lock()
-
-    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-
-    assert windows[0][1] - windows[0][0] == 86400
-    assert windows[1] == windows[0]
-
-
-def test_camera_event_history_day_window_uses_home_assistant_time_zone():
-    from custom_components.xsense.coordinator import _apk_camera_history_day_window
-
-    coordinator = SimpleNamespace(
-        hass=SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Berlin"))
-    )
-
-    start, end = _apk_camera_history_day_window(coordinator, 1787927696)
-
-    assert datetime.fromtimestamp(start, timezone.utc).isoformat() == (
-        "2026-08-27T22:00:00+00:00"
-    )
-    assert end - start == 86400
-
-
-@pytest.mark.parametrize(
-    ("local_time", "expected_seconds"),
-    (
-        (datetime(2026, 3, 29, 12, tzinfo=ZoneInfo("Europe/Berlin")), 23 * 3600),
-        (datetime(2026, 10, 25, 12, tzinfo=ZoneInfo("Europe/Berlin")), 25 * 3600),
-    ),
-)
-def test_camera_event_history_day_window_tracks_dst_boundaries(
-    local_time, expected_seconds
-):
-    from custom_components.xsense.coordinator import _apk_camera_history_day_window
-
-    coordinator = SimpleNamespace(
-        hass=SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Berlin"))
-    )
-
-    start, end = _apk_camera_history_day_window(
-        coordinator, int(local_time.timestamp())
-    )
-
-    assert end - start == expected_seconds
-
-
-def test_camera_event_history_station_data_preserves_direct_video_url():
-    from custom_components.xsense.coordinator import (
-        _camera_event_history_station_data,
-    )
-
-    data = _camera_event_history_station_data(
-        {
-            "serialNumber": "camera-sn",
-            "timestamp": 1781478300,
-            "traceId": "trace-id",
-            "videoUrl": "https://example.invalid/clip.mp4",
-            "imageUrl": "https://example.invalid/still.jpg",
-            "videoEvent": "motion",
-        }
-    )
-
-    assert data["playback"] == {
-        "trace_id": "trace-id",
-        "video_url": "https://example.invalid/clip.mp4",
-        "image_url": "https://example.invalid/still.jpg",
-        "timestamp": 1781478300,
-        "timestamp_s": 1781478300,
-        "video_event": "motion",
-        "source": "video_url",
-    }
-
-
-def test_camera_event_history_station_data_normalizes_ms_playback_times():
-    from custom_components.xsense.coordinator import (
-        _camera_event_history_station_data,
-    )
-
-    data = _camera_event_history_station_data(
-        {
-            "serialNumber": "camera-sn",
-            "timestamp": 1781478300000,
-            "startTime": 1781478300000,
-            "endTime": 1781478310000,
-            "traceId": "trace-id",
-            "tags": "motion",
-        }
-    )
-
-    assert data["playback"]["start_time"] == 1781478300000
-    assert data["playback"]["start_time_s"] == 1781478300
-    assert data["playback"]["end_time"] == 1781478310000
-    assert data["playback"]["end_time_s"] == 1781478310
-    assert data["playback"]["timestamp"] == 1781478300000
-    assert data["playback"]["timestamp_s"] == 1781478300
-
-
-async def test_camera_event_history_does_not_mark_unapplied_records_seen(caplog):
-    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
-
-    class Camera:
-        sn = "camera-sn"
-        type = "SSC0A"
-        shadow_name = "SSC0Acamera-sn"
-
-        def get_device_by_sn(self, _identifier):
-            return None
-
-    class House:
-        stations = {"camera-id": Camera()}
-
-        def get_station_by_sn(self, identifier):
-            camera = self.stations["camera-id"]
-            return camera if identifier == camera.sn else None
-
-    class Client:
-        houses = {"house-id": House()}
-
-        async def get_ai_service_list(self):
-            return []
-
-        async def get_camera_event_history_for_cameras(
-            self, cameras, start_timestamp, end_timestamp
-        ):
-            assert cameras == [self.houses["house-id"].stations["camera-id"]]
-            return {
-                "list": [
-                    {
-                        "serialNumber": "other-camera-sn",
-                        "timestamp": 1781478300,
-                        "traceId": "trace-id",
-                        "tags": "motion",
-                    }
-                ]
-            }
-
-        def parse_get_state(self, station_arg, data):
-            raise AssertionError("unmatched record should not update station state")
+        async def get_camera_library_history_for_cameras(self, *args, **kwargs):
+            raise AssertionError("playback library must not drive live motion")
 
     coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
     coordinator.xsense = Client()
     coordinator._camera_ai_history_seen = set()
     coordinator._camera_ai_history_lock = asyncio.Lock()
 
-    caplog.set_level(logging.DEBUG, logger="custom_components.xsense")
-
     assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-    assert not await XSenseDataUpdateCoordinator._update_camera_ai_history(coordinator)
-
-    assert coordinator._camera_ai_history_seen == set()
-    assert "X-Sense camera record history item was not applied" in caplog.text
-    assert "X-Sense camera record history item skipped as duplicate" not in caplog.text
 
 
 async def test_camera_ai_history_timer_notifies_only_when_history_changes():
@@ -2318,40 +2022,6 @@ def test_mqtt_camera_ai_event_uses_last_ai_detection_with_event_time():
     assert data["eventTime"] == "20260614230300"
     assert "isMoved" not in data
     assert "lastMotionTime" not in data
-
-
-def test_camera_record_history_item_preserves_event_time_without_live_motion():
-    from custom_components.xsense.coordinator import _camera_event_history_station_data
-
-    data = _camera_event_history_station_data(
-        {
-            "serialNumber": "camera-sn",
-            "timestamp": 1782049304,
-            "traceId": "trace-id",
-            "videoEvent": "unknown",
-            "tags": ["unknown"],
-        }
-    )
-
-    assert data["serialNumber"] == "camera-sn"
-    assert data["eventTime"] == "20260621134144"
-    assert "isMoved" not in data
-    assert "lastMotionTime" not in data
-
-
-def test_camera_record_history_rejects_unclassified_playback_row():
-    from custom_components.xsense.coordinator import _camera_event_history_station_data
-
-    data = _camera_event_history_station_data(
-        {
-            "serialNumber": "camera-sn",
-            "timestamp": 1782049304,
-            "traceId": "trace-id",
-            "videoUrl": "https://example.invalid/ordinary.m3u8",
-        }
-    )
-
-    assert data == {}
 
 
 async def test_assure_subscriptions_includes_apk_ai_plan_topic():


### PR DESCRIPTION
## Summary
- keep recording playback on the APK library path
- remove the minute-based recording-to-motion poller
- keep live motion and AI events on their X-Sense event paths
- prepare the v1.4.20.9 prerelease

## Validation
- fork Tests passed on Python 3.13 and 3.14
- HACS and hassfest validation passed
- CodeQL passed
- 923 tests passed locally on Windows and Linux