### PR TITLE
Prerelease v1.4.20.15

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.14):
-  (e.g., 1.4.20.14)
+- **X-Sense-Integration Version** (z. B. 1.4.20.15):
+  (e.g., 1.4.20.15)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.15.md
+++ b/.github/release-notes/1.4.20.15.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.15
+
+### Camera Live View
+- Improves live-view startup when one camera works but another remains stuck loading.
+- Preserves the established camera-switching path and high-quality event snapshots.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.15](.github/release-notes/1.4.20.15.md)
 - [1.4.20.14](.github/release-notes/1.4.20.14.md)
 - [1.4.20.13](.github/release-notes/1.4.20.13.md)
 - [1.4.20.12](.github/release-notes/1.4.20.12.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.14"
+PANEL_ASSET_VERSION = "1.4.20.15"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.14",
+  "version": "1.4.20.15",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -180,10 +180,17 @@ class XSenseWebRTCSignalSession:
         """Return the X-Sense SDP answer for a Home Assistant WebRTC offer."""
         LOGGER.debug("X-Sense WebRTC signal relay starting: %s", self._debug_context())
         await self._connect_signal()
-        LOGGER.debug(
-            "X-Sense WebRTC waiting for PEER_IN before relay offer: %s",
-            self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
-        )
+        if self._camera_online:
+            LOGGER.debug(
+                "X-Sense WebRTC sending relay offer for online camera: %s",
+                self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
+            )
+            await self._send_offer()
+        else:
+            LOGGER.debug(
+                "X-Sense WebRTC waiting for PEER_IN before relay offer: %s",
+                self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
+            )
         try:
             return await asyncio.wait_for(self._answer, timeout=_ANSWER_TIMEOUT)
         except Exception as err:
@@ -484,8 +491,12 @@ class XSenseWebRTCSignalSession:
                 offer_envelope=_signal_envelope_debug(offer),
             ),
         )
-        await self._ws.send_str(offer)
         self._offer_sent = True
+        try:
+            await self._ws.send_str(offer)
+        except Exception:
+            self._offer_sent = False
+            raise
 
         candidates = _local_sdp_candidates(self._offer_sdp)
         self._local_candidate_count = len(candidates)

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -5856,7 +5856,7 @@ def test_webrtc_client_config_uses_signal_relay_defaults():
 
 
 def test_known_good_live_webrtc_path_does_not_reintroduce_drift():
-    """Lock the live camera path to the protected WebRTC success checkpoints."""
+    """Lock the relay architecture confirmed in v1.3.12.10 on June 25."""
     import inspect
     from pathlib import Path
 

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -159,7 +159,8 @@ def test_parse_owned_sdp_answer_from_signal_envelope():
     assert webrtc_signal._owned_answer_sdp(payload, ticket()) == answer_sdp
 
 
-def test_webrtc_signal_relay_path_is_locked_to_known_success_shape():
+def test_webrtc_signal_relay_path_is_locked_to_v1_3_12_10_success_shape():
+    """Protect the native relay used by the confirmed June 25 camera test."""
     source = Path(webrtc_signal.__file__).read_text(encoding="utf-8")
 
     assert "class XSenseWebRTCSignalSession" in source
@@ -272,6 +273,53 @@ async def test_webrtc_signal_online_offer_is_guarded_before_websocket_send():
 
     assert session._offer_attempt_count == 1
     assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
+
+
+async def test_online_camera_preserves_confirmed_offer_answer_ice_order(monkeypatch):
+    """Lock v1.3.12.10 ICE ordering plus APK 1400 online startup."""
+    websocket = FakeWebSocket()
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp="v=0\r\n",
+        resolution="1920x1080",
+        camera_online=True,
+    )
+
+    async def connect_signal():
+        session._ws = websocket
+
+    monkeypatch.setattr(session, "_connect_signal", connect_signal)
+    start_task = asyncio.create_task(session.start())
+    await asyncio.sleep(0)
+
+    assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
+
+    candidate = SimpleNamespace(
+        candidate="candidate:1 1 udp 1 192.0.2.1 123 typ host",
+        sdp_mid="0",
+        sdp_m_line_index=0,
+    )
+    await session.add_candidate(candidate)
+
+    assert len(session._pending_remote_candidates) == 1
+    assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
+
+    answer_sdp = "v=0\r\n"
+    await session._handle_signal_event(
+        "SDP_ANSWER",
+        {
+            "senderClientId": "SSC0ATEST",
+            "recipientClientId": "client123",
+            "messagePayload": b64_json({"type": "answer", "sdp": answer_sdp}),
+        },
+    )
+
+    assert await start_task == answer_sdp
+    assert [message["messageType"] for message in websocket.messages] == [
+        "SDP_OFFER",
+        "ICE_CANDIDATE",
+    ]
 
 
 async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import sys
@@ -182,6 +183,95 @@ async def test_webrtc_signal_session_constructs_without_local_media_stack():
     )
 
     assert session is not None
+
+
+async def test_webrtc_signal_online_camera_sends_offer_without_peer_in(monkeypatch):
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp="v=0\r\n",
+        resolution="1920x1080",
+        camera_online=True,
+    )
+    offer_calls = 0
+
+    async def connect_signal():
+        session._ws = FakeWebSocket()
+
+    async def send_offer():
+        nonlocal offer_calls
+        offer_calls += 1
+        session._offer_sent = True
+        session._answer.set_result("v=0\r\nanswer")
+
+    monkeypatch.setattr(session, "_connect_signal", connect_signal)
+    monkeypatch.setattr(session, "_send_offer", send_offer)
+
+    answer = await session.start()
+
+    assert offer_calls == 1
+    assert answer == "v=0\r\nanswer"
+
+
+async def test_webrtc_signal_offline_camera_waits_for_peer_in(monkeypatch):
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp="v=0\r\n",
+        resolution="1920x1080",
+        camera_online=False,
+    )
+    offer_calls = 0
+
+    async def connect_signal():
+        session._ws = FakeWebSocket()
+
+    async def send_offer():
+        nonlocal offer_calls
+        offer_calls += 1
+
+    async def return_answer(_future, *, timeout):
+        assert timeout == webrtc_signal._ANSWER_TIMEOUT
+        return "v=0\r\nanswer"
+
+    monkeypatch.setattr(session, "_connect_signal", connect_signal)
+    monkeypatch.setattr(session, "_send_offer", send_offer)
+    monkeypatch.setattr(webrtc_signal.asyncio, "wait_for", return_answer)
+
+    answer = await session.start()
+
+    assert offer_calls == 0
+    assert answer == "v=0\r\nanswer"
+
+
+async def test_webrtc_signal_online_offer_is_guarded_before_websocket_send():
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    class BlockingWebSocket(FakeWebSocket):
+        async def send_str(self, message):
+            self.messages.append(json.loads(message))
+            send_started.set()
+            await release_send.wait()
+
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp="v=0\r\n",
+        resolution="1920x1080",
+        camera_online=True,
+    )
+    websocket = BlockingWebSocket()
+    session._ws = websocket
+
+    first_offer = asyncio.create_task(session._send_offer())
+    await send_started.wait()
+    await session._send_offer()
+    release_send.set()
+    await first_offer
+
+    assert session._offer_attempt_count == 1
+    assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
 
 
 async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():


### PR DESCRIPTION
## Summary
- improve live-view startup for online cameras that do not emit the peer-ready event
- preserve the established native Home Assistant relay, multi-camera switching, and HD event snapshot paths
- lock the user-confirmed offer/answer/ICE sequence against future drift

## Validation
- 964 tests passed on Windows
- 964 tests passed on Linux with Python 3.14