### PR TITLE
Use current Home Assistant parent device links

### DIFF
--- a/custom_components/xsense/entity.py
+++ b/custom_components/xsense/entity.py
@@ -13,7 +13,7 @@ from .python_xsense.async_xsense import (
     is_camera_entity,
 )
 
-from homeassistant.const import ATTR_VIA_DEVICE
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -72,6 +72,44 @@ def _software_version(value: object) -> str | None:
     return version.removeprefix("v")
 
 
+def _parent_device_info(
+    coordinator: XSenseDataUpdateCoordinator,
+    station: Entity | None,
+    station_id: str,
+) -> tuple[str, object] | None:
+    """Return the HA-version-specific parent-device field and value."""
+    identifier = (DOMAIN, station_id)
+    get_device_id = getattr(dr, "async_get_device_id_by_identifier", None)
+    if get_device_id is None:
+        return "via_device", identifier
+    if not hasattr(coordinator, "entry") or not hasattr(coordinator, "hass"):
+        return None
+
+    entry_id = coordinator.entry.entry_id
+    registry = dr.async_get(coordinator.hass)
+    try:
+        device_id = get_device_id(
+            coordinator.hass,
+            identifier,
+            config_entry_id=entry_id,
+        )
+    except ValueError:
+        parent_info: dict[str, Any] = {
+            "config_entry_id": entry_id,
+            "identifiers": {identifier},
+            "manufacturer": MANUFACTURER,
+        }
+        if station is not None:
+            parent_info.update(
+                model=_device_info_str(station.type),
+                name=_device_info_str(station.name),
+            )
+            if sw_version := _software_version(station.data.get("sw")):
+                parent_info["sw_version"] = sw_version
+        device_id = registry.async_get_or_create(**parent_info).id
+    return "via_device_id", device_id
+
+
 def _apk_entity_is_available(entity: Entity) -> bool:
     """Return whether the APK treats this entity as not offline."""
     if getattr(entity, "entity_type", None) == EntityType.CAMERA:
@@ -128,8 +166,14 @@ class XSenseEntity(CoordinatorEntity):
         if sw_version := _software_version(entity.data.get("sw")):
             self._attr_device_info["sw_version"] = sw_version
         if station_id:
-            parent = (DOMAIN, station_id)
-            self._attr_device_info.update({ATTR_VIA_DEVICE: parent})
+            parent_info = _parent_device_info(
+                coordinator,
+                station,
+                station_id,
+            )
+            if parent_info is not None:
+                parent_field, parent_value = parent_info
+                self._attr_device_info[parent_field] = parent_value
 
     def _current_entity(self) -> Entity | None:
         """Return the current coordinator entity for this Home Assistant entity."""

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -267,6 +267,136 @@ def test_device_info_software_version_accepts_string_prefix_and_ignores_empty_va
     assert "sw_version" not in ProbeEntity(SimpleNamespace(), missing).device_info
 
 
+def test_child_device_info_uses_current_via_device_id(monkeypatch):
+    from custom_components.xsense import entity as entity_module
+
+    class ProbeEntity(entity_module.XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    hass = object()
+    entry = SimpleNamespace(entry_id="entry_1")
+    coordinator = SimpleNamespace(hass=hass, entry=entry)
+    station = SimpleNamespace(
+        entity_id="station_1",
+        data={"sw": "v1.2.3"},
+        sn="station-serial",
+        type="SBS50",
+        name="Base Station",
+    )
+    child = SimpleNamespace(
+        entity_id="device_1",
+        data={},
+        sn="device-serial",
+        type="SWS51",
+        name="Leak Sensor",
+        station=station,
+    )
+    registry = SimpleNamespace()
+    monkeypatch.setattr(entity_module.dr, "async_get", lambda value: registry)
+    monkeypatch.setattr(
+        entity_module.dr,
+        "async_get_device_id_by_identifier",
+        lambda value, identifier, *, config_entry_id: "parent-device-id",
+        raising=False,
+    )
+
+    device_info = ProbeEntity(coordinator, child, station.entity_id).device_info
+
+    assert device_info["via_device_id"] == "parent-device-id"
+    assert "via_device" not in device_info
+
+
+def test_child_device_info_registers_parent_before_current_lookup(monkeypatch):
+    from custom_components.xsense import entity as entity_module
+
+    class ProbeEntity(entity_module.XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    hass = object()
+    entry = SimpleNamespace(entry_id="entry_1")
+    coordinator = SimpleNamespace(hass=hass, entry=entry)
+    station = SimpleNamespace(
+        entity_id="station_1",
+        data={"sw": 123},
+        sn="station-serial",
+        type=50,
+        name=12345,
+    )
+    child = SimpleNamespace(
+        entity_id="device_1",
+        data={},
+        sn="device-serial",
+        type="SWS51",
+        name="Leak Sensor",
+        station=station,
+    )
+    calls = []
+    registry = SimpleNamespace(
+        async_get_or_create=lambda **kwargs: (
+            calls.append(kwargs) or SimpleNamespace(id="new-parent-device-id")
+        )
+    )
+
+    def _missing_parent(value, identifier, *, config_entry_id):
+        raise ValueError
+
+    monkeypatch.setattr(entity_module.dr, "async_get", lambda value: registry)
+    monkeypatch.setattr(
+        entity_module.dr,
+        "async_get_device_id_by_identifier",
+        _missing_parent,
+        raising=False,
+    )
+
+    device_info = ProbeEntity(coordinator, child, station.entity_id).device_info
+
+    assert device_info["via_device_id"] == "new-parent-device-id"
+    assert calls == [
+        {
+            "config_entry_id": "entry_1",
+            "identifiers": {("xsense", "station_1")},
+            "manufacturer": "X-Sense",
+            "model": "50",
+            "name": "12345",
+            "sw_version": "123",
+        }
+    ]
+
+
+def test_child_device_info_keeps_legacy_parent_identifier_on_older_ha(monkeypatch):
+    from custom_components.xsense import entity as entity_module
+
+    class ProbeEntity(entity_module.XSenseEntity):
+        entity_description = SimpleNamespace(key="probe")
+
+    coordinator = SimpleNamespace()
+    station = SimpleNamespace(
+        entity_id="station_1",
+        data={},
+        sn="station-serial",
+        type="SBS50",
+        name="Base Station",
+    )
+    child = SimpleNamespace(
+        entity_id="device_1",
+        data={},
+        sn="device-serial",
+        type="SWS51",
+        name="Leak Sensor",
+        station=station,
+    )
+    monkeypatch.delattr(
+        entity_module.dr,
+        "async_get_device_id_by_identifier",
+        raising=False,
+    )
+
+    device_info = ProbeEntity(coordinator, child, station.entity_id).device_info
+
+    assert device_info["via_device"] == ("xsense", "station_1")
+    assert "via_device_id" not in device_info
+
+
 def test_alarm_panel_device_info_does_not_expose_serial_number():
     from custom_components.xsense.alarm_control_panel import XSenseAlarmControlPanel
 


### PR DESCRIPTION
## Summary

- Replace the deprecated ATTR_VIA_DEVICE device-info field on Home Assistant 2026.8+ with via_device_id.
- Resolve the parent station through the config entry device registry.
- Register the known parent station first when entity setup order requires it.
- Preserve the legacy parent identifier on older supported Home Assistant versions.

Closes #334

## Validation

- 972 tests passed on Python 3.14 with Home Assistant 2026.8.3.
- Python 3.13 and 3.14 GitHub test jobs passed on the fork.
- HACS and hassfest validation passed.
- CodeQL passed for Python, JavaScript/TypeScript, and Actions.