### PR TITLE
Prerelease v1.4.20.17

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.16):
-  (e.g., 1.4.20.16)
+- **X-Sense-Integration Version** (z. B. 1.4.20.17):
+  (e.g., 1.4.20.17)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.17.md
+++ b/.github/release-notes/1.4.20.17.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.17
+
+### Camera Live View
+- Restores the established camera signaling sequence after recent live-view regressions.
+- Keeps event snapshots separate from live-stream startup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.17](.github/release-notes/1.4.20.17.md)
 - [1.4.20.16](.github/release-notes/1.4.20.16.md)
 - [1.4.20.15](.github/release-notes/1.4.20.15.md)
 - [1.4.20.14](.github/release-notes/1.4.20.14.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.16"
+PANEL_ASSET_VERSION = "1.4.20.17"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.16",
+  "version": "1.4.20.17",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -484,12 +484,8 @@ class XSenseWebRTCSignalSession:
                 offer_envelope=_signal_envelope_debug(offer),
             ),
         )
+        await self._ws.send_str(offer)
         self._offer_sent = True
-        try:
-            await self._ws.send_str(offer)
-        except Exception:
-            self._offer_sent = False
-            raise
 
         candidates = _local_sdp_candidates(self._offer_sdp)
         self._local_candidate_count = len(candidates)

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -6,6 +6,8 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.xsense.python_xsense import webrtc_signal
 
 
@@ -285,7 +287,7 @@ async def test_webrtc_signal_offline_camera_waits_for_peer_in(monkeypatch):
     assert answer == "v=0\r\nanswer"
 
 
-async def test_webrtc_signal_online_offer_is_guarded_before_websocket_send():
+async def test_webrtc_signal_marks_offer_sent_after_websocket_send():
     send_started = asyncio.Event()
     release_send = asyncio.Event()
 
@@ -307,12 +309,35 @@ async def test_webrtc_signal_online_offer_is_guarded_before_websocket_send():
 
     first_offer = asyncio.create_task(session._send_offer())
     await send_started.wait()
-    await session._send_offer()
+
+    assert session._offer_sent is False
+
     release_send.set()
     await first_offer
 
     assert session._offer_attempt_count == 1
+    assert session._offer_sent is True
     assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
+
+
+async def test_webrtc_signal_failed_offer_send_remains_retryable():
+    class FailingWebSocket(FakeWebSocket):
+        async def send_str(self, message):
+            raise RuntimeError("send failed")
+
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(),
+        ticket=ticket(),
+        offer_sdp="v=0\r\n",
+        resolution="1920x1080",
+        camera_online=True,
+    )
+    session._ws = FailingWebSocket()
+
+    with pytest.raises(RuntimeError, match="send failed"):
+        await session._send_offer()
+
+    assert session._offer_sent is False
 
 
 async def test_online_camera_preserves_confirmed_offer_answer_ice_order(monkeypatch):


### PR DESCRIPTION
## Summary

- restore the established camera WebRTC offer-send sequence
- keep event snapshot handling separate from live-stream startup
- update release metadata for v1.4.20.17

## Validation

- 966 tests passed on Linux with Python 3.14
- compileall passed
- git diff check passed