### PR TITLE
Serve highest-quality camera event snapshots

### DIFF
--- a/.github/release-notes/1.4.20.17.md
+++ b/.github/release-notes/1.4.20.17.md
@@ -1,5 +1,6 @@
 ## X-Sense Home Security v1.4.20.17
 
-### Camera Live View
-- Restores the established camera signaling sequence after recent live-view regressions.
-- Keeps event snapshots separate from live-stream startup.
+### Camera Live View and Snapshots
+- Restores the established camera signaling sequence used by Home Assistant live view.
+- Selects the highest-resolution video stream available when creating event snapshots.
+- Waits for the event-recording frame before falling back to the lower-resolution X-Sense thumbnail.

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -202,7 +202,14 @@ class XSenseCameraEntity(XSenseEntity, Camera):
         if entity is None:
             return None
 
-        image = self.coordinator.camera_event_snapshot(entity)
+        prepare_snapshot = getattr(
+            self.coordinator, "async_camera_event_snapshot", None
+        )
+        image = (
+            await prepare_snapshot(entity)
+            if callable(prepare_snapshot)
+            else self.coordinator.camera_event_snapshot(entity)
+        )
         if image is None:
             image = await self.coordinator.xsense.get_camera_thumbnail(entity)
         if image:

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -77,6 +77,9 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._camera_event_history_seen: set[str] = set()
         self._camera_event_history_initialized = False
         self._camera_event_snapshots: dict[str, tuple[str, bytes]] = {}
+        self._camera_event_snapshot_tasks: dict[
+            str, tuple[str, asyncio.Task[bytes | None]]
+        ] = {}
         self._camera_ai_service_houses: dict[str, set[str]] = {}
         self._camera_ai_history_unsub = None
         self._camera_ai_history_lock = asyncio.Lock()
@@ -123,6 +126,54 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return None
         return image
 
+    async def async_camera_event_snapshot(self, camera: Any) -> bytes | None:
+        """Return the current event frame, extracting it once when necessary."""
+        if image := self.camera_event_snapshot(camera):
+            return image
+
+        serial = camera_addx_serial(camera)
+        data = getattr(camera, "data", {})
+        event_time = str(data.get("eventTime") or "") if isinstance(data, dict) else ""
+        playback = data.get("playback") if isinstance(data, dict) else None
+        if not serial or not event_time or not isinstance(playback, dict):
+            return None
+
+        tasks = self._camera_event_snapshot_tasks
+        pending = tasks.get(serial)
+        if pending is not None and pending[0] != event_time:
+            if not pending[1].done():
+                pending[1].cancel()
+            tasks.pop(serial, None)
+            pending = None
+
+        if pending is None:
+            from .recordings_media import async_extract_camera_event_snapshot
+
+            task = self._async_create_entry_task(
+                async_extract_camera_event_snapshot(self.hass, playback),
+                f"X-Sense camera event snapshot {serial}",
+            )
+            pending = (event_time, task)
+            tasks[serial] = pending
+
+        try:
+            image = await asyncio.shield(pending[1])
+        except asyncio.CancelledError:
+            if pending[1].cancelled():
+                return None
+            raise
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.debug(
+                "X-Sense camera event snapshot task failed: %s",
+                {"error_type": type(exc).__name__},
+            )
+            return None
+
+        current_time = str(getattr(camera, "data", {}).get("eventTime") or "")
+        if image and current_time == event_time:
+            self.store_camera_event_snapshot(camera, event_time, image)
+        return self.camera_event_snapshot(camera)
+
     def _async_create_entry_task(self, coro, name: str):
         """Create a task owned by this config entry when supported."""
         create_task = getattr(getattr(self, "entry", None), "async_create_task", None)
@@ -146,6 +197,14 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._camera_ai_history_unsub is not None:
             self._camera_ai_history_unsub()
             self._camera_ai_history_unsub = None
+
+        snapshot_tasks = [task for _, task in self._camera_event_snapshot_tasks.values()]
+        self._camera_event_snapshot_tasks.clear()
+        for task in snapshot_tasks:
+            if not task.done():
+                task.cancel()
+        if snapshot_tasks:
+            await asyncio.gather(*snapshot_tasks, return_exceptions=True)
 
         mqtt_servers = list(self.mqtt_servers.values())
         self.mqtt_servers.clear()

--- a/custom_components/xsense/event.py
+++ b/custom_components/xsense/event.py
@@ -561,10 +561,7 @@ def _trigger_event_after_recording_cache(
     event_data["recording_cache_ready"] = False
 
     async def _async_cache_then_trigger() -> None:
-        from .recordings_media import (
-            async_cache_recording_playback,
-            async_extract_camera_event_snapshot,
-        )
+        from .recordings_media import async_cache_recording_playback
 
         cache_started_at = monotonic()
         LOGGER.debug(
@@ -618,7 +615,13 @@ def _trigger_event_after_recording_cache(
             return
         proxied = cached_url.startswith(f"/api/{DOMAIN}/recordings/play/")
         try:
-            snapshot = await async_extract_camera_event_snapshot(hass, playback)
+            prepare_snapshot = getattr(coordinator, "async_camera_event_snapshot", None)
+            if callable(prepare_snapshot):
+                snapshot = await prepare_snapshot(entity)
+            else:
+                from .recordings_media import async_extract_camera_event_snapshot
+
+                snapshot = await async_extract_camera_event_snapshot(hass, playback)
         except Exception as exc:  # noqa: BLE001
             LOGGER.debug(
                 "X-Sense camera event snapshot preparation failed: %s",

--- a/custom_components/xsense/recordings_media.py
+++ b/custom_components/xsense/recordings_media.py
@@ -2513,6 +2513,7 @@ def _extract_camera_event_snapshot(video_url: str) -> dict[str, Any]:
     ffmpeg = shutil.which("ffmpeg")
     if not ffmpeg:
         return {"reason": "ffmpeg_unavailable"}
+    # Let ffmpeg select the highest-resolution video variant from HLS masters.
     command = [
         ffmpeg,
         "-hide_banner",
@@ -2520,11 +2521,7 @@ def _extract_camera_event_snapshot(video_url: str) -> dict[str, Any]:
         "error",
         "-i",
         video_url,
-        "-map",
-        "0:v:0",
         "-an",
-        "-ss",
-        "1",
         "-frames:v",
         "1",
         "-c:v",

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -6175,7 +6175,7 @@ async def test_camera_image_prefers_derived_event_frame_over_cloud_thumbnail():
     assert await camera.async_camera_image() == b"high-resolution-event-frame"
 
 
-def test_camera_event_snapshot_extraction_uses_video_only_ffmpeg(monkeypatch):
+def test_camera_event_snapshot_extraction_uses_best_video_only_ffmpeg(monkeypatch):
     from custom_components.xsense import recordings_media as media_source
 
     jpeg = b"\xff\xd8\xff\xc0\x00\x07\x08\x04\x38\x07\x80"
@@ -6201,10 +6201,57 @@ def test_camera_event_snapshot_extraction_uses_video_only_ffmpeg(monkeypatch):
     }
     command, kwargs = calls[0]
     assert command[command.index("-i") + 1] == "https://example.invalid/event-hd.m3u8"
-    assert command[command.index("-map") + 1] == "0:v:0"
     assert "-an" in command
-    assert command[command.index("-ss") + 1] == "1"
+    assert "-map" not in command
+    assert "-ss" not in command
     assert kwargs == {"capture_output": True, "check": False, "timeout": 10}
+
+
+async def test_camera_image_waits_for_current_event_frame_before_thumbnail():
+    from custom_components.xsense.camera import (
+        CAMERA_DESCRIPTION,
+        XSenseCameraEntity,
+    )
+
+    camera_entity = entity(
+        "SSC0A",
+        {
+            "eventTime": "20260905190000",
+            "playback": {"video_url": "https://example.invalid/event.m3u8"},
+        },
+    )
+    camera_entity.entity_id = "camera-test"
+    camera_entity.sn = "SSC0ATEST"
+    camera_entity.name = "Camera"
+    order = []
+
+    async def prepare_snapshot(current):
+        assert current is camera_entity
+        order.append("extract")
+        await asyncio.sleep(0)
+        return b"full-resolution-frame"
+
+    async def unexpected_thumbnail(current):
+        order.append("thumbnail")
+        return b"low-resolution-thumbnail"
+
+    class Coordinator:
+        def __init__(self):
+            self.data = {
+                "stations": {camera_entity.entity_id: camera_entity},
+                "devices": {},
+            }
+            self.xsense = SimpleNamespace(get_camera_thumbnail=unexpected_thumbnail)
+
+        async_camera_event_snapshot = staticmethod(prepare_snapshot)
+
+        def async_add_listener(self, *args, **kwargs):
+            return lambda: None
+
+    camera = XSenseCameraEntity(Coordinator(), camera_entity, CAMERA_DESCRIPTION)
+
+    assert await camera.async_camera_image() == b"full-resolution-frame"
+    assert order == ["extract"]
 
 
 def test_camera_event_snapshot_prefers_hd_recording_candidate(monkeypatch):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1257,6 +1257,82 @@ def test_camera_event_snapshot_is_scoped_to_camera_and_current_event():
     assert coordinator._camera_event_snapshots == {}
 
 
+async def test_camera_event_snapshot_extraction_is_shared_per_camera_event(monkeypatch):
+    from custom_components.xsense import recordings_media
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    release = asyncio.Event()
+    calls = []
+
+    async def extract(_hass, playback):
+        calls.append(playback["video_url"])
+        await release.wait()
+        return b"full-resolution-frame"
+
+    monkeypatch.setattr(recordings_media, "async_extract_camera_event_snapshot", extract)
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.hass = SimpleNamespace(create_task=asyncio.create_task)
+    coordinator.entry = None
+    coordinator._camera_event_snapshots = {}
+    coordinator._camera_event_snapshot_tasks = {}
+    camera = SimpleNamespace(
+        entity_id="camera-one",
+        sn="CAMERA-ONE",
+        data={
+            "eventTime": "20260905190000",
+            "playback": {"video_url": "https://example.invalid/event.m3u8"},
+        },
+    )
+
+    first = asyncio.create_task(coordinator.async_camera_event_snapshot(camera))
+    second = asyncio.create_task(coordinator.async_camera_event_snapshot(camera))
+    await asyncio.sleep(0)
+    release.set()
+
+    assert await first == b"full-resolution-frame"
+    assert await second == b"full-resolution-frame"
+    assert calls == ["https://example.invalid/event.m3u8"]
+
+
+async def test_camera_event_snapshot_does_not_store_frame_for_superseded_event(
+    monkeypatch,
+):
+    from custom_components.xsense import recordings_media
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    release = asyncio.Event()
+
+    async def extract(_hass, _playback):
+        await release.wait()
+        return b"old-event-frame"
+
+    monkeypatch.setattr(recordings_media, "async_extract_camera_event_snapshot", extract)
+    coordinator = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    coordinator.hass = SimpleNamespace(create_task=asyncio.create_task)
+    coordinator.entry = None
+    coordinator._camera_event_snapshots = {}
+    coordinator._camera_event_snapshot_tasks = {}
+    camera = SimpleNamespace(
+        entity_id="camera-one",
+        sn="CAMERA-ONE",
+        data={
+            "eventTime": "20260905190000",
+            "playback": {"video_url": "https://example.invalid/old.m3u8"},
+        },
+    )
+
+    pending = asyncio.create_task(coordinator.async_camera_event_snapshot(camera))
+    await asyncio.sleep(0)
+    camera.data = {
+        "eventTime": "20260905190100",
+        "playback": {"video_url": "https://example.invalid/new.m3u8"},
+    }
+    release.set()
+
+    assert await pending is None
+    assert coordinator.camera_event_snapshot(camera) is None
+
+
 def test_mqtt_camera_motion_event_preserves_apk_event_time():
     from custom_components.xsense.coordinator import _mqtt_reported_data
 


### PR DESCRIPTION
## Summary
- allow ffmpeg to select the highest-resolution stream from X-Sense HLS master playlists instead of forcing the first variant
- remove the one-second seek from event-frame extraction
- make snapshot extraction shared and awaitable per camera/event so immediate automation requests do not fall back to the low-resolution cloud thumbnail
- leave live WebRTC signaling unchanged

## Evidence
A Linux HLS fixture with a 320x180 first variant and 1280x720 second variant reproduced the problem: the released command returned 320x180, while this change returned 1280x720.

## Validation
- 969 tests passed on Linux/Python 3.14
- 969 tests passed on Windows
- HACS validation passed
- hassfest passed
- CodeQL passed for Python, JavaScript/TypeScript, and Actions
- compileall and git diff checks passed