### PR TITLE
Clean up v1.4.20.12 release notes

### DIFF
--- a/.github/release-notes/1.4.20.12.md
+++ b/.github/release-notes/1.4.20.12.md
@@ -4,5 +4,3 @@
 - Keeps motion, AI events, current images, and recordings tied to the correct physical camera when multiple cameras share internal labels.
 - Loads the latest camera image after startup without reporting an old recording as new motion or suppressing the next real event.
 - Refreshes older recording indexes using the current camera identity before serving them.
-
-Please test each camera's Motion sensor, event entities, current image, and recordings independently and report any remaining issues.


### PR DESCRIPTION
Removes the tester request from the v1.4.20.12 user-facing release notes.