### PR TITLE
Fix SBS50 blocked-arm prompt correlation

### DIFF
--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -207,7 +207,7 @@ class XSenseAlarmControlPanel(
         if station is None:
             return None
 
-        mode = pending_force_arm_mode(station)
+        mode = self._pending_force_arm_mode
         if mode is None:
             return None
 
@@ -240,44 +240,49 @@ class XSenseAlarmControlPanel(
         self._bound_station = station
         reported_mode = getattr(station, "alarm_mode", None)
         if self._active_normal_arm_mode is not None:
-            # Discovery can replace Station objects while an APK-style arm
-            # request is waiting for its MQTT result. Keep the request in this
-            # long-lived entity, just as the APK keeps it in its presenter.
             station.set_alarm_data(
                 {"requestedSafeMode": self._active_normal_arm_mode}
             )
-
         previous_pending_mode = self._pending_force_arm_mode
-        pending_mode = pending_force_arm_mode(station)
-        if pending_mode is not None:
+        pending_mode = previous_pending_mode
+        alarm_data = getattr(station, "alarm_data", {}) or {}
+        force_reason = alarm_data.get("forceReason")
+        if self._active_normal_arm_mode is not None:
+            requested_mode = self._active_normal_arm_mode
+            if reported_mode == requested_mode:
+                # The APK's mode listener completes the request before its
+                # force-reason listener can open a bypass confirmation.
+                self._async_clear_arm_request(station)
+                pending_mode = None
+            elif force_reason:
+                pending_mode = requested_mode
+                station.set_alarm_data(
+                    {
+                        "requestedSafeMode": requested_mode,
+                        "safeModeAim": None,
+                    }
+                )
+                self._active_normal_arm_mode = None
+                self._async_cancel_arm_request_timeout()
+        elif previous_pending_mode is not None and self._pending_force_arm_data:
+            # Keep the already-open confirmation available if discovery swaps
+            # the Station object. No new prompt is inferred from refresh data.
+            if station_replaced or not force_reason:
+                station.set_alarm_data(self._pending_force_arm_data)
+            pending_mode = previous_pending_mode
+        else:
+            pending_mode = None
+            if force_reason:
+                # The APK ignores mode results when no request listener is active.
+                station.set_alarm_data({"forceReason": None, "exitDelay": None})
+
+        if pending_mode is not None and previous_pending_mode is None:
             alarm_data = getattr(station, "alarm_data", {}) or {}
             self._pending_force_arm_data = {
                 "forceReason": alarm_data.get("forceReason"),
-                "safeModeAim": pending_mode,
                 "requestedSafeMode": pending_mode,
                 "exitDelay": alarm_data.get("exitDelay"),
             }
-            self._active_normal_arm_mode = None
-            self._async_cancel_arm_request_timeout()
-        elif (
-            station_replaced
-            and previous_pending_mode is not None
-            and self._pending_force_arm_data
-        ):
-            # Once the APK receives a blocked result, its bypass dialog lives
-            # independently of later station refreshes. Rehydrate the HA-side
-            # prompt until the user confirms it or starts a new mode request.
-            station.set_alarm_data(self._pending_force_arm_data)
-            pending_mode = previous_pending_mode
-        elif (
-            self._active_normal_arm_mode is not None
-            and reported_mode == self._active_normal_arm_mode
-        ):
-            self._async_clear_arm_request(station)
-            pending_mode = None
-        alarm_data = getattr(station, "alarm_data", {}) or {}
-        if pending_mode is not None or not alarm_data.get("requestedSafeMode"):
-            self._async_cancel_arm_request_timeout()
         if pending_mode != previous_pending_mode:
             self._pending_force_arm_mode = pending_mode
             if pending_mode is None:
@@ -373,7 +378,7 @@ class XSenseAlarmControlPanel(
         if station is None:
             raise xsense_error("station_unavailable")
 
-        pending_mode = pending_force_arm_mode(station)
+        pending_mode = self._pending_force_arm_mode
         if pending_mode != mode:
             raise xsense_error("force_arm_not_pending", mode=mode)
 
@@ -457,8 +462,7 @@ class XSenseAlarmControlPanel(
         station = self._station
         if station is None:
             return
-        alarm_data = getattr(station, "alarm_data", {}) or {}
-        if self._active_normal_arm_mode is None or alarm_data.get("forceReason"):
+        if self._active_normal_arm_mode is None:
             return
         LOGGER.debug("Station %s arm request timed out", station.sn)
         self._async_clear_arm_request(station)

--- a/custom_components/xsense/python_xsense/base.py
+++ b/custom_components/xsense/python_xsense/base.py
@@ -381,7 +381,7 @@ class XSenseBase:
 
         _normalize_apk_alarm_status(station_data)
         has_alarm_status = 'alarmStatus' in station_data or 'a' in station_data
-        _apply_sbs50_force_arm_prompt(station, station_data)
+        _apply_sbs50_mode_result(station, station_data)
         if station_data:
             station.set_data(station_data)
         if 'safeMode' in station_data:
@@ -562,96 +562,19 @@ def _child_state_identifiers(child_key, child_state) -> tuple[str, ...]:
     return tuple(result)
 
 
-def _apply_sbs50_force_arm_prompt(station: Station, station_data: Dict) -> None:
-    """Track the APK bypass confirmation prompt for SBS50 arm requests."""
-    current_alarm_data = getattr(station, "alarm_data", {}) or {}
-    reported_mode = station_data.get("safeMode")
-    requested_mode = current_alarm_data.get("requestedSafeMode")
-    prompt = _sbs50_force_arm_prompt(
-        station_data,
-        requested_mode=requested_mode,
-    )
-    if prompt is not None:
-        station.set_alarm_data(prompt)
+def _apply_sbs50_mode_result(station: Station, station_data: Dict) -> None:
+    """Retain the SBS50 mode result for the active alarm-panel request."""
+    if "forceReason" not in station_data:
+        if "safeMode" in station_data:
+            station.set_alarm_data({"forceReason": None, "exitDelay": None})
         return
 
-    request_completed = reported_mode in ("Home", "Away") and (
-        reported_mode == requested_mode
-    )
-    if request_completed:
-        station.set_alarm_data(
-            {
-                "forceReason": None,
-                "safeModeAim": None,
-                "requestedSafeMode": None,
-                "exitDelay": None,
-            }
-        )
-        return
-
-    force_reason_reported = "forceReason" in station_data
-    if force_reason_reported:
-        # The SBS50 can acknowledge the normal arm request with an empty
-        # forceReason before publishing the blocked result, and later routine
-        # state updates can report it empty again. The APK ignores empty reasons
-        # throughout the active request instead of dismissing its bypass dialog.
-        if requested_mode in ("Home", "Away"):
-            return
-        station.set_alarm_data(
-            {
-                "forceReason": None,
-                "safeModeAim": None,
-                "requestedSafeMode": None,
-                "exitDelay": None,
-            }
-        )
-
-
-def _sbs50_force_arm_prompt(
-    station_data: Dict, *, requested_mode: str | None = None
-) -> Dict | None:
-    active_request = requested_mode if requested_mode in ("Home", "Away") else None
-
-    if "forceReason" in station_data:
-        force_reason = station_data.get("forceReason")
-        if force_reason:
-            return {
-                "forceReason": force_reason,
-                "safeModeAim": active_request
-                or station_data.get("safeModeAim")
-                or station_data.get("safeMode"),
-                "requestedSafeMode": active_request,
-                "exitDelay": station_data.get("exitDelay"),
-            }
-
-    notices = station_data.get("notices")
-    if not isinstance(notices, list):
-        return None
-
-    for notice in notices:
-        if not isinstance(notice, dict):
-            continue
-        event_param = notice.get("eventParam")
-        if not isinstance(event_param, dict):
-            continue
-        safe_mode_aim = event_param.get("safeModeAim")
-        if active_request is not None and safe_mode_aim not in (
-            None,
-            "",
-            active_request,
-        ):
-            continue
-        force_reason = event_param.get("forceReason")
-        if not force_reason:
-            continue
-        return {
-            "forceReason": force_reason,
-            "safeModeAim": active_request or safe_mode_aim,
-            "requestedSafeMode": active_request,
-            "exitDelay": event_param.get("exitDelay"),
+    station.set_alarm_data(
+        {
+            "forceReason": station_data.get("forceReason") or None,
+            "exitDelay": station_data.get("exitDelay"),
         }
-
-    return None
+    )
 
 
 def _apply_group_light_state(station: Station, station_data: Dict, children) -> bool:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -850,7 +850,7 @@ def test_mqtt_skp0a_safenotice_fires_keypad_code_event(caplog):
 
 
 @pytest.mark.parametrize("requested_mode", ["Home", "Away"])
-def test_mqtt_safenotice_exposes_force_arm_prompt_for_pending_request(
+def test_mqtt_safenotice_does_not_impersonate_mode_result(
     requested_mode,
 ):
     from custom_components.xsense.alarm_control_panel import pending_force_arm_mode
@@ -907,8 +907,8 @@ def test_mqtt_safenotice_exposes_force_arm_prompt_for_pending_request(
         ).encode(),
     )
 
-    assert pending_force_arm_mode(station) == requested_mode
-    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
 
 
 def test_mqtt_skp0a_safenotice_skips_keypad_notice_without_code(caplog):

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1042,12 +1042,18 @@ async def test_blocked_arm_prompt_survives_station_object_refresh(
 
     panel._handle_coordinator_update()
 
-    assert pending_force_arm_mode(refreshed) == requested_mode
-    assert refreshed.alarm_data["requestedSafeMode"] == requested_mode
-    assert panel._cancel_arm_request_timeout is None
-    assert cancelled == [True]
-    assert len(created) == 1
-    assert f"mode={requested_mode}" in created[0][0]
+    if reported_mode == "requested":
+        assert pending_force_arm_mode(refreshed) is None
+        assert panel._pending_force_arm_mode is None
+        assert cancelled == [True]
+        assert created == []
+    else:
+        assert pending_force_arm_mode(refreshed) == requested_mode
+        assert refreshed.alarm_data["requestedSafeMode"] == requested_mode
+        assert panel._cancel_arm_request_timeout is None
+        assert cancelled == [True]
+        assert len(created) == 1
+        assert f"mode={requested_mode}" in created[0][0]
 
 
 async def test_visible_force_arm_prompt_survives_station_object_refresh(monkeypatch):
@@ -1269,6 +1275,8 @@ async def test_alarm_panel_force_arm_requires_matching_pending_mode(monkeypatch)
     coordinator = Coordinator(station)
     coordinator.xsense = Api()
     panel = XSenseAlarmControlPanel(coordinator, station)
+    panel._pending_force_arm_mode = "Away"
+    panel._pending_force_arm_data = dict(station.alarm_data)
     panel.hass = object()
     panel.async_write_ha_state = lambda: None
     dismissed = []
@@ -1458,7 +1466,7 @@ async def test_light_group_power_action_uses_apk_group_shadow():
     assert coordinator.update_listener_calls == 1
 
 
-def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target():
+def test_mode_result_keeps_request_target_out_of_adapter_payload_state():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data({"requestedSafeMode": "Home"})
@@ -1474,7 +1482,7 @@ def test_force_arm_prompt_prefers_locally_requested_home_over_stale_away_target(
     )
 
     assert pending_force_arm_mode(station) == "Home"
-    assert station.alarm_data["safeModeAim"] == "Home"
+    assert "safeModeAim" not in station.alarm_data
 
 
 def test_force_arm_result_is_retained_but_not_exposed_without_local_request():
@@ -1496,7 +1504,7 @@ def test_force_arm_result_is_retained_but_not_exposed_without_local_request():
     assert station.alarm_data.get("requestedSafeMode") is None
 
 
-def test_force_arm_prompt_uses_matching_notice_during_local_request():
+def test_keypad_notice_does_not_create_force_arm_prompt():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data({"requestedSafeMode": "Away"})
@@ -1519,12 +1527,11 @@ def test_force_arm_prompt_uses_matching_notice_during_local_request():
         },
     )
 
-    assert pending_force_arm_mode(station) == "Away"
-    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
-    assert station.alarm_data["exitDelay"] == "0"
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
 
 
-def test_force_arm_prompt_uses_unscoped_notice_during_local_request():
+def test_unscoped_notice_does_not_create_force_arm_prompt():
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data({"requestedSafeMode": "Home"})
@@ -1546,9 +1553,8 @@ def test_force_arm_prompt_uses_unscoped_notice_during_local_request():
         },
     )
 
-    assert pending_force_arm_mode(station) == "Home"
-    assert station.alarm_data["safeModeAim"] == "Home"
-    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert pending_force_arm_mode(station) is None
+    assert station.alarm_data.get("forceReason") is None
 
 
 def test_force_arm_prompt_ignores_notice_for_different_local_request():
@@ -1637,30 +1643,39 @@ def test_force_arm_prompt_does_not_return_after_request_is_cleared():
     )
 
     assert pending_force_arm_mode(station) is None
-    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert station.alarm_data["forceReason"] is None
     assert station.alarm_data.get("requestedSafeMode") is None
 
 
-def test_live_force_reason_wins_before_normal_arm_success_like_apk_listeners():
+def test_successful_mode_result_wins_before_force_reason_like_apk_listeners(monkeypatch):
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
-    station.set_alarm_data({"requestedSafeMode": "Home"})
-    api = XSenseBase.__new__(XSenseBase)
+    coordinator = Coordinator(station)
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    panel._active_normal_arm_mode = "Home"
+    panel._cancel_arm_request_timeout = lambda: None
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
 
-    api.parse_get_state(
+    XSenseBase.__new__(XSenseBase).parse_get_state(
         station,
         {
             "safeMode": "Home",
             "forceReason": [{"deviceSN": "door-sn"}],
         },
     )
+    panel._handle_coordinator_update()
 
-    assert pending_force_arm_mode(station) == "Home"
-    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
-    assert station.alarm_data["requestedSafeMode"] == "Home"
+    assert panel._active_normal_arm_mode is None
+    assert panel._pending_force_arm_mode is None
+    assert pending_force_arm_mode(station) is None
 
 
-def test_empty_force_arm_reason_does_not_dismiss_active_prompt():
+def test_empty_force_arm_reason_does_not_dismiss_visible_prompt(monkeypatch):
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"
     station.set_alarm_data(
@@ -1670,12 +1685,21 @@ def test_empty_force_arm_reason_does_not_dismiss_active_prompt():
             "requestedSafeMode": "Home",
         }
     )
-    api = XSenseBase.__new__(XSenseBase)
+    coordinator = Coordinator(station)
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel.hass = object()
+    panel.async_write_ha_state = lambda: None
+    panel._pending_force_arm_mode = "Home"
+    panel._pending_force_arm_data = dict(station.alarm_data)
+    monkeypatch.setattr(
+        "custom_components.xsense.alarm_control_panel.persistent_notification.async_dismiss",
+        lambda hass, notification_id: None,
+    )
 
-    api.parse_get_state(station, {"forceReason": []})
+    XSenseBase.__new__(XSenseBase).parse_get_state(station, {"forceReason": []})
+    panel._handle_coordinator_update()
 
     assert pending_force_arm_mode(station) == "Home"
-    assert station.alarm_data["requestedSafeMode"] == "Home"
     assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
 
 
@@ -1688,6 +1712,7 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
     panel.entity_id = "alarm_control_panel.base_station_alarm"
     panel.hass = object()
     panel.async_write_ha_state = lambda: None
+    panel._active_normal_arm_mode = "Away"
     created = []
     dismissed = []
     monkeypatch.setattr(
@@ -1706,13 +1731,7 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
         lambda hass, notification_id: dismissed.append((hass, notification_id)),
     )
 
-    station.set_alarm_data(
-        {
-            "forceReason": [{"deviceSN": "door-sn"}],
-            "safeModeAim": "Away",
-            "requestedSafeMode": "Away",
-        }
-    )
+    station.set_alarm_data({"forceReason": [{"deviceSN": "door-sn"}]})
     panel._handle_coordinator_update()
 
     assert created == [
@@ -1733,7 +1752,6 @@ def test_force_arm_prompt_creates_and_clears_persistent_notification(monkeypatch
 
     assert len(created) == 1
 
-    station.set_alarm_data({"forceReason": None, "safeModeAim": None})
-    panel._handle_coordinator_update()
+    panel._async_clear_arm_request(station)
 
     assert dismissed == [(panel.hass, f"xsense_force_arm_{station.entity_id}")]


### PR DESCRIPTION
Fixes the reversed blocked-arm prompt behavior reported in #284.\n\nThe alarm panel now correlates a direct SBS50 forceReason only with the active normal Home/Away request, accepts a matching reported safeMode as success before considering a bypass prompt, and ignores keypad/safe-notice payloads as mode results. Direct force-arm automation actions remain prompt-free.\n\nValidated on the fork with HACS, hassfest, and the full test suite on Python 3.13 and 3.14. Local Linux validation: 980 tests passed, compileall clean, and git diff --check clean.