### PR TITLE
Prepare v1.4.20.12 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.11):
-  (e.g., 1.4.20.11)
+- **X-Sense-Integration Version** (z. B. 1.4.20.12):
+  (e.g., 1.4.20.12)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.12.md
+++ b/.github/release-notes/1.4.20.12.md
@@ -1,0 +1,8 @@
+## X-Sense Home Security v1.4.20.12
+
+### 📷 Camera Motion and Recordings
+- Keeps motion, AI events, current images, and recordings tied to the correct physical camera when multiple cameras share internal labels.
+- Loads the latest camera image after startup without reporting an old recording as new motion or suppressing the next real event.
+- Refreshes older recording indexes using the current camera identity before serving them.
+
+Please test each camera's Motion sensor, event entities, current image, and recordings independently and report any remaining issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.12](.github/release-notes/1.4.20.12.md)
 - [1.4.20.11](.github/release-notes/1.4.20.11.md)
 - [1.4.20.10](.github/release-notes/1.4.20.10.md)
 - [1.4.20.9](.github/release-notes/1.4.20.9.md)

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -23,7 +23,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from webrtc_models import RTCIceCandidateInit
 
-from .python_xsense.async_xsense import camera_live_resolution, is_camera_entity
+from .python_xsense.async_xsense import (
+    camera_addx_serial,
+    camera_live_resolution,
+    cameras_share_identity,
+    is_camera_entity,
+)
 from .python_xsense.exceptions import APIFailure, SessionExpired
 from .const import DOMAIN, LOGGER
 from .coordinator import XSenseDataUpdateCoordinator
@@ -88,21 +93,22 @@ def _camera_entities(
     """Return X-Sense camera entities from station and device records."""
     entities: list[XSenseCameraEntity] = []
     seen_entity_ids: set[str] = set()
-    seen_camera_serials: set[str] = set()
+    seen_cameras: list = []
 
     for station in coordinator_stations(coordinator).values():
-        if is_camera_entity(station):
-            entities.append(_camera_entity(coordinator, station))
-            seen_entity_ids.add(station.entity_id)
-            if serial := _camera_serial(station):
-                seen_camera_serials.add(serial)
+        if not is_camera_entity(station) or any(
+            cameras_share_identity(station, seen) for seen in seen_cameras
+        ):
+            continue
+        entities.append(_camera_entity(coordinator, station))
+        seen_entity_ids.add(station.entity_id)
+        seen_cameras.append(station)
 
     for device in coordinator_devices(coordinator).values():
-        serial = _camera_serial(device)
         if (
             not is_camera_entity(device)
             or device.entity_id in seen_entity_ids
-            or (serial is not None and serial in seen_camera_serials)
+            or any(cameras_share_identity(device, seen) for seen in seen_cameras)
         ):
             continue
         entities.append(
@@ -110,6 +116,7 @@ def _camera_entities(
                 coordinator, device, station_id=DEVICE_ENTITY_WITHOUT_STATION
             )
         )
+        seen_cameras.append(device)
 
     return entities
 
@@ -130,9 +137,7 @@ def _camera_entity(
 
 def _camera_serial(entity) -> str | None:
     """Return a normalized camera serial for station/device de-duplication."""
-    serial = getattr(entity, "sn", None)
-    if serial is None:
-        serial = entity.data.get("serialNumber") if isinstance(entity.data, dict) else None
+    serial = camera_addx_serial(entity)
     normalized = str(serial or "").strip().upper()
     return normalized or None
 
@@ -140,7 +145,7 @@ def _camera_serial(entity) -> str | None:
 def _camera_entity_keys(entity: XSenseCameraEntity) -> set[str]:
     """Return stable keys used to avoid duplicate camera entity adds."""
     keys = {str(entity._dev_id).upper()}
-    serial = getattr(entity, "_entity_serial", None)
+    serial = getattr(entity, "_camera_identity", None)
     if serial:
         keys.add(str(serial).upper())
     return keys
@@ -162,6 +167,7 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         Camera.__init__(self)
         self.entity_description = entity_description
         self._last_camera_image: bytes | None = None
+        self._camera_identity = camera_addx_serial(entity)
         super().__init__(coordinator, entity, station_id=station_id)
 
     @callback
@@ -553,7 +559,7 @@ def _camera_webrtc_ticket_serial(entity, ticket_data) -> str:
         serial = ticket_data.get("serialNumber")
         if serial not in (None, ""):
             return str(serial)
-    return str(entity.sn)
+    return camera_addx_serial(entity)
 
 
 def _send_remote_candidate(send_message, entity, session_id, candidate) -> None:

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -20,7 +20,8 @@ from homeassistant.util.logging import catch_log_exception
 from .python_xsense import (
     AsyncXSense,
     House,
-    camera_matches_identifier,
+    camera_for_identifier,
+    cameras_share_identity,
 )
 from .python_xsense.async_xsense import is_camera_entity
 from .python_xsense.event_parser import (
@@ -370,6 +371,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 LOGGER.debug("X-Sense device state polling skipped during startup refresh")
 
             self._merge_cached_camera_stations(stations)
+            _deduplicate_camera_devices(stations, devices)
             LOGGER.debug(
                 "X-Sense coordinator refresh summary: stations=%s devices=%s camera_initialized=%s camera_cache=%s mqtt_servers=%s mqtt_connected=%s",
                 len(stations),
@@ -522,9 +524,10 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             alarm_items = history.get("alarmItems")
             if not isinstance(alarm_items, list):
                 continue
-            for alarm_item in reversed(alarm_items):
-                if not isinstance(alarm_item, dict):
-                    continue
+            for alarm_item in sorted(
+                (item for item in alarm_items if isinstance(item, dict)),
+                key=_camera_ai_history_sort_key,
+            ):
                 event_key = _camera_ai_history_event_key(server_id, alarm_item)
                 if first_poll:
                     payload = dict(alarm_item)
@@ -579,9 +582,12 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         baselined = 0
         skipped = 0
         seen_now: set[str] = set()
-        active_cameras: set[int] = set()
-        records = _camera_event_records(history)
-        for record in reversed(records):
+        active_cameras: list[Any] = []
+        baseline_changed = False
+        records = sorted(
+            _camera_event_records(history), key=_camera_event_record_sort_key
+        )
+        for record in records:
             event_key = _camera_event_record_event_key(record)
             station_data = _camera_event_record_station_data(record)
             station = (
@@ -594,19 +600,39 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             seen_now.add(event_key)
             if first_poll:
                 baselined += 1
+                if _camera_event_time_relation(station, station_data) < 0:
+                    continue
+                station_data["cameraMotionDetected"] = False
+                station_data["cameraEventBaseline"] = True
+                self.xsense.parse_get_state(station, station_data)
+                baseline_changed = True
                 continue
             if event_key in self._camera_event_history_seen:
                 skipped += 1
                 continue
+            time_relation = _camera_event_time_relation(station, station_data)
+            if time_relation < 0:
+                skipped += 1
+                continue
+            if time_relation == 0:
+                station_data["cameraMotionDetected"] = False
+                station_data["cameraEventBaseline"] = False
+                self.xsense.parse_get_state(station, station_data)
+                applied += 1
+                continue
             station_data["cameraMotionDetected"] = True
+            station_data["cameraEventBaseline"] = False
             self.xsense.parse_get_state(station, station_data)
-            active_cameras.add(id(station))
+            active_cameras.append(station)
             applied += 1
 
         self._camera_event_history_seen.update(seen_now)
         state_changed = False
         for camera in cameras:
-            detected = id(camera) in active_cameras
+            detected = any(
+                camera is active or cameras_share_identity(camera, active)
+                for active in active_cameras
+            )
             previous = (
                 getattr(camera, "data", {}).get("cameraMotionDetected") is True
             )
@@ -625,7 +651,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             skipped,
             first_poll,
         )
-        return applied > 0 or state_changed
+        return applied > 0 or state_changed or baseline_changed
 
     def _apply_camera_ai_history_item(
         self, server_id: str, alarm_item: dict[str, Any]
@@ -672,15 +698,66 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for station in house.stations.values():
                 if not is_camera_entity(station):
                     continue
-                previous = self._camera_station_cache.get(station.entity_id)
+                previous = next(
+                    (
+                        cached
+                        for cached in self._camera_station_cache.values()
+                        if cached is station
+                        or cameras_share_identity(cached, station)
+                    ),
+                    None,
+                )
                 if previous is not None:
                     _preserve_camera_event_image(previous, station)
-                refreshed_cache[station.entity_id] = station
+                duplicate = next(
+                    (
+                        cached
+                        for cached in refreshed_cache.values()
+                        if cameras_share_identity(cached, station)
+                    ),
+                    None,
+                )
+                if duplicate is None:
+                    refreshed_cache[station.entity_id] = station
+                else:
+                    _merge_camera_metadata(station, duplicate)
         self._camera_station_cache = refreshed_cache
 
     def _merge_cached_camera_stations(self, stations: dict[str, Any]) -> None:
         """Keep ADDX-only cameras present when the camera API refresh is skipped."""
-        stations.update(self._camera_station_cache)
+        canonical_cameras: list[Any] = []
+        for station_id, station in list(stations.items()):
+            if not is_camera_entity(station):
+                continue
+            existing = next(
+                (
+                    camera
+                    for camera in canonical_cameras
+                    if cameras_share_identity(camera, station)
+                ),
+                None,
+            )
+            if existing is None:
+                canonical_cameras.append(station)
+                continue
+            _merge_camera_metadata(station, existing)
+            stations.pop(station_id, None)
+
+        for cached_id, cached in self._camera_station_cache.items():
+            existing = next(
+                (
+                    camera
+                    for camera in canonical_cameras
+                    if camera is cached or cameras_share_identity(camera, cached)
+                ),
+                None,
+            )
+            if existing is None:
+                stations[cached_id] = cached
+                canonical_cameras.append(cached)
+                continue
+            if existing is not cached:
+                _merge_camera_metadata(cached, existing)
 
     async def _update_safe_mode(self, station) -> None:
         """Fetch safeMode from the 2nd_safemode AWS IoT shadow as a fallback."""
@@ -756,7 +833,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if station is None:
             station = self._get_station_by_id(station_sn)
         if station is None:
-            station = self._get_station_by_device_sn(device_sn)
+            station = _station_for_device_identifier(self, device_sn)
         identifier_candidates: list[str] = []
         if isinstance(station_data, dict):
             identifier_candidates.extend(_mqtt_identifier_candidates(station_data))
@@ -765,7 +842,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for identifier in identifier_candidates:
                 station = self._get_station_by_id(identifier)
                 if station is None:
-                    station = self._get_station_by_device_sn(identifier)
+                    station = _station_for_device_identifier(self, identifier)
                 if station is None:
                     station = _camera_station_for_identifiers(self, [identifier])
                 if station is not None:
@@ -1015,12 +1092,78 @@ def _camera_entities(coordinator: XSenseDataUpdateCoordinator) -> list[Any]:
     """Return camera entities known to the coordinator."""
     if not coordinator.xsense:
         return []
-    return [
-        station
-        for house in coordinator.xsense.houses.values()
-        for station in house.stations.values()
-        if is_camera_entity(station)
-    ]
+    cameras: list[Any] = []
+    for house in coordinator.xsense.houses.values():
+        for station in house.stations.values():
+            if not is_camera_entity(station):
+                continue
+            if any(cameras_share_identity(station, camera) for camera in cameras):
+                continue
+            cameras.append(station)
+    return cameras
+
+
+def _deduplicate_camera_devices(
+    stations: dict[str, Any], devices: dict[str, Any]
+) -> None:
+    """Remove only duplicate camera representations from the device collection."""
+    canonical = [station for station in stations.values() if is_camera_entity(station)]
+    for device_id, device in list(devices.items()):
+        if not is_camera_entity(device):
+            continue
+        if any(
+            device is camera or cameras_share_identity(device, camera)
+            for camera in canonical
+        ):
+            devices.pop(device_id, None)
+            continue
+        canonical.append(device)
+
+
+def _merge_camera_metadata(source: Any, target: Any) -> None:
+    """Merge a duplicate camera record without replacing its stable HA identity."""
+    source_data = getattr(source, "data", None)
+    target_data = getattr(target, "data", None)
+    if not isinstance(source_data, dict) or not isinstance(target_data, dict):
+        return
+    _preserve_camera_event_image(source, target)
+    merged = {
+        key: value
+        for key, value in source_data.items()
+        if key != "cameraMotionDetected"
+    }
+    merged.update(target_data)
+    set_data = getattr(target, "set_data", None)
+    if callable(set_data):
+        set_data(merged)
+    else:
+        target_data.update(merged)
+
+
+def _camera_event_record_sort_key(record: dict[str, Any]) -> tuple[bool, str]:
+    """Return an order-independent APK event timestamp key."""
+    event_time = _camera_event_record_station_data(record).get("eventTime")
+    return (event_time not in (None, ""), str(event_time or ""))
+
+
+def _camera_ai_history_sort_key(item: dict[str, Any]) -> tuple[bool, str]:
+    """Return an order-independent APK AI event timestamp key."""
+    event_time = item.get("createTime")
+    if event_time in (None, ""):
+        station_data = _mqtt_reported_data(item)
+        event_time = station_data.get("eventTime") if station_data else None
+    return (event_time not in (None, ""), str(event_time or ""))
+
+
+def _camera_event_time_relation(station: Any, station_data: dict[str, Any]) -> int:
+    """Compare an event record with the newest event already held by a camera."""
+    current = str(getattr(station, "data", {}).get("eventTime") or "")
+    incoming = str(station_data.get("eventTime") or "")
+    if not current or incoming > current:
+        return 1
+    if incoming == current:
+        return 0
+    return -1
 
 
 _CAMERA_EVENT_IMAGE_KEYS = (
@@ -1104,6 +1247,17 @@ def _camera_station_for_event_data(
     return _camera_station_for_identifiers(coordinator, identifiers)
 
 
+def _station_for_device_identifier(
+    coordinator: XSenseDataUpdateCoordinator,
+    identifier: Any,
+):
+    """Resolve a child identifier without accepting an ambiguous camera label."""
+    station = coordinator._get_station_by_device_sn(identifier)
+    if station is None or not is_camera_entity(station):
+        return station
+    return camera_for_identifier(_camera_entities(coordinator), identifier)
+
+
 def _camera_station_for_identifiers(
     coordinator: XSenseDataUpdateCoordinator,
     identifiers: list[Any],
@@ -1113,13 +1267,10 @@ def _camera_station_for_identifiers(
         if identifier in (None, ""):
             continue
         station = coordinator._get_station_by_id(str(identifier))
-        if station is None:
-            station = coordinator._get_station_by_device_sn(str(identifier))
         if station is not None and is_camera_entity(station):
             return station
-        for camera in _camera_entities(coordinator):
-            if camera_matches_identifier(camera, identifier):
-                return camera
+        if camera := camera_for_identifier(_camera_entities(coordinator), identifier):
+            return camera
     return None
 
 

--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 from .python_xsense.entity import Entity
 from .python_xsense.entity_map import EntityType
+from .python_xsense.async_xsense import (
+    camera_addx_serial,
+    camera_for_identifier,
+    is_camera_entity,
+)
 
 from homeassistant.const import ATTR_VIA_DEVICE
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -102,6 +107,9 @@ class XSenseEntity(CoordinatorEntity):
         self._dev_id = entity.entity_id
         self._station_id = station_id
         self._entity_serial = _entity_serial(entity)
+        self._camera_identity = (
+            camera_addx_serial(entity) if is_camera_entity(entity) else None
+        )
         station = getattr(entity, "station", None)
         self._station_serial = _entity_serial(station)
 
@@ -127,11 +135,22 @@ class XSenseEntity(CoordinatorEntity):
         """Return the current coordinator entity for this Home Assistant entity."""
         data = self.coordinator.data or {}
         if self._station_id is not None:
-            return _entity_by_id_or_serial(
-                data.get("devices", {}), self._dev_id, self._entity_serial
+            entities = data.get("devices", {})
+        else:
+            entities = data.get("stations", {})
+        return self._current_entity_from(entities)
+
+    def _current_entity_from(self, entities: dict[str, Entity]) -> Entity | None:
+        """Resolve this entity from one coordinator collection."""
+        if self._camera_identity:
+            if entity := entities.get(self._dev_id):
+                return entity
+            return camera_for_identifier(
+                [entity for entity in entities.values() if is_camera_entity(entity)],
+                self._camera_identity,
             )
         return _entity_by_id_or_serial(
-            data.get("stations", {}), self._dev_id, self._entity_serial
+            entities, self._dev_id, self._entity_serial
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/xsense/event.py
+++ b/custom_components/xsense/event.py
@@ -8,7 +8,10 @@ from time import monotonic
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from .python_xsense.async_xsense import is_camera_entity
+from .python_xsense.async_xsense import (
+    camera_addx_serial,
+    is_camera_entity,
+)
 from .python_xsense.device import Device
 from .python_xsense.entity import Entity
 
@@ -24,7 +27,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import entity_registry as er
 
 from .const import CAMERA_AI_SERVICE_AVAILABLE, DOMAIN, LOGGER
-from .entity import XSenseEntity, coordinator_devices, setup_dynamic_entities
+from .entity import (
+    XSenseEntity,
+    coordinator_devices,
+    setup_dynamic_entities,
+)
 from .frontend import recordings_panel_url
 
 if TYPE_CHECKING:
@@ -137,7 +144,7 @@ class XSenseEventEntity(XSenseEntity, EventEntity):
     def _current_entity(self) -> Entity | None:
         """Return the current coordinator entity for this event entity."""
         if self._device_entity:
-            return coordinator_devices(self.coordinator).get(self._dev_id)
+            return self._current_entity_from(coordinator_devices(self.coordinator))
         return super()._current_entity()
 
     def _add_camera_event_context(
@@ -148,8 +155,8 @@ class XSenseEventEntity(XSenseEntity, EventEntity):
             return
         if camera_name := getattr(entity, "name", None):
             event_data["camera_name"] = str(camera_name)
-        if camera_serial := getattr(entity, "sn", None):
-            event_data["camera_serial"] = str(camera_serial)
+        if camera_serial := camera_addx_serial(entity):
+            event_data["camera_serial"] = camera_serial
         if camera_entity_id := _camera_entity_id_for_event(self.hass, entity):
             event_data["camera_entity_id"] = camera_entity_id
 
@@ -244,7 +251,7 @@ class XSenseMotionEventEntity(XSenseEntity, EventEntity):
     def _current_entity(self) -> Entity | None:
         """Return the current coordinator entity for this event entity."""
         if self._device_entity:
-            return coordinator_devices(self.coordinator).get(self._dev_id)
+            return self._current_entity_from(coordinator_devices(self.coordinator))
         return super()._current_entity()
 
     def _trigger_event_after_recording_cache(
@@ -270,6 +277,13 @@ class XSenseMotionEventEntity(XSenseEntity, EventEntity):
         if fingerprint is None:
             if not self._motion_initialized:
                 self._motion_initialized = True
+            self._write_state_if_added()
+            return
+
+        if entity.data.get("cameraEventBaseline") is True:
+            self._last_motion_fingerprint = fingerprint
+            self._motion_initialized = True
+            entity.data["cameraEventBaseline"] = False
             self._write_state_if_added()
             return
 
@@ -300,8 +314,8 @@ class XSenseMotionEventEntity(XSenseEntity, EventEntity):
             return
         if camera_name := getattr(entity, "name", None):
             event_data["camera_name"] = str(camera_name)
-        if camera_serial := getattr(entity, "sn", None):
-            event_data["camera_serial"] = str(camera_serial)
+        if camera_serial := camera_addx_serial(entity):
+            event_data["camera_serial"] = camera_serial
         if camera_entity_id := _camera_entity_id_for_event(self.hass, entity):
             event_data["camera_entity_id"] = camera_entity_id
 
@@ -461,7 +475,8 @@ def _add_recording_panel_url(
             "timestamp",
         )
     )
-    if start_time in (None, "") or not getattr(entity, "sn", None):
+    camera_serial = camera_addx_serial(entity)
+    if start_time in (None, "") or not camera_serial:
         return
     end_time = _recording_epoch_seconds(
         _first_present(playback, "end_time_s", "end_time")
@@ -471,7 +486,7 @@ def _add_recording_panel_url(
     if not _is_recordings_panel_url(event_data.get("recording_url")):
         event_data["recording_url"] = recordings_panel_url(
             entry_id,
-            str(entity.sn),
+            camera_serial,
             int(start_time),
             end_time=end_time,
         )

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.11"
+PANEL_ASSET_VERSION = "1.4.20.12"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.11",
+  "version": "1.4.20.12",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/__init__.py
+++ b/custom_components/xsense/python_xsense/__init__.py
@@ -1,7 +1,15 @@
 """Async X-Sense cloud, MQTT, and camera client library."""
 
 from .device import Device
-from .async_xsense import AsyncXSense, camera_addx_serial, camera_matches_identifier
+from .async_xsense import (
+    AsyncXSense,
+    camera_addx_serial,
+    camera_for_identifier,
+    camera_identifiers,
+    camera_matches_identifier,
+    camera_primary_identifiers,
+    cameras_share_identity,
+)
 from .house import House
 from .mqtt_helper import MQTTHelper
 from .station import Station
@@ -11,7 +19,11 @@ __version__ = "0.1.0"
 __all__ = [
     "AsyncXSense",
     "camera_addx_serial",
+    "camera_for_identifier",
+    "camera_identifiers",
     "camera_matches_identifier",
+    "camera_primary_identifiers",
+    "cameras_share_identity",
     "Device",
     "House",
     "MQTTHelper",

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -204,8 +204,8 @@ def _camera_addx_serial(camera: Entity) -> str:
     return _camera_addx_serial_candidates(camera)[0]
 
 
-def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
-    """Return APK camera identifiers in ADDX preference order."""
+def camera_primary_identifiers(camera: Entity) -> tuple[str, ...]:
+    """Return strong APK camera identifiers in ADDX preference order."""
     data = getattr(camera, "data", {}) or {}
     ticket = data.get("cameraWebrtcTicket")
     if not isinstance(ticket, dict):
@@ -218,14 +218,27 @@ def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
         ticket.get("realCxSerialNumber"),
         data.get("addxSerialNumber"),
         getattr(camera, "entity_id", None),
-        getattr(camera, "sn", None),
     ):
         if value in (None, ""):
             continue
         serial = str(value)
         if serial not in result:
             result.append(serial)
-    return result or [""]
+    return tuple(result)
+
+
+def camera_identifiers(camera: Entity) -> tuple[str, ...]:
+    """Return all APK camera identifiers, including the secondary IPC label."""
+    result = list(camera_primary_identifiers(camera))
+    serial = getattr(camera, "sn", None)
+    if serial not in (None, "") and str(serial) not in result:
+        result.append(str(serial))
+    return tuple(result)
+
+
+def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
+    """Return APK camera identifiers in ADDX preference order."""
+    return list(camera_identifiers(camera)) or [""]
 
 
 def camera_addx_serial(camera: Entity) -> str:
@@ -240,28 +253,70 @@ def camera_matches_identifier(camera: Entity, identifier: Any) -> bool:
         return False
     return any(
         _normalized_camera_serial(candidate) == normalized
-        for candidate in _camera_addx_serial_candidates(camera)
+        for candidate in camera_identifiers(camera)
     )
 
 
-def _camera_history_record_matches_serial(
-    record: dict[str, Any], serial: str
-) -> bool:
-    """Return whether a library row belongs to the exact requested camera."""
-    record_serial = (
+def cameras_share_identity(left: Entity, right: Entity) -> bool:
+    """Return whether two records share a strong APK camera identifier."""
+    left_identifiers = {
+        normalized
+        for value in camera_primary_identifiers(left)
+        if (normalized := _normalized_camera_serial(value)) is not None
+    }
+    right_identifiers = {
+        normalized
+        for value in camera_primary_identifiers(right)
+        if (normalized := _normalized_camera_serial(value)) is not None
+    }
+    return bool(left_identifiers & right_identifiers)
+
+
+def _camera_history_record_owner(
+    cameras: list[Entity], record: dict[str, Any]
+) -> Entity | None:
+    """Return the one camera proven to own an APK library record."""
+    identifier = (
         record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
     )
-    return _normalized_camera_serial(record_serial) == _normalized_camera_serial(serial)
+    return camera_for_identifier(cameras, identifier)
 
 
-def _camera_history_record_matches_camera(
-    record: dict[str, Any], camera: Entity
-) -> bool:
-    """Return whether a library row carries a proven identity for this camera."""
-    record_serial = (
-        record.get("serialNumber") or record.get("deviceSn") or record.get("sn")
+def camera_for_identifier(
+    cameras: list[Entity], identifier: Any
+) -> Entity | None:
+    """Return the one camera proven to own an APK identifier."""
+    normalized = _normalized_camera_serial(identifier)
+    if normalized is None:
+        return None
+
+    primary_matches = [
+        camera
+        for camera in cameras
+        if any(
+            _normalized_camera_serial(candidate) == normalized
+            for candidate in camera_primary_identifiers(camera)
+        )
+    ]
+    if primary_matches:
+        owner = primary_matches[0]
+        return (
+            owner
+            if all(cameras_share_identity(owner, match) for match in primary_matches)
+            else None
+        )
+
+    secondary_matches = [
+        camera for camera in cameras if camera_matches_identifier(camera, identifier)
+    ]
+    if not secondary_matches:
+        return None
+    owner = secondary_matches[0]
+    return (
+        owner
+        if all(cameras_share_identity(owner, match) for match in secondary_matches)
+        else None
     )
-    return camera_matches_identifier(camera, record_serial)
 
 
 def _is_addx_device_no_access(error: Exception) -> bool:
@@ -609,15 +664,14 @@ class AsyncXSense(XSenseBase):
         records: list[dict[str, Any]] = []
         first_error: APIFailure | None = None
         successful_requests = 0
-        seen_cameras: set[str] = set()
+        seen_cameras: list[Entity] = []
         for camera in cameras:
             serials = _camera_addx_serial_candidates(camera)
             if not serials:
                 continue
-            camera_key = _normalized_camera_serial(serials[0]) or serials[0]
-            if camera_key in seen_cameras:
+            if any(cameras_share_identity(camera, seen) for seen in seen_cameras):
                 continue
-            seen_cameras.add(camera_key)
+            seen_cameras.append(camera)
             house = self._camera_addx_house(camera)
             camera_request_succeeded = False
             accepted_serial = None
@@ -656,7 +710,7 @@ class AsyncXSense(XSenseBase):
                     record
                     for record in group_records
                     if isinstance(record, dict)
-                    and _camera_history_record_matches_serial(record, serial)
+                    and _camera_history_record_owner(cameras, record) is camera
                 ]
                 if not matching_records:
                     continue
@@ -689,15 +743,14 @@ class AsyncXSense(XSenseBase):
         records: list[dict[str, Any]] = []
         first_error: APIFailure | None = None
         successful_requests = 0
-        seen_cameras: set[str] = set()
+        seen_cameras: list[Entity] = []
         for camera in cameras:
             serials = _camera_addx_serial_candidates(camera)
             if not serials:
                 continue
-            camera_key = _normalized_camera_serial(serials[0]) or serials[0]
-            if camera_key in seen_cameras:
+            if any(cameras_share_identity(camera, seen) for seen in seen_cameras):
                 continue
-            seen_cameras.add(camera_key)
+            seen_cameras.append(camera)
             house = self._camera_addx_house(camera)
             accepted_serial = None
             camera_request_succeeded = False
@@ -736,7 +789,7 @@ class AsyncXSense(XSenseBase):
                     record
                     for record in group_records
                     if isinstance(record, dict)
-                    and _camera_history_record_matches_camera(record, camera)
+                    and _camera_history_record_owner(cameras, record) is camera
                 ]
                 if not matching_records:
                     continue
@@ -1551,8 +1604,22 @@ class AsyncXSense(XSenseBase):
     async def _update_camera_push_image_metadata(self, camera: Entity) -> None:
         """Read the APK's latest stored push-image metadata for one camera."""
         data = await self._camera_addx_call(camera, "/device/devicePushImage")
+        cameras = [
+            station
+            for house in self.houses.values()
+            for station in house.stations.values()
+            if is_camera_entity(station)
+        ]
+        if not any(
+            known is camera or cameras_share_identity(known, camera)
+            for known in cameras
+        ):
+            cameras.append(camera)
         for item in _camera_push_image_rows(data):
-            if not camera_matches_identifier(camera, item.get("serialNumber")):
+            owner = camera_for_identifier(cameras, item.get("serialNumber"))
+            if owner is not camera and not (
+                owner is not None and cameras_share_identity(owner, camera)
+            ):
                 continue
             values = {
                 "lastPushImageUrl": item.get("lastPushImageUrl"),
@@ -1572,22 +1639,36 @@ class AsyncXSense(XSenseBase):
         if normalized_serial is None:
             return None
 
-        for house in self.houses.values():
-            for station in house.stations.values():
-                if (
-                    is_camera_entity(station)
-                    and normalized_serial
-                    in {
-                        _normalized_camera_serial(station.entity_id),
-                        _normalized_camera_serial(station.sn),
-                    }
-                ):
-                    camera_type = _camera_type(data)
-                    if camera_type:
-                        station.type = camera_type
-                    if data.get("deviceName"):
-                        station.name = data["deviceName"]
-                    return station
+        existing_cameras = [
+            station
+            for house in self.houses.values()
+            for station in house.stations.values()
+            if is_camera_entity(station)
+        ]
+        matches = [
+            camera
+            for camera in existing_cameras
+            if any(
+                _normalized_camera_serial(candidate) == normalized_serial
+                for candidate in camera_primary_identifiers(camera)
+            )
+        ]
+        if not matches:
+            matches = [
+                camera
+                for camera in existing_cameras
+                if camera_matches_identifier(camera, serial)
+            ]
+        if len(matches) > 1:
+            return None
+        if len(matches) == 1:
+            station = matches[0]
+            camera_type = _camera_type(data)
+            if camera_type:
+                station.type = camera_type
+            if data.get("deviceName"):
+                station.name = data["deviceName"]
+            return station
 
         device_house_id = data.get("houseId")
         if device_house_id in (None, ""):

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -30,7 +30,13 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.storage import Store
 
-from .python_xsense.async_xsense import camera_addx_serial, is_camera_entity
+from .python_xsense.async_xsense import (
+    camera_addx_serial,
+    camera_for_identifier,
+    camera_identifiers,
+    cameras_share_identity,
+    is_camera_entity,
+)
 from .recordings_gate import has_any_camera_entities
 from .const import (
     CONF_RECORDING_CACHE_MAX_SIZE_MB,
@@ -308,14 +314,15 @@ async def async_cache_recording_playback(
     camera_entity_id: str = "",
 ) -> str:
     """Cache one motion-event recording from APK playback metadata."""
-    if not getattr(entity, "sn", None):
+    serial = camera_addx_serial(entity)
+    if not serial:
         return ""
     started_at = monotonic()
 
     media_root = _recording_media_root(hass, entry_id)
     clip = _recording_clip_from_playback(
         entry_id,
-        str(entity.sn),
+        serial,
         camera_entity_id,
         playback,
         media_root,
@@ -325,7 +332,7 @@ async def async_cache_recording_playback(
         LOGGER.debug(
             "X-Sense motion recording cache skipped: %s",
             {
-                "camera": _short_serial(getattr(entity, "sn", "")),
+                "camera": _short_serial(serial),
                 "source": playback.get("source"),
                 "reason": "no_playable_clip",
                 "elapsed_ms": int((monotonic() - started_at) * 1000),
@@ -1658,10 +1665,12 @@ class XSenseRecordingsMediaSource(MediaSource):
     def _find_camera(
         index: dict[str, Any], entry_id: str, serial: str
     ) -> dict[str, Any] | None:
-        for camera in index.get("cameras", []):
-            if camera.get("entry_id") == entry_id and camera.get("serial") == serial:
-                return camera
-        return None
+        cameras = [
+            camera
+            for camera in index.get("cameras", [])
+            if camera.get("entry_id") == entry_id
+        ]
+        return _recording_camera_for_identifier(cameras, serial)
 
     @staticmethod
     def _find_clip(camera: dict[str, Any], start: int) -> dict[str, Any] | None:
@@ -1778,6 +1787,7 @@ class XSenseRecordingIndex:
             not force_refresh
             and self._cache
             and not _cache_expired(self._cache.get("generated_at"))
+            and _recording_index_matches_cameras(self._cache, cameras)
         ):
             cached = dict(self._cache)
             cached["cached"] = True
@@ -1787,7 +1797,9 @@ class XSenseRecordingIndex:
             index = await self._async_refresh()
         except Exception as exc:  # noqa: BLE001
             LOGGER.debug("Could not refresh X-Sense recording index: %s", exc)
-            if self._cache:
+            if self._cache and _recording_index_matches_cameras(
+                self._cache, cameras
+            ):
                 stale = dict(self._cache)
                 stale["cached"] = True
                 stale["stale"] = True
@@ -1905,23 +1917,24 @@ def _coordinator_cameras(coordinator: Any, entry_id: str) -> list[dict[str, Any]
         return []
 
     cameras: list[dict[str, Any]] = []
-    seen: set[str] = set()
+    seen: list[Any] = []
     for entity in (
         *(data.get("stations") or {}).values(),
         *(data.get("devices") or {}).values(),
     ):
         if not is_camera_entity(entity):
             continue
-        serial = str(getattr(entity, "sn", "") or "")
-        if not serial or serial in seen:
+        serial = camera_addx_serial(entity)
+        if not serial or any(cameras_share_identity(entity, item) for item in seen):
             continue
-        seen.add(serial)
+        seen.append(entity)
         cameras.append(
             {
                 "entry_id": entry_id,
                 "serial": serial,
                 "addx_serial": camera_addx_serial(entity),
                 "entity_id": str(getattr(entity, "entity_id", "") or ""),
+                "identifiers": list(camera_identifiers(entity)),
                 "name": str(getattr(entity, "name", "") or serial),
                 "online": bool(getattr(entity, "online", False)),
                 "model": str(getattr(entity, "type", "") or ""),
@@ -1935,13 +1948,62 @@ def _coordinator_camera_entity(coordinator: Any, serial: str) -> Any | None:
     data = getattr(coordinator, "data", None)
     if not isinstance(data, dict):
         return None
-    for entity in (
-        *(data.get("stations") or {}).values(),
-        *(data.get("devices") or {}).values(),
-    ):
-        if str(getattr(entity, "sn", "") or "") == serial and is_camera_entity(entity):
-            return entity
-    return None
+    cameras = [
+        entity
+        for entity in (
+            *(data.get("stations") or {}).values(),
+            *(data.get("devices") or {}).values(),
+        )
+        if is_camera_entity(entity)
+    ]
+    return camera_for_identifier(cameras, serial)
+
+
+def _recording_camera_for_identifier(
+    cameras: list[dict[str, Any]], identifier: Any
+) -> dict[str, Any] | None:
+    """Return the uniquely owned recording camera for an APK serial."""
+    normalized = _normalized_recording_camera_identifier(identifier)
+    if not normalized:
+        return None
+    matches = []
+    for camera in cameras:
+        identifiers = {
+            camera.get("serial"),
+            camera.get("entity_id"),
+            camera.get("addx_serial"),
+            *(camera.get("identifiers") or []),
+        }
+        if normalized in {
+            _normalized_recording_camera_identifier(value)
+            for value in identifiers
+            if value not in (None, "")
+        }:
+            matches.append(camera)
+    if not matches:
+        return None
+    owners = {
+        _normalized_recording_camera_identifier(camera.get("serial"))
+        for camera in matches
+    }
+    return matches[0] if len(owners) == 1 else None
+
+
+def _recording_index_matches_cameras(
+    index: dict[str, Any], cameras: list[dict[str, Any]]
+) -> bool:
+    """Return whether a stored index uses the current strong camera identities."""
+    indexed = {
+        _normalized_recording_camera_identifier(camera.get("serial"))
+        for camera in index.get("cameras", [])
+        if isinstance(camera, dict) and camera.get("serial")
+    }
+    current = {
+        _normalized_recording_camera_identifier(camera.get("serial"))
+        for camera in cameras
+        if camera.get("serial")
+    }
+    return bool(current) and indexed == current
 
 
 def _recording_clip_from_record(
@@ -1955,20 +2017,7 @@ def _recording_clip_from_record(
     )
     if not serial:
         return None
-    normalized_serial = _normalized_recording_camera_identifier(serial)
-    camera = next(
-        (
-            item
-            for item in cameras
-            if normalized_serial
-            in {
-                _normalized_recording_camera_identifier(item.get("serial")),
-                _normalized_recording_camera_identifier(item.get("entity_id")),
-                _normalized_recording_camera_identifier(item.get("addx_serial")),
-            }
-        ),
-        None,
-    )
+    camera = _recording_camera_for_identifier(cameras, serial)
     if camera is None:
         return None
     media_root = media_root or _recording_media_root_from_value(None)

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5516,6 +5516,78 @@ async def test_camera_event_record_history_rejects_cross_camera_rows():
 
 
 @pytest.mark.asyncio
+async def test_camera_library_history_rejects_shared_secondary_camera_label():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    cameras = [
+        SimpleNamespace(
+            sn="shared-label",
+            entity_id=f"camera-{index}",
+            data={"addxSerialNumber": f"camera-{index}"},
+            house=house,
+            set_data=lambda data: None,
+        )
+        for index in (1, 2)
+    ]
+
+    async def get_history(*args, **kwargs):
+        return {
+            "list": [
+                {
+                    "serialNumber": "shared-label",
+                    "timestamp": 1781484300,
+                    "videoEvent": "motion",
+                }
+            ]
+        }
+
+    client.get_camera_library_history = get_history
+
+    result = await client.get_camera_library_history_for_cameras(
+        cameras, 1781484300, 1781487900
+    )
+
+    assert result == {"list": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_camera_event_record_history_rejects_shared_secondary_camera_label():
+    client = async_xsense.AsyncXSense()
+    house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
+    client.houses = {"house-1": house}
+    cameras = [
+        SimpleNamespace(
+            sn="shared-label",
+            entity_id=f"camera-{index}",
+            data={"addxSerialNumber": f"camera-{index}"},
+            house=house,
+            set_data=lambda data: None,
+        )
+        for index in (1, 2)
+    ]
+
+    async def get_event_history(*args, **kwargs):
+        return {
+            "list": [
+                {
+                    "serialNumber": "shared-label",
+                    "timestamp": 1781484300,
+                    "videoEvent": "motion",
+                }
+            ]
+        }
+
+    client.get_camera_event_record_history = get_event_history
+
+    result = await client.get_camera_event_record_history_for_cameras(
+        cameras, 1781484300, 1781487900
+    )
+
+    assert result == {"list": [], "total": 0}
+
+
+@pytest.mark.asyncio
 async def test_camera_event_record_history_accepts_same_camera_real_serial_alias():
     client = async_xsense.AsyncXSense()
     house = SimpleNamespace(house_id="house-1", mqtt_region="eu-west-1")
@@ -6177,6 +6249,109 @@ def test_camera_from_addx_device_matches_existing_house_camera_by_ipc_id():
     )
 
     assert camera is test_house.stations["addx-camera-id"]
+
+
+def test_camera_identifier_owner_rejects_shared_secondary_ipc_label():
+    camera_1 = SimpleNamespace(
+        entity_id="camera-1", sn="shared-label", data={}
+    )
+    camera_2 = SimpleNamespace(
+        entity_id="camera-2", sn="shared-label", data={}
+    )
+
+    assert (
+        async_xsense.camera_for_identifier(
+            [camera_1, camera_2], "shared-label"
+        )
+        is None
+    )
+    assert (
+        async_xsense.camera_for_identifier([camera_1, camera_2], "camera-2")
+        is camera_2
+    )
+
+
+def test_camera_from_addx_device_does_not_merge_ambiguous_ipc_label():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "camera-1",
+                    "ipcSn": "shared-label",
+                    "ipcName": "Camera 1",
+                    "category": "SSC0A",
+                },
+                {
+                    "ipcId": "camera-2",
+                    "ipcSn": "shared-label",
+                    "ipcName": "Camera 2",
+                    "category": "SSC0A",
+                },
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+
+    assert (
+        client._camera_from_addx_device(
+            {
+                "serialNumber": "shared-label",
+                "deviceName": "Ambiguous Camera",
+                "modelNo": "SSC0A",
+            }
+        )
+        is None
+    )
+    assert set(test_house.stations) == {"camera-1", "camera-2"}
+
+
+@pytest.mark.asyncio
+async def test_camera_push_image_rejects_shared_secondary_ipc_label():
+    client = async_xsense.AsyncXSense()
+    test_house = house.House(None, "house-id", "Home", "US", "us-east-1", "mqtt")
+    test_house.set_stations(
+        {
+            "stationSort": [],
+            "stations": [],
+            "cameras": [
+                {
+                    "ipcId": "camera-1",
+                    "ipcSn": "shared-label",
+                    "ipcName": "Camera 1",
+                    "category": "SSC0A",
+                },
+                {
+                    "ipcId": "camera-2",
+                    "ipcSn": "shared-label",
+                    "ipcName": "Camera 2",
+                    "category": "SSC0A",
+                },
+            ],
+        }
+    )
+    client.houses = {"house-id": test_house}
+    camera = test_house.stations["camera-1"]
+
+    async def camera_addx_call(*args, **kwargs):
+        return {
+            "list": [
+                {
+                    "serialNumber": "shared-label",
+                    "lastPushImageUrl": "https://example.invalid/wrong.jpg",
+                    "lastPushTime": 1781484300,
+                }
+            ]
+        }
+
+    client._camera_addx_call = camera_addx_call
+
+    await client._update_camera_push_image_metadata(camera)
+
+    assert "lastPushImageUrl" not in camera.data
 
 
 def test_ipc_language_uses_simple_apk_app_language_code():

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -1249,13 +1249,19 @@ def test_camera_entities_do_not_duplicate_station_backed_cameras():
 
 
 def test_camera_entities_do_not_duplicate_station_backed_camera_serials():
-    station_camera = entity("SSC0A", {"streamProtocol": "webrtc"})
+    station_camera = entity(
+        "SSC0A",
+        {"streamProtocol": "webrtc", "addxSerialNumber": "physical-camera"},
+    )
     station_camera.entity_id = "station-camera-id"
     station_camera.sn = "cam-sn"
     station_camera.name = "Station Camera"
     station_camera.online = True
 
-    device_camera = entity("SSC0A", {"streamProtocol": "webrtc"})
+    device_camera = entity(
+        "SSC0A",
+        {"streamProtocol": "webrtc", "addxSerialNumber": "physical-camera"},
+    )
     device_camera.entity_id = "device-camera-id"
     device_camera.sn = "CAM-SN"
     device_camera.name = "Device Camera"
@@ -1274,6 +1280,36 @@ def test_camera_entities_do_not_duplicate_station_backed_camera_serials():
 
     assert [entity._dev_id for entity in entities] == [station_camera.entity_id]
     assert entities[0]._station_id is None
+
+
+def test_camera_entities_keep_distinct_cameras_with_shared_secondary_serial():
+    cameras = []
+    for index in (1, 2):
+        camera_entity = entity(
+            "SSC0A",
+            {
+                "streamProtocol": "webrtc",
+                "addxSerialNumber": f"physical-camera-{index}",
+            },
+        )
+        camera_entity.entity_id = f"camera-{index}"
+        camera_entity.sn = "shared-label"
+        camera_entity.name = f"Camera {index}"
+        camera_entity.online = True
+        cameras.append(camera_entity)
+
+    class Coordinator:
+        data = {
+            "stations": {camera.entity_id: camera for camera in cameras},
+            "devices": {},
+        }
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    entities = camera._camera_entities(Coordinator())
+
+    assert [entity._dev_id for entity in entities] == ["camera-1", "camera-2"]
 
 
 def test_ai_detection_event_entities_include_standalone_device_cameras():
@@ -1413,7 +1449,7 @@ def test_motion_fingerprint_ignores_playback_enrichment_for_same_event():
 
 
 def test_motion_event_entity_adds_ha_sd_playback_url(monkeypatch):
-    camera_entity = entity("SSC0A", {})
+    camera_entity = entity("SSC0A", {"addxSerialNumber": "ADDX-CAMERA-SN"})
     camera_entity.entity_id = "camera-id"
     camera_entity.name = "Garden Camera"
     camera_entity.sn = "CAMERA-SN"
@@ -1447,10 +1483,10 @@ def test_motion_event_entity_adds_ha_sd_playback_url(monkeypatch):
     event_entity._add_motion_playback_url(camera_entity, event_data)
 
     assert event_data["camera_name"] == "Garden Camera"
-    assert event_data["camera_serial"] == "CAMERA-SN"
+    assert event_data["camera_serial"] == "ADDX-CAMERA-SN"
     assert event_data["camera_entity_id"] == "camera.garden"
     assert event_data["recording_url"] == (
-        "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+        "/xsense-recordings#entry_id=entry-id&serial=ADDX-CAMERA-SN"
         "&start=1782049304&end=1782049334"
     )
     assert event_data["recording_source"] == "sd_playback"
@@ -1490,7 +1526,7 @@ def test_motion_event_entity_derives_recording_url_end_from_period(monkeypatch):
     event_entity._add_motion_playback_url(camera_entity, event_data)
 
     assert event_data["recording_url"] == (
-        "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+        "/xsense-recordings#entry_id=entry-id&serial=camera-id"
         "&start=1782049304&end=1782049334"
     )
 
@@ -1528,7 +1564,7 @@ def test_motion_event_entity_adds_recordings_link_without_camera_entity(monkeypa
 
     assert "camera_entity_id" not in event_data
     assert event_data["recording_url"] == (
-        "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+        "/xsense-recordings#entry_id=entry-id&serial=camera-id"
         "&start=1782049304&end=1782049334"
     )
 
@@ -1567,7 +1603,7 @@ def test_motion_event_entity_normalizes_ms_recording_times(monkeypatch):
     event_entity._add_motion_playback_url(camera_entity, event_data)
 
     assert event_data["recording_url"] == (
-        "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+        "/xsense-recordings#entry_id=entry-id&serial=camera-id"
         "&start=1782049304&end=1782049334"
     )
 
@@ -1596,7 +1632,7 @@ def test_motion_event_entity_replaces_direct_recording_url_with_panel_link(monke
     event_entity._add_motion_playback_url(camera_entity, event_data)
 
     assert event_data["recording_url"] == (
-        "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+        "/xsense-recordings#entry_id=entry-id&serial=camera-id"
         "&start=1782049304&end=1782049304"
     )
 
@@ -1677,7 +1713,7 @@ def test_motion_event_entity_caches_recording_before_trigger(monkeypatch, caplog
         (
             "trigger",
             "motion",
-            "/xsense-recordings#entry_id=entry-id&serial=CAMERA-SN"
+            "/xsense-recordings#entry_id=entry-id&serial=camera-id"
             "&start=1782049304&end=1782049334",
             "/media/local/xsense_recordings/videos/CAMERA-SN_1782049304_1782049334.mp4",
             "cached_media",
@@ -2092,6 +2128,82 @@ def test_recording_media_source_matches_addx_camera_serial_alias():
 
     assert clip is not None
     assert clip["serial"] == "IPC-CAMERA-SN"
+
+
+def test_recording_media_rejects_shared_secondary_camera_label():
+    from custom_components.xsense import recordings_media as media_source
+
+    cameras = [
+        {
+            "entry_id": "entry-id",
+            "serial": f"camera-{index}",
+            "entity_id": f"camera-{index}",
+            "identifiers": [f"camera-{index}", "shared-label"],
+        }
+        for index in (1, 2)
+    ]
+
+    assert (
+        media_source._recording_camera_for_identifier(cameras, "shared-label")
+        is None
+    )
+    assert (
+        media_source._recording_camera_for_identifier(cameras, "camera-2")
+        is cameras[1]
+    )
+
+
+def test_recording_index_rejects_legacy_weak_camera_identity():
+    from custom_components.xsense import recordings_media as media_source
+
+    current = [
+        {
+            "entry_id": "entry-id",
+            "serial": "physical-camera-1",
+            "entity_id": "camera-1",
+            "identifiers": ["physical-camera-1", "shared-label"],
+        },
+        {
+            "entry_id": "entry-id",
+            "serial": "physical-camera-2",
+            "entity_id": "camera-2",
+            "identifiers": ["physical-camera-2", "shared-label"],
+        },
+    ]
+    legacy_index = {
+        "cameras": [{"entry_id": "entry-id", "serial": "shared-label"}]
+    }
+    current_index = {"cameras": current}
+
+    assert not media_source._recording_index_matches_cameras(
+        legacy_index, current
+    )
+    assert media_source._recording_index_matches_cameras(current_index, current)
+
+
+def test_recording_media_keeps_cameras_with_shared_secondary_label_separate():
+    from custom_components.xsense import recordings_media as media_source
+
+    cameras = [
+        SimpleNamespace(
+            type="SSC0A",
+            entity_type=None,
+            entity_id=f"camera-{index}",
+            sn="shared-label",
+            data={"addxSerialNumber": f"camera-{index}"},
+            name=f"Camera {index}",
+            online=True,
+        )
+        for index in (1, 2)
+    ]
+    coordinator = SimpleNamespace(
+        data={"stations": {camera.entity_id: camera for camera in cameras}}
+    )
+
+    indexed = media_source._coordinator_cameras(coordinator, "entry-id")
+
+    assert [camera["serial"] for camera in indexed] == ["camera-1", "camera-2"]
+    assert all("shared-label" in camera["identifiers"] for camera in indexed)
 
 
 def test_recording_media_source_prefers_hd_direct_video_candidate():
@@ -5124,6 +5236,80 @@ def test_motion_event_entity_does_not_retrigger_when_history_enriches_mqtt_event
     event_entity._handle_coordinator_update()
 
     assert triggered == []
+
+
+def test_motion_event_entity_baselines_latest_apk_history_without_triggering():
+    camera_entity = entity(
+        "SSC0A",
+        {
+            "eventTime": "20260621134144",
+            "cameraEventBaseline": True,
+            "playback": {"image_url": "https://example.invalid/latest.jpg"},
+        },
+    )
+    event_entity = event.XSenseMotionEventEntity.__new__(
+        event.XSenseMotionEventEntity
+    )
+    event_entity._motion_initialized = True
+    event_entity._last_motion_fingerprint = ("20260620120000",)
+    event_entity.hass = object()
+    event_entity.platform = object()
+    event_entity._current_entity = lambda: camera_entity
+    triggered = []
+    event_entity._trigger_event = lambda *args: triggered.append(args)
+    event_entity.async_write_ha_state = lambda: None
+
+    event_entity._handle_coordinator_update()
+
+    assert triggered == []
+    assert event_entity._last_motion_fingerprint == ("20260621134144",)
+    assert camera_entity.data["cameraEventBaseline"] is False
+
+    camera_entity.data["eventTime"] = "20260621134200"
+    event_entity._handle_coordinator_update()
+
+    assert len(triggered) == 1
+
+
+def test_camera_entity_rebinds_by_strong_addx_identity_only():
+    original = entity("SSC0A", {"addxSerialNumber": "physical-camera-1"})
+    original.entity_id = "old-camera-id"
+    original.sn = "shared-label"
+    refreshed = entity("SSC0A", {"addxSerialNumber": "physical-camera-1"})
+    refreshed.entity_id = "new-camera-id"
+    refreshed.sn = "shared-label"
+    other = entity("SSC0A", {"addxSerialNumber": "physical-camera-2"})
+    other.entity_id = "other-camera-id"
+    other.sn = "shared-label"
+    camera_entity = camera.XSenseCameraEntity.__new__(camera.XSenseCameraEntity)
+    camera_entity.coordinator = SimpleNamespace(
+        data={"stations": {refreshed.entity_id: refreshed, other.entity_id: other}}
+    )
+    camera_entity._station_id = None
+    camera_entity._dev_id = original.entity_id
+    camera_entity._camera_identity = "physical-camera-1"
+
+    assert camera_entity._current_entity() is refreshed
+
+
+def test_camera_event_entity_rejects_ambiguous_weak_identity():
+    camera_1 = entity("SSC0A", {"addxSerialNumber": "physical-camera-1"})
+    camera_1.entity_id = "camera-1"
+    camera_1.sn = "shared-label"
+    camera_2 = entity("SSC0A", {"addxSerialNumber": "physical-camera-2"})
+    camera_2.entity_id = "camera-2"
+    camera_2.sn = "shared-label"
+    event_entity = event.XSenseMotionEventEntity.__new__(
+        event.XSenseMotionEventEntity
+    )
+    event_entity.coordinator = SimpleNamespace(
+        data={"stations": {camera_1.entity_id: camera_1, camera_2.entity_id: camera_2}}
+    )
+    event_entity._device_entity = False
+    event_entity._dev_id = "missing-camera-id"
+    event_entity._camera_identity = "shared-label"
+
+    assert event_entity._current_entity() is None
 
 
 def test_ai_detection_event_data_uses_apk_detection_payload():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1920,6 +1920,68 @@ async def test_camera_ai_history_poll_routes_apk_alarm_items():
     assert updates == []
 
 
+async def test_camera_ai_history_applies_new_items_in_timestamp_order():
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Camera:
+        sn = "camera-sn"
+        entity_id = "camera-id"
+        type = "SSC0A"
+        data = {"addxSerialNumber": "camera-sn"}
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+        def set_data(self, data):
+            self.data.update(data)
+
+    camera = Camera()
+    class House:
+        stations = {camera.entity_id: camera}
+
+        def get_station_by_sn(self, identifier):
+            return self.stations.get(identifier)
+
+    house = House()
+
+    class Client:
+        houses = {"house-id": house}
+
+        async def get_ai_service_history(self, _server_id):
+            return {
+                "alarmItems": [
+                    {
+                        "eventId": "new",
+                        "createTime": "20260614230600",
+                        "deviceSn": "camera-sn",
+                        "eventItems": [
+                            {"eventType": "vehicle", "eventTime": "20260614230601"}
+                        ],
+                    },
+                    {
+                        "eventId": "old",
+                        "createTime": "20260614230500",
+                        "deviceSn": "camera-sn",
+                        "eventItems": [
+                            {"eventType": "person", "eventTime": "20260614230501"}
+                        ],
+                    },
+                ]
+            }
+
+        def parse_get_state(self, station, data):
+            station.set_data(data)
+
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = Client()
+    coordinator._camera_ai_history_seen = {"already-initialized"}
+    coordinator._camera_ai_service_houses = {}
+
+    assert await coordinator._update_camera_ai_service_history(["service-id"])
+    assert camera.data["eventTime"] == "20260614230600"
+    assert camera.data["lastAiDetection"] == "vehicle"
+
+
 async def test_camera_ai_history_does_not_poll_recording_library():
     from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
 
@@ -2020,7 +2082,9 @@ async def test_camera_motion_history_routes_each_record_to_exact_camera_only():
     coordinator._camera_event_history_seen = set()
     coordinator._camera_event_history_initialized = False
 
-    assert not await coordinator._update_camera_event_history([camera_1, camera_2])
+    assert await coordinator._update_camera_event_history([camera_1, camera_2])
+    assert camera_1.data["cameraEventBaseline"] is True
+    assert camera_1.data["cameraMotionDetected"] is False
     assert await coordinator._update_camera_event_history([camera_1, camera_2])
     assert camera_1.data.get("cameraMotionDetected") is not True
     assert camera_2.data["cameraMotionDetected"] is True
@@ -2029,13 +2093,215 @@ async def test_camera_motion_history_routes_each_record_to_exact_camera_only():
     assert camera_2.data["cameraMotionDetected"] is False
     assert not await coordinator._update_camera_event_history([camera_1, camera_2])
 
-    assert len(parsed) == 1
-    assert parsed[0][0] is camera_2
-    assert parsed[0][1]["serialNumber"] == "camera-2"
-    assert parsed[0][1]["lastEventImageUrl"] == (
+    assert len(parsed) == 2
+    assert parsed[1][0] is camera_2
+    assert parsed[1][1]["serialNumber"] == "camera-2"
+    assert parsed[1][1]["lastEventImageUrl"] == (
         "https://example.invalid/camera-2.jpg"
     )
-    assert "eventTime" not in camera_1.data
+    assert camera_1.data["eventTime"] == "20260621134144"
+
+
+async def test_camera_motion_history_keeps_newest_image_regardless_of_api_order():
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    class Camera:
+        type = "SSC0A"
+
+        def __init__(self):
+            self.sn = "camera-1"
+            self.entity_id = "camera-1"
+            self.data = {}
+
+        def set_data(self, data):
+            self.data.update(data)
+
+        def get_device_by_sn(self, _identifier):
+            return None
+
+    camera = Camera()
+
+    class House:
+        stations = {camera.entity_id: camera}
+
+        def get_station_by_sn(self, identifier):
+            return self.stations.get(identifier)
+
+    class Client:
+        houses = {"house-id": House()}
+
+        async def get_camera_event_record_history_for_cameras(self, *args):
+            return {
+                "list": [
+                    {
+                        "serialNumber": "camera-1",
+                        "timestamp": 1782049364,
+                        "traceId": "new",
+                        "imageUrl": "https://example.invalid/new.jpg",
+                    },
+                    {
+                        "serialNumber": "camera-1",
+                        "timestamp": 1782049304,
+                        "traceId": "old",
+                        "imageUrl": "https://example.invalid/old.jpg",
+                    },
+                ]
+            }
+
+        def parse_get_state(self, station, data):
+            station.set_data(data)
+
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.xsense = Client()
+    coordinator._camera_event_history_seen = set()
+    coordinator._camera_event_history_initialized = False
+
+    assert await coordinator._update_camera_event_history([camera])
+    assert camera.data["lastEventImageUrl"] == "https://example.invalid/new.jpg"
+    assert camera.data["eventTime"] == "20260621134244"
+    assert camera.data["cameraMotionDetected"] is False
+
+
+def test_camera_entities_deduplicate_strong_addx_identity_only():
+    from custom_components.xsense.coordinator import _camera_entities
+
+    camera_1 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-1",
+        sn="shared-label",
+        data={"addxSerialNumber": "physical-camera-1"},
+    )
+    duplicate_1 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="legacy-camera-1",
+        sn="shared-label",
+        data={"addxAccessSerialNumber": "physical-camera-1"},
+    )
+    camera_2 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-2",
+        sn="shared-label",
+        data={"addxSerialNumber": "physical-camera-2"},
+    )
+    coordinator = SimpleNamespace(
+        xsense=SimpleNamespace(
+            houses={
+                "house": SimpleNamespace(
+                    stations={
+                        "camera-1": camera_1,
+                        "legacy-camera-1": duplicate_1,
+                        "camera-2": camera_2,
+                    }
+                )
+            }
+        )
+    )
+
+    assert _camera_entities(coordinator) == [camera_1, camera_2]
+
+
+def test_camera_device_deduplication_uses_strong_identity_only():
+    from custom_components.xsense.coordinator import _deduplicate_camera_devices
+
+    station_camera = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="station-camera",
+        sn="shared-label",
+        data={"addxSerialNumber": "physical-camera-1"},
+    )
+    duplicate = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="device-duplicate",
+        sn="another-label",
+        data={"addxAccessSerialNumber": "physical-camera-1"},
+    )
+    distinct = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="device-camera-2",
+        sn="shared-label",
+        data={"addxSerialNumber": "physical-camera-2"},
+    )
+    devices = {duplicate.entity_id: duplicate, distinct.entity_id: distinct}
+
+    _deduplicate_camera_devices({station_camera.entity_id: station_camera}, devices)
+
+    assert devices == {distinct.entity_id: distinct}
+
+
+def test_camera_station_lookup_rejects_shared_secondary_camera_label():
+    from custom_components.xsense.coordinator import (
+        _camera_station_for_identifiers,
+    )
+
+    camera_1 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-1",
+        sn="shared-label",
+        data={"addxSerialNumber": "camera-1"},
+    )
+    camera_2 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-2",
+        sn="shared-label",
+        data={"addxSerialNumber": "camera-2"},
+    )
+    coordinator = SimpleNamespace(
+        xsense=SimpleNamespace(
+            houses={
+                "house": SimpleNamespace(
+                    stations={"camera-1": camera_1, "camera-2": camera_2}
+                )
+            }
+        ),
+        _get_station_by_id=lambda identifier: {
+            "camera-1": camera_1,
+            "camera-2": camera_2,
+        }.get(identifier),
+    )
+
+    assert _camera_station_for_identifiers(coordinator, ["shared-label"]) is None
+    assert _camera_station_for_identifiers(coordinator, ["camera-2"]) is camera_2
+
+
+def test_device_lookup_rejects_shared_secondary_camera_label():
+    from custom_components.xsense.coordinator import _station_for_device_identifier
+
+    camera_1 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-1",
+        sn="shared-label",
+        data={"addxSerialNumber": "camera-1"},
+    )
+    camera_2 = SimpleNamespace(
+        type="SSC0A",
+        entity_type=None,
+        entity_id="camera-2",
+        sn="shared-label",
+        data={"addxSerialNumber": "camera-2"},
+    )
+    coordinator = SimpleNamespace(
+        xsense=SimpleNamespace(
+            houses={
+                "house": SimpleNamespace(
+                    stations={"camera-1": camera_1, "camera-2": camera_2}
+                )
+            }
+        ),
+        _get_station_by_device_sn=lambda identifier: (
+            camera_1 if identifier == "shared-label" else None
+        ),
+    )
+
+    assert _station_for_device_identifier(coordinator, "shared-label") is None
 
 
 async def test_camera_ai_history_timer_notifies_only_when_history_changes():


### PR DESCRIPTION
## Summary
- keep motion, AI events, current images, and recordings associated with the correct physical camera
- prevent startup history from appearing as new motion or suppressing the next real event
- refresh legacy recording indexes when their camera identities no longer match discovery
- add regression coverage for multi-camera identity, event ordering, startup baselines, entity rebinding, and recording indexes

## Validation
- 947 tests pass on Windows and Linux
- fork Tests, HACS validation, hassfest, and CodeQL workflows pass