### PR TITLE
Prepare v1.4.20.18 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.17):
-  (e.g., 1.4.20.17)
+- **X-Sense-Integration Version** (z. B. 1.4.20.18):
+  (e.g., 1.4.20.18)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.18.md
+++ b/.github/release-notes/1.4.20.18.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.20.18
+
+### Home Assistant Compatibility
+- Updates parent-device linking for Home Assistant 2026.8 and removes the deprecated `ATTR_VIA_DEVICE` warning.
+- Keeps child devices correctly linked to their X-Sense base station.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.18](.github/release-notes/1.4.20.18.md)
 - [1.4.20.17](.github/release-notes/1.4.20.17.md)
 - [1.4.20.16](.github/release-notes/1.4.20.16.md)
 - [1.4.20.15](.github/release-notes/1.4.20.15.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.17"
+PANEL_ASSET_VERSION = "1.4.20.18"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.17",
+  "version": "1.4.20.18",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary

- Bump the integration to 1.4.20.18.
- Add user-facing release notes for the Home Assistant 2026.8 parent-device compatibility update.
- Refresh the frontend asset version and issue-template version example.

## Validation

- 972 tests passed on Linux with Python 3.14 and Home Assistant 2026.8.3.
- Fork checks passed on Python 3.13 and 3.14.
- HACS, hassfest, and CodeQL passed.