### PR TITLE
Prepare v1.4.20.16 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.15):
-  (e.g., 1.4.20.15)
+- **X-Sense-Integration Version** (z. B. 1.4.20.16):
+  (e.g., 1.4.20.16)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.16.md
+++ b/.github/release-notes/1.4.20.16.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.16
+
+### Camera Live View
+- Restores the previously working camera live-view startup and switching behavior.
+- Keeps high-quality event snapshots separate from live streaming.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.16](.github/release-notes/1.4.20.16.md)
 - [1.4.20.15](.github/release-notes/1.4.20.15.md)
 - [1.4.20.14](.github/release-notes/1.4.20.14.md)
 - [1.4.20.13](.github/release-notes/1.4.20.13.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.15"
+PANEL_ASSET_VERSION = "1.4.20.16"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.15",
+  "version": "1.4.20.16",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- prepare the `v1.4.20.16` prerelease
- restore the previously working camera live-view startup and switching behavior
- keep high-quality event snapshots separate from live streaming

## Validation
- 965 tests passed locally
- fork Tests passed on Python 3.13 and 3.14
- fork Validate and CodeQL passed
- `compileall` and `git diff --check` clean