### PR TITLE
Prepare v1.4.20.19 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.18):
-  (e.g., 1.4.20.18)
+- **X-Sense-Integration Version** (z. B. 1.4.20.19):
+  (e.g., 1.4.20.19)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.19.md
+++ b/.github/release-notes/1.4.20.19.md
@@ -2,3 +2,4 @@
 
 ### Home Assistant Compatibility
 - Removes the remaining device-registry deprecation warning on Home Assistant 2026.8.
+- Retries a transient cloud connection failure once before entities are marked unavailable.

--- a/.github/release-notes/1.4.20.19.md
+++ b/.github/release-notes/1.4.20.19.md
@@ -1,0 +1,4 @@
+## X-Sense Home Security v1.4.20.19
+
+### Home Assistant Compatibility
+- Removes the remaining device-registry deprecation warning on Home Assistant 2026.8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.19](.github/release-notes/1.4.20.19.md)
 - [1.4.20.18](.github/release-notes/1.4.20.18.md)
 - [1.4.20.17](.github/release-notes/1.4.20.17.md)
 - [1.4.20.16](.github/release-notes/1.4.20.16.md)

--- a/custom_components/xsense/__init__.py
+++ b/custom_components/xsense/__init__.py
@@ -757,6 +757,15 @@ def _clear_visible_device_metadata(device_registry, device) -> None:
     )
 
 
+def _device_by_identifier(device_registry, identifier, entry_id):
+    """Return one registry device by its config-entry-scoped identifier."""
+    get_device = getattr(device_registry, "async_get_device_by_identifier", None)
+    if get_device is not None:
+        return get_device(identifier, config_entry_id=entry_id)
+
+    return device_registry.async_get_device(identifiers={identifier})
+
+
 def _remove_obsolete_device_metadata(
     hass: HomeAssistant, data, entry: ConfigEntry
 ) -> None:
@@ -772,8 +781,10 @@ def _remove_obsolete_device_metadata(
         *data.get("stations", {}).values(),
         *data.get("devices", {}).values(),
     ):
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entity.entity_id)}
+        device = _device_by_identifier(
+            device_registry,
+            (DOMAIN, entity.entity_id),
+            entry.entry_id,
         )
         if device is None or device.id in checked_device_ids:
             continue

--- a/custom_components/xsense/coordinator.py
+++ b/custom_components/xsense/coordinator.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta, timezone
 import json
 from typing import Any
 
+import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant, callback
@@ -309,6 +311,28 @@ class XSenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._camera_station_cache = {}
 
     async def _async_update_data(self) -> dict[str, Any]:
+        try:
+            return await self._async_update_data_once()
+        except (aiohttp.ClientError, TimeoutError, OSError) as ex:
+            LOGGER.debug(
+                "Transient X-Sense transport failure; retrying coordinator refresh once: %s",
+                ex,
+            )
+            await asyncio.sleep(1)
+            try:
+                return await self._async_update_data_once()
+            except (aiohttp.ClientError, TimeoutError, OSError) as retry_ex:
+                raise UpdateFailed(
+                    f"X-Sense cloud connection failed after one retry: {retry_ex}"
+                ) from retry_ex
+
+    async def _async_update_data_once(self) -> dict[str, Any]:
+        """Refresh X-Sense data once.
+
+        Home Assistant's shared aiohttp connector and Paho already perform
+        address-family fallback. This additional retry prevents a single
+        transient DNS or connect failure from making every entity unavailable.
+        """
         if self.xsense is None:
             await self._connect()
         startup_refresh = not self._startup_refresh_complete

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.18"
+PANEL_ASSET_VERSION = "1.4.20.19"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.18",
+  "version": "1.4.20.19",
   "zeroconf": []
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,6 +3,7 @@ import inspect
 import json
 import logging
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -340,6 +341,87 @@ async def test_startup_refresh_defers_mqtt_and_camera_history_work():
         ("assure_subscriptions",),
         ("request_device_updates",),
     ]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_retries_one_transient_transport_failure(monkeypatch):
+    from custom_components.xsense import coordinator as coordinator_module
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+
+    instance = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    instance.xsense = SimpleNamespace(houses={})
+    instance._startup_refresh_complete = True
+    calls = 0
+
+    async def get_devices(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(101, "Network is unreachable")
+        return {"stations": {}, "devices": {}}
+
+    sleep = AsyncMock()
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", sleep)
+    instance.get_devices = get_devices
+
+    assert await XSenseDataUpdateCoordinator._async_update_data(instance) == {
+        "stations": {},
+        "devices": {},
+    }
+    assert calls == 2
+    sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_unavailable_after_transport_retry_fails(monkeypatch):
+    from custom_components.xsense import coordinator as coordinator_module
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    instance = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    instance.xsense = SimpleNamespace(houses={})
+    instance._startup_refresh_complete = True
+    calls = 0
+
+    async def get_devices(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError("DNS lookup timed out")
+
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", AsyncMock())
+    instance.get_devices = get_devices
+
+    with pytest.raises(UpdateFailed, match="after one retry"):
+        await XSenseDataUpdateCoordinator._async_update_data(instance)
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_coordinator_does_not_retry_non_transport_update_failure(monkeypatch):
+    from custom_components.xsense import coordinator as coordinator_module
+    from custom_components.xsense.coordinator import XSenseDataUpdateCoordinator
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    instance = XSenseDataUpdateCoordinator.__new__(XSenseDataUpdateCoordinator)
+    instance.xsense = SimpleNamespace(houses={})
+    instance._startup_refresh_complete = True
+    calls = 0
+
+    async def get_devices(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise UpdateFailed("API rejected request")
+
+    sleep = AsyncMock()
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", sleep)
+    instance.get_devices = get_devices
+
+    with pytest.raises(UpdateFailed, match="API rejected request"):
+        await XSenseDataUpdateCoordinator._async_update_data(instance)
+
+    assert calls == 1
+    sleep.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_entity_registry_cleanup.py
+++ b/tests/test_entity_registry_cleanup.py
@@ -480,8 +480,9 @@ def test_obsolete_device_metadata_cleanup_skips_clean_registry_entries(monkeypat
     calls = []
 
     class FakeDeviceRegistry:
-        def async_get_device(self, *, identifiers):
-            assert identifiers == {("xsense", "station_1")}
+        def async_get_device_by_identifier(self, identifier, *, config_entry_id):
+            assert identifier == ("xsense", "station_1")
+            assert config_entry_id == "entry-id"
             return device
 
         def async_update_device(self, device_id, **kwargs):
@@ -523,8 +524,9 @@ def test_obsolete_device_metadata_cleanup_handles_child_devices(monkeypatch):
     calls = []
 
     class FakeDeviceRegistry:
-        def async_get_device(self, *, identifiers):
-            return devices_by_identifier[next(iter(identifiers))]
+        def async_get_device_by_identifier(self, identifier, *, config_entry_id):
+            assert config_entry_id == "entry-id"
+            return devices_by_identifier[identifier]
 
         def async_update_device(self, device_id, **kwargs):
             calls.append((device_id, kwargs))
@@ -569,7 +571,8 @@ def test_obsolete_device_metadata_cleanup_scans_config_entry_devices(monkeypatch
     calls = []
 
     class FakeDeviceRegistry:
-        def async_get_device(self, *, identifiers):
+        def async_get_device_by_identifier(self, identifier, *, config_entry_id):
+            assert config_entry_id == "entry-id"
             return None
 
         def async_update_device(self, device_id, **kwargs):
@@ -596,6 +599,49 @@ def test_obsolete_device_metadata_cleanup_scans_config_entry_devices(monkeypatch
             {"new_connections": set(), "serial_number": None},
         )
     ]
+
+
+def test_obsolete_device_metadata_cleanup_keeps_legacy_lookup_fallback(monkeypatch):
+    device = SimpleNamespace(
+        id="device-id",
+        serial_number=None,
+        connections=set(),
+    )
+    lookups = []
+
+    class FakeLegacyDeviceRegistry:
+        def async_get_device(self, *, identifiers):
+            lookups.append(identifiers)
+            return device
+
+        def async_update_device(self, device_id, **kwargs):
+            raise AssertionError("Clean device metadata must not be updated")
+
+    import custom_components.xsense as xsense
+
+    monkeypatch.setattr(
+        xsense.dr,
+        "async_get",
+        lambda hass: FakeLegacyDeviceRegistry(),
+    )
+    monkeypatch.setattr(
+        xsense.dr,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [],
+    )
+
+    _remove_obsolete_device_metadata(
+        SimpleNamespace(),
+        {
+            "stations": {
+                "station_1": SimpleNamespace(entity_id="station_1")
+            },
+            "devices": {},
+        },
+        SimpleNamespace(entry_id="entry-id"),
+    )
+
+    assert lookups == [{("xsense", "station_1")}]
 
 
 def test_obsolete_sensor_entry_detection_is_scoped_to_xsense_sensors():


### PR DESCRIPTION
Rolls up the recent camera signaling and HD event snapshot fixes, updates Home Assistant device-registry compatibility, and retries one transient cloud transport failure before entities become unavailable.