### PR TITLE
Prepare v1.4.20.21 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.20):
-  (e.g., 1.4.20.20)
+- **X-Sense-Integration Version** (z. B. 1.4.20.21):
+  (e.g., 1.4.20.21)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.20.21.md
+++ b/.github/release-notes/1.4.20.21.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.20.21
+
+### Security Modes
+- Improves SBS50 blocked-arm handling for normal Home and Away requests.
+- Shows the force-arm prompt only when X-Sense reports that the active arm request is blocked by an open sensor.
+- Keeps direct force-arm automation actions prompt-free.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.20.21](.github/release-notes/1.4.20.21.md)
 - [1.4.20.20](.github/release-notes/1.4.20.20.md)
 - [1.4.20.19](.github/release-notes/1.4.20.19.md)
 - [1.4.20.18](.github/release-notes/1.4.20.18.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.20"
+PANEL_ASSET_VERSION = "1.4.20.21"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -20,6 +20,6 @@
     "pycognito==2024.5.1"
   ],
   "ssdp": [],
-  "version": "1.4.20.20",
+  "version": "1.4.20.21",
   "zeroconf": []
 }


### PR DESCRIPTION
Prepares v1.4.20.21 with the SBS50 blocked-arm prompt correlation fix from #284.\n\nValidated on the fork with HACS, hassfest, and the full test suite on Python 3.13 and 3.14.