### PR TITLE
Prepare v1.4.20.13 blocked-arm prompt prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.12):
-  (e.g., 1.4.20.12)
+- **X-Sense-Integration Version** (z. B. 1.4.20.13):
+  (e.g., 1.4.20.13)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.13.md
+++ b/.github/release-notes/1.4.20.13.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.20.13
+
+### Alarm Arming
+- Keeps normal Home and Away requests pending while the SBS50 returns open-sensor bypass details.
+- Preserves the force-arm prompt across base-station refreshes instead of silently losing it.
+- Keeps direct force-arm automation actions prompt-free and prevents routine polling from creating false prompts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.13](.github/release-notes/1.4.20.13.md)
 - [1.4.20.12](.github/release-notes/1.4.20.12.md)
 - [1.4.20.11](.github/release-notes/1.4.20.11.md)
 - [1.4.20.10](.github/release-notes/1.4.20.10.md)

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -174,8 +174,11 @@ class XSenseAlarmControlPanel(
             "manufacturer": MANUFACTURER,
             "model": _device_info_str(station.type),
         }
+        self._bound_station = station
         self._safemode: str | None = None
+        self._active_normal_arm_mode: str | None = None
         self._pending_force_arm_mode: str | None = None
+        self._pending_force_arm_data: dict | None = None
         self._cancel_arm_request_timeout = None
 
     @property
@@ -223,19 +226,62 @@ class XSenseAlarmControlPanel(
         """Handle updated coordinator data."""
         station = self._station
         if station is None:
+            self._bound_station = None
             self._safemode = None
+            self._active_normal_arm_mode = None
+            self._pending_force_arm_mode = None
+            self._pending_force_arm_data = None
             self._async_cancel_arm_request_timeout()
             self._async_clear_force_arm_notification()
             self.async_write_ha_state()
             return
 
+        station_replaced = station is not self._bound_station
+        self._bound_station = station
+        reported_mode = getattr(station, "alarm_mode", None)
+        if self._active_normal_arm_mode is not None:
+            # Discovery can replace Station objects while an APK-style arm
+            # request is waiting for its MQTT result. Keep the request in this
+            # long-lived entity, just as the APK keeps it in its presenter.
+            station.set_alarm_data(
+                {"requestedSafeMode": self._active_normal_arm_mode}
+            )
+
+        previous_pending_mode = self._pending_force_arm_mode
         pending_mode = pending_force_arm_mode(station)
+        if pending_mode is not None:
+            alarm_data = getattr(station, "alarm_data", {}) or {}
+            self._pending_force_arm_data = {
+                "forceReason": alarm_data.get("forceReason"),
+                "safeModeAim": pending_mode,
+                "requestedSafeMode": pending_mode,
+                "exitDelay": alarm_data.get("exitDelay"),
+            }
+            self._active_normal_arm_mode = None
+            self._async_cancel_arm_request_timeout()
+        elif (
+            station_replaced
+            and previous_pending_mode is not None
+            and self._pending_force_arm_data
+        ):
+            # Once the APK receives a blocked result, its bypass dialog lives
+            # independently of later station refreshes. Rehydrate the HA-side
+            # prompt until the user confirms it or starts a new mode request.
+            station.set_alarm_data(self._pending_force_arm_data)
+            pending_mode = previous_pending_mode
+        elif (
+            self._active_normal_arm_mode is not None
+            and reported_mode == self._active_normal_arm_mode
+        ):
+            self._async_clear_arm_request(station)
+            pending_mode = None
         alarm_data = getattr(station, "alarm_data", {}) or {}
         if pending_mode is not None or not alarm_data.get("requestedSafeMode"):
             self._async_cancel_arm_request_timeout()
-        if pending_mode != self._pending_force_arm_mode:
+        if pending_mode != previous_pending_mode:
             self._pending_force_arm_mode = pending_mode
             if pending_mode is None:
+                self._pending_force_arm_data = None
                 self._async_clear_force_arm_notification()
             else:
                 self._async_create_force_arm_notification(station, pending_mode)
@@ -384,6 +430,7 @@ class XSenseAlarmControlPanel(
     def _async_clear_arm_request(self, station) -> None:
         """Clear local state for an APK-style mode request."""
         self._async_cancel_arm_request_timeout()
+        self._active_normal_arm_mode = None
         station.set_alarm_data(
             {
                 "forceReason": None,
@@ -393,6 +440,7 @@ class XSenseAlarmControlPanel(
             }
         )
         self._pending_force_arm_mode = None
+        self._pending_force_arm_data = None
         self._async_clear_force_arm_notification()
 
     @callback
@@ -410,7 +458,7 @@ class XSenseAlarmControlPanel(
         if station is None:
             return
         alarm_data = getattr(station, "alarm_data", {}) or {}
-        if not alarm_data.get("requestedSafeMode") or alarm_data.get("forceReason"):
+        if self._active_normal_arm_mode is None or alarm_data.get("forceReason"):
             return
         LOGGER.debug("Station %s arm request timed out", station.sn)
         self._async_clear_arm_request(station)
@@ -443,10 +491,19 @@ class XSenseAlarmControlPanel(
         api = coordinator.xsense
 
         if safe_mode in ("Home", "Away") and force_arm == "0":
+            if self._active_normal_arm_mode is not None:
+                LOGGER.debug(
+                    "Station %s ignored overlapping safeMode request %s while %s is pending",
+                    station.sn,
+                    safe_mode,
+                    self._active_normal_arm_mode,
+                )
+                return
             current_mode = getattr(station, "alarm_mode", None)
             if current_mode == safe_mode:
                 self._async_clear_arm_request(station)
                 return
+            self._active_normal_arm_mode = safe_mode
             station.set_alarm_data(
                 {
                     "forceReason": None,
@@ -456,6 +513,7 @@ class XSenseAlarmControlPanel(
                 }
             )
             self._pending_force_arm_mode = None
+            self._pending_force_arm_data = None
             self._async_clear_force_arm_notification()
             self._async_start_arm_request_timeout()
         elif safe_mode == "Disarmed":

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.12"
+PANEL_ASSET_VERSION = "1.4.20.13"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.12",
+  "version": "1.4.20.13",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import aiohttp
 
 from .aws_signer import AWSSigner
-from .base import XSenseBase, _apply_sbs50_force_arm_prompt, shadow_update_body
+from .base import XSenseBase, shadow_update_body
 from .entity import Entity
 from .entity_map import EntityType
 from .exceptions import SessionExpired, APIFailure, XSenseError
@@ -1997,7 +1997,6 @@ class AsyncXSense(XSenseBase):
 
         if "reported" in res.get("state", {}):
             reported = res["state"]["reported"].copy()
-            _apply_sbs50_force_arm_prompt(station, reported)
             station.set_alarm_data(
                 {
                     key: value

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -567,6 +567,14 @@ def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
     current_alarm_data = getattr(station, "alarm_data", {}) or {}
     reported_mode = station_data.get("safeMode")
     requested_mode = current_alarm_data.get("requestedSafeMode")
+    prompt = _sbs50_force_arm_prompt(
+        station_data,
+        requested_mode=requested_mode,
+    )
+    if prompt is not None:
+        station.set_alarm_data(prompt)
+        return
+
     request_completed = reported_mode in ("Home", "Away") and (
         reported_mode == requested_mode
     )
@@ -579,14 +587,6 @@ def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
                 "exitDelay": None,
             }
         )
-        return
-
-    prompt = _sbs50_force_arm_prompt(
-        station_data,
-        requested_mode=requested_mode,
-    )
-    if prompt is not None:
-        station.set_alarm_data(prompt)
         return
 
     force_reason_reported = "forceReason" in station_data
@@ -610,18 +610,17 @@ def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
 def _sbs50_force_arm_prompt(
     station_data: Dict, *, requested_mode: str | None = None
 ) -> Dict | None:
-    if requested_mode not in ("Home", "Away"):
-        return None
+    active_request = requested_mode if requested_mode in ("Home", "Away") else None
 
     if "forceReason" in station_data:
         force_reason = station_data.get("forceReason")
         if force_reason:
             return {
                 "forceReason": force_reason,
-                "safeModeAim": requested_mode
+                "safeModeAim": active_request
                 or station_data.get("safeModeAim")
                 or station_data.get("safeMode"),
-                "requestedSafeMode": requested_mode,
+                "requestedSafeMode": active_request,
                 "exitDelay": station_data.get("exitDelay"),
             }
 
@@ -636,15 +635,19 @@ def _sbs50_force_arm_prompt(
         if not isinstance(event_param, dict):
             continue
         safe_mode_aim = event_param.get("safeModeAim")
-        if safe_mode_aim not in (None, "", requested_mode):
+        if active_request is not None and safe_mode_aim not in (
+            None,
+            "",
+            active_request,
+        ):
             continue
         force_reason = event_param.get("forceReason")
         if not force_reason:
             continue
         return {
             "forceReason": force_reason,
-            "safeModeAim": requested_mode,
-            "requestedSafeMode": requested_mode,
+            "safeModeAim": active_request or safe_mode_aim,
+            "requestedSafeMode": active_request,
             "exitDelay": event_param.get("exitDelay"),
         }
 

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1399,7 +1399,7 @@ async def test_get_station_state_uses_second_info_for_new_wifi_devices_like_apk(
 
 
 @pytest.mark.asyncio
-async def test_get_alarm_state_ignores_stale_force_reason_without_local_request():
+async def test_get_alarm_state_does_not_create_prompt_from_polled_force_reason():
     client = async_xsense.AsyncXSense()
     station_obj = station.Station(
         None,
@@ -1428,10 +1428,11 @@ async def test_get_alarm_state_ignores_stale_force_reason_without_local_request(
     assert station_obj.safe_mode == "Disarmed"
     assert station_obj.alarm_data["safeMode"] == "Disarmed"
     assert station_obj.alarm_data.get("forceReason") is None
+    assert station_obj.alarm_data.get("requestedSafeMode") is None
 
 
 @pytest.mark.asyncio
-async def test_get_alarm_state_keeps_force_reason_for_active_local_request():
+async def test_get_alarm_state_does_not_create_prompt_during_active_request():
     client = async_xsense.AsyncXSense()
     station_obj = station.Station(
         None,
@@ -1459,7 +1460,45 @@ async def test_get_alarm_state_keeps_force_reason_for_active_local_request():
     await client.get_alarm_state(station_obj)
 
     assert station_obj.alarm_data["requestedSafeMode"] == "Away"
-    assert station_obj.alarm_data["forceReason"] == [{"door-sn": "1"}]
+    assert station_obj.alarm_data.get("forceReason") is None
+
+
+@pytest.mark.asyncio
+async def test_get_alarm_state_does_not_overwrite_live_force_arm_prompt():
+    client = async_xsense.AsyncXSense()
+    station_obj = station.Station(
+        None,
+        stationId="station-id",
+        stationName="Station",
+        stationSn="station-sn",
+        category="SBS50",
+    )
+    station_obj.set_alarm_data(
+        {
+            "requestedSafeMode": "Home",
+            "safeModeAim": "Home",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        }
+    )
+    client.get_thing = AsyncMock(
+        return_value={
+            "state": {
+                "reported": {
+                    "safeMode": "Disarmed",
+                    "forceReason": [],
+                    "safeModeAim": "Away",
+                }
+            }
+        }
+    )
+    client._lastres = SimpleNamespace(status=200)
+
+    await client.get_alarm_state(station_obj)
+
+    assert station_obj.alarm_data["requestedSafeMode"] == "Home"
+    assert station_obj.alarm_data["safeModeAim"] == "Home"
+    assert station_obj.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
 
 
 def test_xc0m_ir_maps_compact_temperature_and_humidity_fields():

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -733,7 +733,7 @@ def test_alarm_control_panel_requires_security_device_family():
         assert station_supports_alarm_panel(security_station)
 
 
-async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation(monkeypatch):
+async def test_alarm_panel_ignores_overlapping_normal_arm_requests_like_apk(monkeypatch):
     class Api:
         def __init__(self):
             self.calls = []
@@ -774,9 +774,8 @@ async def test_alarm_panel_uses_strict_arm_before_force_arm_confirmation(monkeyp
 
     assert api.calls == [
         (station.sn, "Home", "0"),
-        (station.sn, "Away", "0"),
     ]
-    assert station.alarm_data["requestedSafeMode"] == "Away"
+    assert station.alarm_data["requestedSafeMode"] == "Home"
 
 
 async def test_normal_arm_clears_stale_bypass_state_before_publish(monkeypatch):
@@ -985,6 +984,164 @@ async def test_blocked_arm_prompt_survives_empty_acknowledgement_end_to_end(
 
     assert calls == [(requested_mode, "0"), (requested_mode, "1")]
     assert pending_force_arm_mode(station) is None
+
+
+@pytest.mark.parametrize("requested_mode", ["Home", "Away"])
+@pytest.mark.parametrize("reported_mode", ["Disarmed", "requested"])
+async def test_blocked_arm_prompt_survives_station_object_refresh(
+    monkeypatch, requested_mode, reported_mode
+):
+    """Keep the APK presenter request while discovery replaces its Station."""
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    cancelled = []
+    created = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.entity_id = "alarm_control_panel.base_station_alarm"
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: cancelled.append(True)
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
+        lambda hass, message, title=None, notification_id=None: created.append(
+            (message, title, notification_id)
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    if requested_mode == "Home":
+        await panel.async_alarm_arm_home()
+    else:
+        await panel.async_alarm_arm_away()
+
+    refreshed = _xs01_wx_from_real_shadow()
+    refreshed.type = "SBS50"
+    XSenseBase.__new__(XSenseBase).parse_get_state(
+        refreshed,
+        {
+            "safeMode": (
+                requested_mode if reported_mode == "requested" else reported_mode
+            ),
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        },
+    )
+    coordinator.data["stations"][station.entity_id] = refreshed
+
+    panel._handle_coordinator_update()
+
+    assert pending_force_arm_mode(refreshed) == requested_mode
+    assert refreshed.alarm_data["requestedSafeMode"] == requested_mode
+    assert panel._cancel_arm_request_timeout is None
+    assert cancelled == [True]
+    assert len(created) == 1
+    assert f"mode={requested_mode}" in created[0][0]
+
+
+async def test_visible_force_arm_prompt_survives_station_object_refresh(monkeypatch):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    created = []
+    dismissed = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.entity_id = "alarm_control_panel.base_station_alarm"
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    _patch_alarm_call_later(monkeypatch, lambda hass, delay, action: lambda: None)
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_create",
+        lambda hass, message, title=None, notification_id=None: created.append(
+            notification_id
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: dismissed.append(notification_id),
+    )
+
+    await panel.async_alarm_arm_home()
+    XSenseBase.__new__(XSenseBase).parse_get_state(
+        station,
+        {
+            "safeMode": "Disarmed",
+            "forceReason": [{"deviceSN": "door-sn"}],
+            "exitDelay": "0",
+        },
+    )
+    panel._handle_coordinator_update()
+    dismiss_count_after_prompt = len(dismissed)
+
+    refreshed = _xs01_wx_from_real_shadow()
+    refreshed.type = "SBS50"
+    coordinator.data["stations"][station.entity_id] = refreshed
+    panel._handle_coordinator_update()
+
+    assert pending_force_arm_mode(refreshed) == "Home"
+    assert refreshed.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert panel._pending_force_arm_mode == "Home"
+    assert panel._active_normal_arm_mode is None
+    assert len(created) == 1
+    assert len(dismissed) == dismiss_count_after_prompt
+
+
+async def test_normal_arm_success_clears_request_after_station_object_refresh(
+    monkeypatch,
+):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    cancelled = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            return None
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    _patch_alarm_call_later(
+        monkeypatch, lambda hass, delay, action: lambda: cancelled.append(True)
+    )
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
+
+    await panel.async_alarm_arm_away()
+
+    refreshed = _xs01_wx_from_real_shadow()
+    refreshed.type = "SBS50"
+    refreshed.safe_mode = "Away"
+    refreshed.set_alarm_data({"safeMode": "Away"})
+    coordinator.data["stations"][station.entity_id] = refreshed
+
+    panel._handle_coordinator_update()
+
+    assert panel._active_normal_arm_mode is None
+    assert panel._cancel_arm_request_timeout is None
+    assert pending_force_arm_mode(refreshed) is None
+    assert refreshed.alarm_data.get("requestedSafeMode") is None
+    assert cancelled == [True]
 
 
 async def test_normal_arm_is_noop_when_station_already_reports_target_mode(
@@ -1320,7 +1477,7 @@ def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target(
     assert station.alarm_data["safeModeAim"] == "Home"
 
 
-def test_force_arm_prompt_ignores_stale_reason_without_local_request():
+def test_force_arm_result_is_retained_but_not_exposed_without_local_request():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     api = XSenseBase.__new__(XSenseBase)
@@ -1335,7 +1492,8 @@ def test_force_arm_prompt_ignores_stale_reason_without_local_request():
     )
 
     assert pending_force_arm_mode(station) is None
-    assert station.alarm_data.get("forceReason") is None
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data.get("requestedSafeMode") is None
 
 
 def test_force_arm_prompt_uses_matching_notice_during_local_request():
@@ -1479,10 +1637,11 @@ def test_force_arm_prompt_does_not_return_after_request_is_cleared():
     )
 
     assert pending_force_arm_mode(station) is None
-    assert station.alarm_data.get("forceReason") is None
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data.get("requestedSafeMode") is None
 
 
-def test_successful_normal_arm_ignores_stale_force_reason():
+def test_live_force_reason_wins_before_normal_arm_success_like_apk_listeners():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data({"requestedSafeMode": "Home"})
@@ -1496,9 +1655,9 @@ def test_successful_normal_arm_ignores_stale_force_reason():
         },
     )
 
-    assert pending_force_arm_mode(station) is None
-    assert station.alarm_data["forceReason"] is None
-    assert station.alarm_data["requestedSafeMode"] is None
+    assert pending_force_arm_mode(station) == "Home"
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data["requestedSafeMode"] == "Home"
 
 
 def test_empty_force_arm_reason_does_not_dismiss_active_prompt():


### PR DESCRIPTION
## Summary
- preserve SBS50 Home and Away arm requests across refreshed station objects
- keep the force-arm prompt available after the blocked result is received
- follow the APK listener ordering for blocked and successful mode results
- prevent overlapping requests and HTTP polling from creating false prompt state
- prepare the v1.4.20.13 prerelease

## Validation
- 954 tests passed on Windows and Linux Python 3.14
- fork CI passed on Python 3.13 and 3.14
- HACS and hassfest validation passed
- CodeQL passed for Actions, Python, and JavaScript/TypeScript