### PR TITLE
Improve camera event snapshot quality

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.13):
-  (e.g., 1.4.20.13)
+- **X-Sense-Integration Version** (z. B. 1.4.20.14):
+  (e.g., 1.4.20.14)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.14.md
+++ b/.github/release-notes/1.4.20.14.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.20.14
+
+### Camera Images
+- Produces clearer motion-event snapshots from the highest-quality available recording instead of relying only on the smaller cloud thumbnail.
+- Makes the improved image available through the Home Assistant camera entity and event snapshot link.
+- Continues using the X-Sense-provided event image whenever a higher-quality frame is unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.14](.github/release-notes/1.4.20.14.md)
 - [1.4.20.13](.github/release-notes/1.4.20.13.md)
 - [1.4.20.12](.github/release-notes/1.4.20.12.md)
 - [1.4.20.11](.github/release-notes/1.4.20.11.md)

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -202,7 +202,9 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         if entity is None:
             return None
 
-        image = await self.coordinator.xsense.get_camera_thumbnail(entity)
+        image = self.coordinator.camera_event_snapshot(entity)
+        if image is None:
+            image = await self.coordinator.xsense.get_camera_thumbnail(entity)
         if image:
             self._last_camera_image = image
         return self._last_camera_image

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -23,7 +23,7 @@ from .python_xsense import (
     camera_for_identifier,
     cameras_share_identity,
 )
-from .python_xsense.async_xsense import is_camera_entity
+from .python_xsense.async_xsense import camera_addx_serial, is_camera_entity
 from .python_xsense.event_parser import (
     camera_ai_history_event_key as _camera_ai_history_event_key,
     camera_event_record_event_key as _camera_event_record_event_key,
@@ -76,6 +76,7 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._camera_ai_history_seen: set[str] = set()
         self._camera_event_history_seen: set[str] = set()
         self._camera_event_history_initialized = False
+        self._camera_event_snapshots: dict[str, tuple[str, bytes]] = {}
         self._camera_ai_service_houses: dict[str, set[str]] = {}
         self._camera_ai_history_unsub = None
         self._camera_ai_history_lock = asyncio.Lock()
@@ -94,6 +95,33 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def mqtt_server(self, host: str):
         """Get mqtt server instance for specific host."""
         return self.mqtt_servers.get(host)
+
+    def clear_camera_event_snapshot(self, camera: Any) -> None:
+        """Discard the derived event frame for one camera."""
+        if serial := camera_addx_serial(camera):
+            self._camera_event_snapshots.pop(serial, None)
+
+    def store_camera_event_snapshot(
+        self, camera: Any, event_time: Any, image: bytes
+    ) -> None:
+        """Store one derived event frame for the matching camera event."""
+        serial = camera_addx_serial(camera)
+        timestamp = str(event_time or "")
+        if serial and timestamp and image:
+            self._camera_event_snapshots[serial] = (timestamp, image)
+
+    def camera_event_snapshot(self, camera: Any) -> bytes | None:
+        """Return the derived frame only while it matches the current event."""
+        serial = camera_addx_serial(camera)
+        if not serial:
+            return None
+        snapshot = self._camera_event_snapshots.get(serial)
+        if snapshot is None:
+            return None
+        event_time, image = snapshot
+        if event_time != str(getattr(camera, "data", {}).get("eventTime") or ""):
+            return None
+        return image
 
     def _async_create_entry_task(self, coro, name: str):
         """Create a task owned by this config entry when supported."""

--- a/custom_components/xsense/event.py
+++ b/custom_components/xsense/event.py
@@ -552,12 +552,19 @@ def _trigger_event_after_recording_cache(
     if not entry_id:
         return False
     _add_recording_panel_url(event_data, entry_id=entry_id, entity=entity)
+    coordinator = getattr(event_entity, "coordinator", None)
+    clear_snapshot = getattr(coordinator, "clear_camera_event_snapshot", None)
+    if callable(clear_snapshot):
+        clear_snapshot(entity)
     event_received_at = monotonic()
     event_data["recording_cache_pending"] = True
     event_data["recording_cache_ready"] = False
 
     async def _async_cache_then_trigger() -> None:
-        from .recordings_media import async_cache_recording_playback
+        from .recordings_media import (
+            async_cache_recording_playback,
+            async_extract_camera_event_snapshot,
+        )
 
         cache_started_at = monotonic()
         LOGGER.debug(
@@ -610,6 +617,19 @@ def _trigger_event_after_recording_cache(
             _write_event_state(event_entity)
             return
         proxied = cached_url.startswith(f"/api/{DOMAIN}/recordings/play/")
+        try:
+            snapshot = await async_extract_camera_event_snapshot(hass, playback)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug(
+                "X-Sense camera event snapshot preparation failed: %s",
+                {"error_type": type(exc).__name__},
+            )
+            snapshot = None
+        store_snapshot = getattr(coordinator, "store_camera_event_snapshot", None)
+        if snapshot and callable(store_snapshot):
+            store_snapshot(entity, event_data.get("time"), snapshot)
+            if camera_entity_id := event_data.get("camera_entity_id"):
+                event_data["snapshot_url"] = f"/api/camera_proxy/{camera_entity_id}"
         event_data["recording_media_url"] = cached_url
         event_data["recording_cache_ready"] = True
         event_data["recording_cache_pending"] = False

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.13"
+PANEL_ASSET_VERSION = "1.4.20.14"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.13",
+  "version": "1.4.20.14",
   "zeroconf": []
 }

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -397,6 +397,39 @@ async def async_cache_recording_playback(
     return ""
 
 
+async def async_extract_camera_event_snapshot(
+    hass: HomeAssistant, playback: dict[str, Any]
+) -> bytes | None:
+    """Extract one high-quality still from the APK-provided event recording."""
+    video_url = _preferred_recording_video_url(playback, "HD")
+    if not video_url:
+        return None
+    try:
+        result = await hass.async_add_executor_job(
+            _extract_camera_event_snapshot,
+            video_url,
+        )
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.debug(
+            "X-Sense camera event snapshot extraction failed: %s",
+            {"error_type": type(exc).__name__},
+        )
+        return None
+    image = result.get("image")
+    LOGGER.debug(
+        "X-Sense camera event snapshot extraction: %s",
+        {
+            "ready": isinstance(image, bytes) and bool(image),
+            "width": result.get("width"),
+            "height": result.get("height"),
+            "bytes": len(image) if isinstance(image, bytes) else 0,
+            "reason": result.get("reason"),
+            "returncode": result.get("returncode"),
+        },
+    )
+    return image if isinstance(image, bytes) and image else None
+
+
 async def async_cache_recent_recording_media(
     hass: HomeAssistant,
     *,
@@ -2473,6 +2506,102 @@ def _write_cache_file(path: Path, payload: bytes) -> None:
     temp_path = path.with_name(f"{path.stem}.tmp{path.suffix}")
     temp_path.write_bytes(payload)
     temp_path.replace(path)
+
+
+def _extract_camera_event_snapshot(video_url: str) -> dict[str, Any]:
+    """Extract the first complete video frame without retaining the recording."""
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return {"reason": "ffmpeg_unavailable"}
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        video_url,
+        "-map",
+        "0:v:0",
+        "-an",
+        "-ss",
+        "1",
+        "-frames:v",
+        "1",
+        "-c:v",
+        "mjpeg",
+        "-q:v",
+        "2",
+        "-f",
+        "image2pipe",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {"reason": "ffmpeg_failed"}
+    if result.returncode != 0:
+        return {"reason": "ffmpeg_failed", "returncode": result.returncode}
+    image = bytes(result.stdout or b"")
+    dimensions = _jpeg_dimensions(image)
+    if dimensions is None:
+        return {"reason": "invalid_jpeg", "returncode": result.returncode}
+    width, height = dimensions
+    return {
+        "image": image,
+        "width": width,
+        "height": height,
+        "returncode": result.returncode,
+    }
+
+
+def _jpeg_dimensions(payload: bytes) -> tuple[int, int] | None:
+    """Return JPEG dimensions without adding an image-library dependency."""
+    if len(payload) < 4 or payload[:2] != b"\xff\xd8":
+        return None
+    start_of_frame = {
+        0xC0,
+        0xC1,
+        0xC2,
+        0xC3,
+        0xC5,
+        0xC6,
+        0xC7,
+        0xC9,
+        0xCA,
+        0xCB,
+        0xCD,
+        0xCE,
+        0xCF,
+    }
+    index = 2
+    while index + 3 < len(payload):
+        if payload[index] != 0xFF:
+            index += 1
+            continue
+        while index < len(payload) and payload[index] == 0xFF:
+            index += 1
+        if index >= len(payload):
+            return None
+        marker = payload[index]
+        index += 1
+        if marker in {0x01, 0xD8, 0xD9}:
+            continue
+        if index + 2 > len(payload):
+            return None
+        segment_length = int.from_bytes(payload[index : index + 2], "big")
+        if segment_length < 2 or index + segment_length > len(payload):
+            return None
+        if marker in start_of_frame and segment_length >= 7:
+            height = int.from_bytes(payload[index + 3 : index + 5], "big")
+            width = int.from_bytes(payload[index + 5 : index + 7], "big")
+            return (width, height) if width > 0 and height > 0 else None
+        index += segment_length
+    return None
 
 
 def _hls_leading_playback_segment_path(path: Path) -> Path:

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -1799,6 +1799,119 @@ def test_trigger_camera_event_fires_entity_and_rich_bus_event(caplog):
     assert "CAMERA-SN" not in caplog.text
 
 
+def test_motion_event_stores_derived_frame_before_firing(monkeypatch):
+    from custom_components.xsense import event as event_module
+    from custom_components.xsense import recordings_media as media_source
+
+    scheduled = []
+    order = []
+
+    class Coordinator:
+        entry = SimpleNamespace(entry_id="entry-id")
+
+        def clear_camera_event_snapshot(self, camera_entity):
+            order.append(("clear", camera_entity.sn))
+
+        def store_camera_event_snapshot(self, camera_entity, event_time, image):
+            order.append(("store", camera_entity.sn, event_time, image))
+
+    event_entity = SimpleNamespace(
+        hass=SimpleNamespace(async_create_task=lambda coro: scheduled.append(coro)),
+        coordinator=Coordinator(),
+        _trigger_event=lambda event_type, data: order.append(
+            ("trigger", event_type, data.get("snapshot_url"))
+        ),
+    )
+    camera_entity = SimpleNamespace(sn="CAMERA-SN")
+    event_data = {
+        "time": "20260903172848",
+        "camera_entity_id": "camera.garden",
+        "snapshot_url": "https://example.invalid/event.jpg",
+        "playback": {
+            "video_url": "https://example.invalid/event.m3u8",
+            "start_time_s": 1788449308,
+            "end_time_s": 1788449326,
+        },
+    }
+
+    async def cache_recording(*args, **kwargs):
+        order.append(("recording", kwargs["playback"]["video_url"]))
+        return "/api/xsense/recordings/play/entry-id/1788449308/1788449326"
+
+    async def extract_snapshot(*args, **kwargs):
+        order.append(("extract", args[1]["video_url"]))
+        return b"high-resolution-event-frame"
+
+    monkeypatch.setattr(media_source, "async_cache_recording_playback", cache_recording)
+    monkeypatch.setattr(
+        media_source, "async_extract_camera_event_snapshot", extract_snapshot
+    )
+
+    assert event_module._trigger_event_after_recording_cache(
+        event_entity, "motion", camera_entity, event_data
+    )
+    asyncio.run(scheduled[0])
+
+    assert order == [
+        ("clear", "CAMERA-SN"),
+        ("recording", "https://example.invalid/event.m3u8"),
+        ("extract", "https://example.invalid/event.m3u8"),
+        (
+            "store",
+            "CAMERA-SN",
+            "20260903172848",
+            b"high-resolution-event-frame",
+        ),
+        ("trigger", "motion", "/api/camera_proxy/camera.garden"),
+    ]
+
+
+def test_motion_event_still_fires_when_snapshot_extraction_fails(monkeypatch):
+    from custom_components.xsense import event as event_module
+    from custom_components.xsense import recordings_media as media_source
+
+    scheduled = []
+    triggered = []
+    event_entity = SimpleNamespace(
+        hass=SimpleNamespace(async_create_task=lambda coro: scheduled.append(coro)),
+        coordinator=SimpleNamespace(entry=SimpleNamespace(entry_id="entry-id")),
+        _trigger_event=lambda event_type, data: triggered.append(
+            (event_type, data.get("snapshot_url"))
+        ),
+    )
+    event_data = {
+        "time": "20260903172848",
+        "camera_entity_id": "camera.garden",
+        "snapshot_url": "https://example.invalid/event.jpg",
+        "playback": {
+            "video_url": "https://example.invalid/event.m3u8",
+            "start_time_s": 1788449308,
+            "end_time_s": 1788449326,
+        },
+    }
+
+    async def cache_recording(*args, **kwargs):
+        return "/api/xsense/recordings/play/entry-id/1788449308/1788449326"
+
+    async def fail_snapshot(*args, **kwargs):
+        raise RuntimeError("snapshot unavailable")
+
+    monkeypatch.setattr(media_source, "async_cache_recording_playback", cache_recording)
+    monkeypatch.setattr(
+        media_source, "async_extract_camera_event_snapshot", fail_snapshot
+    )
+
+    assert event_module._trigger_event_after_recording_cache(
+        event_entity,
+        "motion",
+        SimpleNamespace(sn="CAMERA-SN"),
+        event_data,
+    )
+    asyncio.run(scheduled[0])
+
+    assert triggered == [("motion", "https://example.invalid/event.jpg")]
+
+
 def test_motion_event_entity_updates_state_only_when_recording_cache_returns_no_media(
     monkeypatch,
     caplog,
@@ -6014,6 +6127,10 @@ async def test_camera_image_uses_adapter_and_keeps_last_good_image():
                 get_camera_thumbnail=get_camera_thumbnail,
             )
 
+        def camera_event_snapshot(self, current):
+            assert current is camera_entity
+            return None
+
         def async_add_listener(self, *args, **kwargs):
             return lambda: None
 
@@ -6022,6 +6139,106 @@ async def test_camera_image_uses_adapter_and_keeps_last_good_image():
 
     assert await camera.async_camera_image() == b"jpeg-image"
     assert await camera.async_camera_image() == b"jpeg-image"
+
+
+async def test_camera_image_prefers_derived_event_frame_over_cloud_thumbnail():
+    from custom_components.xsense.camera import (
+        CAMERA_DESCRIPTION,
+        XSenseCameraEntity,
+    )
+
+    camera_entity = entity("SSC0A", {"eventTime": "20260903172848"})
+    camera_entity.entity_id = "camera-test"
+    camera_entity.sn = "SSC0ATEST"
+    camera_entity.name = "Camera"
+
+    async def unexpected_thumbnail(current):
+        raise AssertionError("cloud thumbnail must remain a fallback")
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = SimpleNamespace(get_camera_thumbnail=unexpected_thumbnail)
+
+        def camera_event_snapshot(self, current):
+            assert current is camera_entity
+            return b"high-resolution-event-frame"
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    camera = XSenseCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+
+    assert await camera.async_camera_image() == b"high-resolution-event-frame"
+
+
+def test_camera_event_snapshot_extraction_uses_video_only_ffmpeg(monkeypatch):
+    from custom_components.xsense import recordings_media as media_source
+
+    jpeg = b"\xff\xd8\xff\xc0\x00\x07\x08\x04\x38\x07\x80"
+    calls = []
+
+    monkeypatch.setattr(media_source.shutil, "which", lambda executable: "/ffmpeg")
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(returncode=0, stdout=jpeg, stderr=b"")
+
+    monkeypatch.setattr(media_source.subprocess, "run", run)
+
+    result = media_source._extract_camera_event_snapshot(
+        "https://example.invalid/event-hd.m3u8"
+    )
+
+    assert result == {
+        "image": jpeg,
+        "width": 1920,
+        "height": 1080,
+        "returncode": 0,
+    }
+    command, kwargs = calls[0]
+    assert command[command.index("-i") + 1] == "https://example.invalid/event-hd.m3u8"
+    assert command[command.index("-map") + 1] == "0:v:0"
+    assert "-an" in command
+    assert command[command.index("-ss") + 1] == "1"
+    assert kwargs == {"capture_output": True, "check": False, "timeout": 10}
+
+
+def test_camera_event_snapshot_prefers_hd_recording_candidate(monkeypatch):
+    from custom_components.xsense import recordings_media as media_source
+
+    extracted = []
+
+    def extract(url):
+        extracted.append(url)
+        return {"image": b"jpeg", "width": 1920, "height": 1080, "returncode": 0}
+
+    monkeypatch.setattr(media_source, "_extract_camera_event_snapshot", extract)
+    hass = SimpleNamespace(
+        async_add_executor_job=lambda func, *args: asyncio.to_thread(func, *args)
+    )
+
+    image = asyncio.run(
+        media_source.async_extract_camera_event_snapshot(
+            hass,
+            {
+                "video_url": "https://example.invalid/event-720.m3u8",
+                "resolution": "1280x720",
+                "multi_resolution_videos": [
+                    {
+                        "videoUrl": "https://example.invalid/event-1080.m3u8",
+                        "resolutionInfo": "1920x1080",
+                    }
+                ],
+            },
+        )
+    )
+
+    assert image == b"jpeg"
+    assert extracted == ["https://example.invalid/event-1080.m3u8"]
 
 
 async def test_failed_webrtc_signal_start_is_removed_from_sessions(monkeypatch):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1227,6 +1227,36 @@ def test_camera_metadata_refresh_preserves_latest_motion_event_image():
     assert refreshed.data["lastEventImageTime"] == 1_700_000_100
 
 
+def test_camera_event_snapshot_is_scoped_to_camera_and_current_event():
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator._camera_event_snapshots = {}
+    first = SimpleNamespace(
+        entity_id="camera-one",
+        sn="CAMERA-ONE",
+        data={"eventTime": "20260903172848"},
+    )
+    second = SimpleNamespace(
+        entity_id="camera-two",
+        sn="CAMERA-TWO",
+        data={"eventTime": "20260903172948"},
+    )
+
+    coordinator.store_camera_event_snapshot(
+        first, "20260903172848", b"camera-one-frame"
+    )
+
+    assert coordinator.camera_event_snapshot(first) == b"camera-one-frame"
+    assert coordinator.camera_event_snapshot(second) is None
+
+    first.data["eventTime"] = "20260903173048"
+    assert coordinator.camera_event_snapshot(first) is None
+
+    coordinator.clear_camera_event_snapshot(first)
+    assert coordinator._camera_event_snapshots == {}
+
+
 def test_mqtt_camera_motion_event_preserves_apk_event_time():
     from custom_components.xsense.coordinator import _mqtt_reported_data
 


### PR DESCRIPTION
## Summary

- extract a clearer motion-event image from the highest-quality available recording
- serve the improved image through the Home Assistant camera entity and event snapshot URL
- retain the X-Sense event thumbnail as a fallback when extraction is unavailable
- prepare the v1.4.20.14 prerelease metadata and user-facing notes

## Validation

- 960 tests passed on Windows
- 960 tests passed on Linux with Python 3.14
- fork Tests, Validate, and CodeQL workflows passed
- real ffmpeg extraction produced a valid 1920x1080 JPEG

No WebRTC live-signaling or aiortc changes are included.