### PR TITLE
Restore confirmed camera peer signaling

### DIFF
--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -24,7 +24,6 @@ SIGNAL_VIEWER_TYPE = "a4x_sdk"
 _SIGNAL_NAME = "test-123"
 _DEFAULT_RESOLUTION = "1280x720"
 _ANSWER_TIMEOUT = 40
-_ONLINE_PEER_GRACE = 5
 _SIGNAL_RECONNECT_DELAY = 5
 _SIGNAL_TERMINAL_CLOSE_CODES = {3002, 3004}
 _DATA_CHANNEL_CONNECTION_ID = "7893feb"
@@ -139,9 +138,7 @@ class XSenseWebRTCSignalSession:
         self._answer: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._closed = False
         self._offer_sent = False
-        self._offer_sent_before_peer_ready = False
         self._camera_peer_ready = False
-        self._camera_peer_event = asyncio.Event()
         self._signal_event_counts: Counter[str] = Counter()
         self._local_candidate_count = 0
         self._sent_candidate_count = 0
@@ -165,7 +162,6 @@ class XSenseWebRTCSignalSession:
                 "camera_online": self._camera_online,
                 "camera_peer_ready": self._camera_peer_ready,
                 "offer_sent": self._offer_sent,
-                "offer_sent_before_peer_ready": self._offer_sent_before_peer_ready,
                 "sdp_answer_received": _future_has_result(self._answer),
                 "last_signal_event": self._last_signal_event,
                 "signal_events": dict(self._signal_event_counts),
@@ -184,13 +180,10 @@ class XSenseWebRTCSignalSession:
         """Return the X-Sense SDP answer for a Home Assistant WebRTC offer."""
         LOGGER.debug("X-Sense WebRTC signal relay starting: %s", self._debug_context())
         await self._connect_signal()
-        if self._camera_online:
-            await self._send_online_offer_after_peer_grace()
-        else:
-            LOGGER.debug(
-                "X-Sense WebRTC waiting for PEER_IN before relay offer: %s",
-                self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
-            )
+        LOGGER.debug(
+            "X-Sense WebRTC waiting for PEER_IN before relay offer: %s",
+            self._debug_context(answer_timeout_s=_ANSWER_TIMEOUT),
+        )
         try:
             return await asyncio.wait_for(self._answer, timeout=_ANSWER_TIMEOUT)
         except Exception as err:
@@ -333,7 +326,6 @@ class XSenseWebRTCSignalSession:
             return
         self._reset_offer_attempt("signal_reconnect")
         self._camera_peer_ready = False
-        self._camera_peer_event.clear()
         with suppress(Exception):
             await self.close_signal_only()
         self._signal_reconnect_count += 1
@@ -343,8 +335,6 @@ class XSenseWebRTCSignalSession:
         )
         try:
             await self._connect_signal()
-            if self._camera_online:
-                await self._send_online_offer_after_peer_grace()
         except Exception as err:
             LOGGER.debug(
                 "X-Sense WebRTC signal relay reconnect failed: %s",
@@ -352,22 +342,6 @@ class XSenseWebRTCSignalSession:
             )
             if not self._answer.done():
                 self._answer.set_exception(err)
-
-    async def _send_online_offer_after_peer_grace(self) -> None:
-        """Prefer camera readiness, with a bounded fallback for missing peer events."""
-        try:
-            await asyncio.wait_for(
-                self._camera_peer_event.wait(), timeout=_ONLINE_PEER_GRACE
-            )
-        except TimeoutError:
-            LOGGER.debug(
-                "X-Sense WebRTC sending relay offer after online peer grace: %s",
-                self._debug_context(
-                    peer_grace_s=_ONLINE_PEER_GRACE,
-                    answer_timeout_s=_ANSWER_TIMEOUT,
-                ),
-            )
-            await self._send_offer()
 
     async def close_signal_only(self) -> None:
         """Close only the current signal websocket before reconnecting."""
@@ -391,7 +365,6 @@ class XSenseWebRTCSignalSession:
                     or self._should_log_signal_event(event)
                 )
                 self._camera_peer_ready = True
-                self._camera_peer_event.set()
                 if should_log_peer:
                     LOGGER.debug(
                         "X-Sense WebRTC signal relay matched camera peer: %s",
@@ -400,11 +373,6 @@ class XSenseWebRTCSignalSession:
                             **_peer_event_debug(payload, self._ticket.serial_number),
                         ),
                     )
-                if (
-                    self._offer_sent_before_peer_ready
-                    and not _future_has_result(self._answer)
-                ):
-                    self._reset_offer_attempt("peer_ready_after_online_fallback")
                 await self._send_offer()
             else:
                 LOGGER.debug(
@@ -418,7 +386,6 @@ class XSenseWebRTCSignalSession:
         if event == "PEER_OUT":
             if _is_owned_peer_message(payload, self._ticket.serial_number):
                 self._camera_peer_ready = False
-                self._camera_peer_event.clear()
                 if not _future_has_result(self._answer):
                     self._reset_offer_attempt("peer_out_before_answer")
                     LOGGER.debug(
@@ -518,12 +485,10 @@ class XSenseWebRTCSignalSession:
             ),
         )
         self._offer_sent = True
-        self._offer_sent_before_peer_ready = not self._camera_peer_ready
         try:
             await self._ws.send_str(offer)
         except Exception:
             self._offer_sent = False
-            self._offer_sent_before_peer_ready = False
             raise
 
         candidates = _local_sdp_candidates(self._offer_sdp)
@@ -587,7 +552,6 @@ class XSenseWebRTCSignalSession:
 
     def _reset_offer_attempt(self, reason: str) -> None:
         self._offer_sent = False
-        self._offer_sent_before_peer_ready = False
         self._local_candidate_count = 0
         self._sent_candidate_count = 0
         LOGGER.debug(

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -172,6 +172,8 @@ def test_webrtc_signal_relay_path_is_locked_to_v1_3_12_10_success_shape():
     assert "start_forwarding_remote_candidates" in source
     assert "_forward_remote_candidate" in source
     assert "class XSenseWebRTCSession" not in source
+    assert "_ONLINE_PEER_GRACE" not in source
+    assert "_send_online_offer_after_peer_grace" not in source
 
 
 async def test_webrtc_signal_session_constructs_without_local_media_stack():
@@ -186,7 +188,7 @@ async def test_webrtc_signal_session_constructs_without_local_media_stack():
     assert session is not None
 
 
-async def test_webrtc_signal_online_camera_prefers_peer_in_before_offer(monkeypatch):
+async def test_webrtc_signal_online_camera_waits_for_peer_in_before_offer(monkeypatch):
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
         ticket=ticket(),
@@ -194,8 +196,6 @@ async def test_webrtc_signal_online_camera_prefers_peer_in_before_offer(monkeypa
         resolution="1920x1080",
         camera_online=True,
     )
-    offer_calls = 0
-
     async def connect_signal():
         session._ws = FakeWebSocket()
 
@@ -203,16 +203,9 @@ async def test_webrtc_signal_online_camera_prefers_peer_in_before_offer(monkeypa
     start_task = asyncio.create_task(session.start())
     await asyncio.sleep(0)
 
-    assert offer_calls == 0
+    assert session._ws.messages == []
+    assert not session._offer_sent
 
-    original_send_offer = session._send_offer
-
-    async def send_offer():
-        nonlocal offer_calls
-        offer_calls += 1
-        await original_send_offer()
-
-    monkeypatch.setattr(session, "_send_offer", send_offer)
     await session._handle_signal_event(
         "PEER_IN", {"id": "SSC0ATEST", "role": "master"}
     )
@@ -220,66 +213,13 @@ async def test_webrtc_signal_online_camera_prefers_peer_in_before_offer(monkeypa
 
     answer = await start_task
 
-    assert offer_calls == 1
-    assert answer == "v=0\r\nanswer"
-
-
-async def test_webrtc_signal_online_camera_falls_back_without_peer_in(monkeypatch):
-    session = webrtc_signal.XSenseWebRTCSignalSession(
-        session=object(),
-        ticket=ticket(),
-        offer_sdp="v=0\r\n",
-        resolution="1920x1080",
-        camera_online=True,
-    )
-
-    async def connect_signal():
-        session._ws = FakeWebSocket()
-
-    monkeypatch.setattr(session, "_connect_signal", connect_signal)
-    monkeypatch.setattr(webrtc_signal, "_ONLINE_PEER_GRACE", 0)
-    start_task = asyncio.create_task(session.start())
-    for _ in range(10):
-        if session._offer_sent:
-            break
-        await asyncio.sleep(0)
-
-    assert session._offer_sent
-    assert session._offer_sent_before_peer_ready
     assert [message["messageType"] for message in session._ws.messages] == [
         "SDP_OFFER"
     ]
-
-    session._answer.set_result("v=0\r\nanswer")
-    assert await start_task == "v=0\r\nanswer"
+    assert answer == "v=0\r\nanswer"
 
 
-async def test_webrtc_signal_resends_fallback_when_peer_becomes_ready(monkeypatch):
-    session = webrtc_signal.XSenseWebRTCSignalSession(
-        session=object(),
-        ticket=ticket(),
-        offer_sdp="v=0\r\n",
-        resolution="1920x1080",
-        camera_online=True,
-    )
-    session._ws = FakeWebSocket()
-
-    await session._send_offer()
-    await session._handle_signal_event(
-        "PEER_IN", {"id": "SSC0ATEST", "role": "master"}
-    )
-
-    assert session._offer_attempt_count == 2
-    assert not session._offer_sent_before_peer_ready
-    assert [message["messageType"] for message in session._ws.messages] == [
-        "SDP_OFFER",
-        "SDP_OFFER",
-    ]
-
-
-async def test_webrtc_signal_reconnect_clears_stale_peer_and_keeps_fallback(
-    monkeypatch,
-):
+async def test_webrtc_signal_reconnect_waits_for_fresh_peer_in(monkeypatch):
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
         ticket=ticket(),
@@ -288,12 +228,9 @@ async def test_webrtc_signal_reconnect_clears_stale_peer_and_keeps_fallback(
         camera_online=True,
     )
     session._camera_peer_ready = True
-    session._camera_peer_event.set()
-    connect_calls = 0
+    session._offer_sent = True
 
     async def connect_signal():
-        nonlocal connect_calls
-        connect_calls += 1
         session._ws = FakeWebSocket()
 
     async def no_delay(_delay):
@@ -301,15 +238,20 @@ async def test_webrtc_signal_reconnect_clears_stale_peer_and_keeps_fallback(
 
     monkeypatch.setattr(session, "_connect_signal", connect_signal)
     monkeypatch.setattr(webrtc_signal.asyncio, "sleep", no_delay)
-    monkeypatch.setattr(webrtc_signal, "_ONLINE_PEER_GRACE", 0)
 
     await session._reconnect_signal()
 
-    assert connect_calls == 1
     assert not session._camera_peer_ready
-    assert not session._camera_peer_event.is_set()
-    assert session._offer_sent
-    assert session._offer_sent_before_peer_ready
+    assert not session._offer_sent
+    assert session._ws.messages == []
+
+    await session._handle_signal_event(
+        "PEER_IN", {"id": "SSC0ATEST", "role": "master"}
+    )
+
+    assert [message["messageType"] for message in session._ws.messages] == [
+        "SDP_OFFER"
+    ]
 
 
 async def test_webrtc_signal_offline_camera_waits_for_peer_in(monkeypatch):


### PR DESCRIPTION
## Summary
- restore the confirmed v1.3.12.10 camera signaling order
- wait for the matching camera `PEER_IN` before sending one SDP offer
- preserve the same rule after signal reconnects
- remove the timer, fallback offer, and resend heuristic introduced by #329
- add regression assertions preventing those heuristics from returning

## Validation
- focused camera tests: 211 passed
- Windows full suite: 965 passed
- Linux server, Python 3.14 / Home Assistant 2026.8.3: 965 passed
- fork Tests, Validate, and CodeQL: passed
- `compileall` and `git diff --check`: clean

No snapshot, recording, identity, discovery, or Home Assistant media-path code changed.