### PR TITLE
Prepare v1.4.20.20 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.19):
-  (e.g., 1.4.20.19)
+- **X-Sense-Integration Version** (z. B. 1.4.20.20):
+  (e.g., 1.4.20.20)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.20.md
+++ b/.github/release-notes/1.4.20.20.md
@@ -1,0 +1,4 @@
+## X-Sense Home Security v1.4.20.20
+
+### Connection Reliability
+- Adds an IPv4 fallback for X-Sense cloud shadow requests when the normal network route is unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.20](.github/release-notes/1.4.20.20.md)
 - [1.4.20.19](.github/release-notes/1.4.20.19.md)
 - [1.4.20.18](.github/release-notes/1.4.20.18.md)
 - [1.4.20.17](.github/release-notes/1.4.20.17.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.19"
+PANEL_ASSET_VERSION = "1.4.20.20"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.19",
+  "version": "1.4.20.20",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -1,6 +1,9 @@
 import asyncio
+import errno
 import json
 import logging
+import socket
+from contextlib import AsyncExitStack, asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict
 
@@ -10,7 +13,7 @@ from .aws_signer import AWSSigner
 from .base import XSenseBase, shadow_update_body
 from .entity import Entity
 from .entity_map import EntityType
-from .exceptions import SessionExpired, APIFailure, XSenseError
+from .exceptions import APIFailure, SessionExpired, XSenseError
 from .house import House
 from .mapping import bool_state
 from .station import Station
@@ -474,6 +477,7 @@ class AsyncXSense(XSenseBase):
         super().__init__()
         self.session = session
         self._owns_session = session is None
+        self._ipv4_session: aiohttp.ClientSession | None = None
         self.language = _ipc_language(language)
         self._sbs50_child_info_loaded: set[tuple[str, str]] = set()
 
@@ -483,7 +487,45 @@ class AsyncXSense(XSenseBase):
             self._owns_session = True
         return self.session
 
+    async def _get_ipv4_session(self) -> aiohttp.ClientSession:
+        """Return a private IPv4 session for unreachable dual-stack routes."""
+        if self._ipv4_session is None or self._ipv4_session.closed:
+            self._ipv4_session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(family=socket.AF_INET)
+            )
+        return self._ipv4_session
+
+    @asynccontextmanager
+    async def _shadow_request(self, method: str, url: str, **kwargs):
+        """Open an AWS IoT shadow request with a narrow IPv4 fallback."""
+        async with AsyncExitStack() as stack:
+            session = await self._get_session()
+            try:
+                response = await stack.enter_async_context(
+                    getattr(session, method)(url, **kwargs)
+                )
+            except aiohttp.ClientConnectorError as ex:
+                os_error = getattr(ex, "os_error", None)
+                if getattr(os_error, "errno", None) not in {
+                    errno.ENETUNREACH,
+                    errno.EHOSTUNREACH,
+                }:
+                    raise
+                LOGGER.debug(
+                    "X-Sense AWS IoT shadow route unavailable; retrying over IPv4: %s",
+                    ex,
+                )
+                ipv4_session = await self._get_ipv4_session()
+                response = await stack.enter_async_context(
+                    getattr(ipv4_session, method)(url, **kwargs)
+                )
+
+            yield response
+
     async def close(self):
+        if self._ipv4_session is not None and not self._ipv4_session.closed:
+            await self._ipv4_session.close()
+        self._ipv4_session = None
         if self._owns_session and self.session and not self.session.closed:
             await self.session.close()
 
@@ -1304,8 +1346,7 @@ class AsyncXSense(XSenseBase):
 
         url, headers = self._house_request(house, page)
 
-        session = await self._get_session()
-        async with session.get(url, headers=headers) as response:
+        async with self._shadow_request("get", url, headers=headers) as response:
             self._lastres = response
             if response.status in (401, 403) and _retry:
                 self._apply_clock_skew_from_response(response)
@@ -1319,8 +1360,7 @@ class AsyncXSense(XSenseBase):
 
         url, headers = self._thing_request(station, page)
 
-        session = await self._get_session()
-        async with session.get(url, headers=headers) as response:
+        async with self._shadow_request("get", url, headers=headers) as response:
             self._lastres = response
             if response.status in (401, 403) and _retry:
                 self._apply_clock_skew_from_response(response)
@@ -1337,8 +1377,9 @@ class AsyncXSense(XSenseBase):
         body = shadow_update_body(data)
         url, headers = self._thing_request(station, page, body)
 
-        session = await self._get_session()
-        async with session.post(url, data=body, headers=headers) as response:
+        async with self._shadow_request(
+            "post", url, data=body, headers=headers
+        ) as response:
             self._lastres = response
             if (
                 response.status in (401, 403)

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -1,16 +1,18 @@
 import asyncio
 import base64
-from collections import defaultdict
-from datetime import timedelta
+import errno
 import hashlib
 import importlib
 import json
 import logging
 import sys
 import types
+from collections import defaultdict
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import aiohttp
 import pytest
 
 
@@ -2882,6 +2884,110 @@ class FakeGetSession:
     def get(self, url, headers=None):
         self.calls.append({"url": url, "headers": headers})
         return self._responses.pop(0)
+
+
+class FailingRequestContext:
+    def __init__(self, error):
+        self.error = error
+
+    async def __aenter__(self):
+        raise self.error
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def connector_error(error_number: int) -> aiohttp.ClientConnectorError:
+    key = SimpleNamespace(host="eu-central-1.x-sense-iot.com", port=443, ssl=True)
+    return aiohttp.ClientConnectorError(
+        key,
+        OSError(error_number, "Network is unreachable"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_read_falls_back_to_ipv4_when_route_is_unreachable():
+    client = async_xsense.AsyncXSense()
+    client._aws_token_expiring = lambda: False
+    primary = FakeGetSession([FailingRequestContext(connector_error(errno.ENETUNREACH))])
+    ipv4 = FakeGetSession([FakeGetResponse(200, {}, {"ok": True})])
+
+    async def get_session():
+        return primary
+
+    async def get_ipv4_session():
+        return ipv4
+
+    client._get_session = get_session
+    client._get_ipv4_session = get_ipv4_session
+    client._thing_request = lambda station, page: (
+        "https://eu-central-1.x-sense-iot.com/shadow",
+        {},
+    )
+
+    assert await client.get_thing(FakeXSenseStation("SBS50"), "mainpage") == {
+        "ok": True
+    }
+    assert len(primary.calls) == 1
+    assert len(ipv4.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_shadow_write_falls_back_to_ipv4_when_route_is_unreachable():
+    client = async_xsense.AsyncXSense()
+    primary = FakePostSession()
+    primary.post = Mock(
+        return_value=FailingRequestContext(connector_error(errno.EHOSTUNREACH))
+    )
+    ipv4 = FakePostSession()
+
+    async def get_session():
+        return primary
+
+    async def get_ipv4_session():
+        return ipv4
+
+    client._get_session = get_session
+    client._get_ipv4_session = get_ipv4_session
+
+    async with client._shadow_request(
+        "post", "https://eu-central-1.x-sense-iot.com/shadow", data="{}"
+    ) as response:
+        assert await response.json() == {"ok": True}
+
+    primary.post.assert_called_once()
+    assert len(ipv4.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_shadow_request_does_not_force_ipv4_for_other_connect_errors():
+    client = async_xsense.AsyncXSense()
+    primary = FakeGetSession([FailingRequestContext(connector_error(errno.ECONNREFUSED))])
+    get_ipv4_session = AsyncMock()
+
+    async def get_session():
+        return primary
+
+    client._get_session = get_session
+    client._get_ipv4_session = get_ipv4_session
+
+    with pytest.raises(aiohttp.ClientConnectorError):
+        async with client._shadow_request("get", "https://example.invalid"):
+            pass
+
+    get_ipv4_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_closes_private_ipv4_fallback_session():
+    client = async_xsense.AsyncXSense(session=SimpleNamespace(closed=False))
+    ipv4_session = SimpleNamespace(closed=False, close=AsyncMock())
+    client._ipv4_session = ipv4_session
+
+    await client.close()
+
+    ipv4_session.close.assert_awaited_once()
+    assert client._ipv4_session is None
 
 
 def test_aws_signer_applies_global_time_offset():


### PR DESCRIPTION
Adds a narrowly scoped IPv4 fallback for AWS IoT shadow reads and writes when the normal dual-stack route reports network or host unreachable.