### PR TITLE
Release v1.4.21: stable rollup and Home/Away state fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.20.23):
-  (e.g., 1.4.20.23)
+- **X-Sense-Integration Version** (z. B. 1.4.21):
+  (e.g., 1.4.21)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.md
+++ b/.github/release-notes/1.4.21.md
@@ -1,0 +1,34 @@
+## X-Sense Home Security v1.4.21
+
+This stable release rolls up the changes from the v1.4.20 pre-releases, with additional Home and Away arming fixes.
+
+### Home Assistant Compatibility
+- Removes deprecated parent-device and device-registry API usage, including the `ATTR_VIA_DEVICE` warning.
+- Preserves parent-device links and adds an IPv4 fallback for cloud requests when the normal network route is unavailable.
+
+### Security Modes
+- Separates blocked-arm confirmations from actual Home and Away mode reports.
+- Uses the current reported mode so stale alarm data does not silently prevent a new arm request.
+- Updates pending force-arm attributes immediately when a request is cleared, including when publishing fails.
+- Keeps direct force-arm automation actions separate from confirmation prompts.
+
+### Cameras and Recordings
+- Uses on-demand playback through Home Assistant by default without retaining complete recordings on disk.
+- Adds optional retained recordings with storage location, retention age, size limits, background synchronization, and manual cleanup controls.
+- Keeps manually deleted recordings out of background downloads and preserves recordings owned by other integration entries.
+- Improves HLS playback, expired-link recovery, recording-history pagination, and playback-session cleanup.
+- Updates camera-specific motion and AI event matching, duplicate-event handling, and event-image freshness.
+- Selects higher-resolution event-recording frames for snapshots when available, separately from live-view signaling.
+- Improves live-view startup and session cleanup while retaining the native Home Assistant signaling path.
+
+### Devices and Settings
+- Registers supported entities for standalone Wi-Fi smoke and CO detectors returned as stations.
+- Updates End-of-Life status, combined smoke/CO alarm presentation, radon settings, and sensitivity controls.
+- Preserves recording options in older configurations and improves storage-folder validation.
+- Improves connection cleanup and distinguishes temporary login-service failures from invalid credentials.
+
+### Interface and Languages
+- Preserves paused recording playback during refreshes and language or time-zone changes.
+- Improves mobile layouts, keyboard controls, playback errors, storage summaries, and panel reload handling.
+- Completes missing entity, action, and recording-option translations across all previously supported languages.
+- Updates multilingual recording-storage and notification-automation documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21](.github/release-notes/1.4.21.md)
 - [1.4.20.23](.github/release-notes/1.4.20.23.md)
 - [1.4.20.22](.github/release-notes/1.4.20.22.md)
 - [1.4.20.21](.github/release-notes/1.4.20.21.md)

--- a/custom_components/xsense/alarm_control_panel.py
+++ b/custom_components/xsense/alarm_control_panel.py
@@ -468,6 +468,7 @@ class XSenseAlarmControlPanel(
     @callback
     def _async_clear_arm_request(self, station) -> None:
         """Clear local state for an APK-style mode request."""
+        had_pending_prompt = self._pending_force_arm_mode is not None
         self._async_cancel_arm_request_timeout()
         self._active_normal_arm_mode = None
         station.set_alarm_data(
@@ -481,6 +482,9 @@ class XSenseAlarmControlPanel(
         self._pending_force_arm_mode = None
         self._pending_force_arm_data = None
         self._async_clear_force_arm_notification()
+        if had_pending_prompt:
+            # Coordinator entities are not automatically refreshed after actions.
+            self.async_write_ha_state()
 
     @callback
     def _async_cancel_arm_request_timeout(self) -> None:
@@ -537,22 +541,16 @@ class XSenseAlarmControlPanel(
                     self._active_normal_arm_mode,
                 )
                 return
-            current_mode = getattr(station, "alarm_mode", None)
+            # Match the APK's current reported mode, not a prior alarm snapshot.
+            current_mode = getattr(station, "safe_mode", None)
+            if current_mode is None:
+                current_mode = station.data.get("safeMode")
             if current_mode == safe_mode:
                 self._async_clear_arm_request(station)
                 return
+            self._async_clear_arm_request(station)
             self._active_normal_arm_mode = safe_mode
-            station.set_alarm_data(
-                {
-                    "forceReason": None,
-                    "safeModeAim": None,
-                    "requestedSafeMode": safe_mode,
-                    "exitDelay": None,
-                }
-            )
-            self._pending_force_arm_mode = None
-            self._pending_force_arm_data = None
-            self._async_clear_force_arm_notification()
+            station.set_alarm_data({"requestedSafeMode": safe_mode})
             self._async_start_arm_request_timeout()
         elif safe_mode == "Disarmed":
             self._async_clear_arm_request(station)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.20.23"
+PANEL_ASSET_VERSION = "1.4.21"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.20.23",
+  "version": "1.4.21",
   "zeroconf": []
 }

--- a/tests/test_entity_availability.py
+++ b/tests/test_entity_availability.py
@@ -1183,6 +1183,153 @@ async def test_normal_arm_is_noop_when_station_already_reports_target_mode(
     assert station.alarm_data.get("requestedSafeMode") is None
 
 
+@pytest.mark.parametrize("target", ["Home", "Away"])
+@pytest.mark.parametrize("old_field", ["mode", "safeMode"])
+async def test_rearm_uses_current_report_not_old_alarm_snapshot(monkeypatch, target, old_field):
+    from unittest.mock import AsyncMock
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.set_alarm_data({old_field: target})
+    api = XSenseBase.__new__(XSenseBase)
+    api.parse_get_state(station, {"safeMode": "Disarmed"}, mode_result="mode")
+    api.set_station_mode = AsyncMock()
+    coordinator = Coordinator(station)
+    coordinator.xsense = api
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel._async_clear_force_arm_notification = lambda: None
+    panel._async_start_arm_request_timeout = lambda: None
+
+    await panel._set_safe_mode(target, force_arm="0")
+
+    api.set_station_mode.assert_awaited_once_with(station, target, force_arm="0")
+    assert panel._active_normal_arm_mode == target
+
+
+@pytest.mark.parametrize("target", ["Home", "Away"])
+@pytest.mark.parametrize("reported", ["Home", "Away", "Disarmed"])
+def test_actual_mode_result_preserves_open_apk_confirmation(target, reported):
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    coordinator = Coordinator(station)
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    dismissed = []
+    panel._async_clear_force_arm_notification = lambda: dismissed.append(True)
+    panel.async_write_ha_state = lambda: None
+    panel._pending_force_arm_mode = target
+    panel._pending_force_arm_data = {
+        "requestedSafeMode": target, "forceReason": [{"deviceSN": "door-sn"}]
+    }
+    station.set_alarm_data(panel._pending_force_arm_data)
+    _parse_mode(station, {"safeMode": reported})
+
+    panel._handle_coordinator_update()
+
+    assert panel._pending_force_arm_mode == target
+    assert panel._pending_force_arm_data is not None
+    assert station.alarm_data["requestedSafeMode"] == target
+    assert station.alarm_data["forceReason"] == [{"deviceSN": "door-sn"}]
+    assert not dismissed
+
+
+@pytest.mark.parametrize("target", ["Home", "Away"])
+async def test_repeated_normal_and_force_arm_cycles(target):
+    from unittest.mock import AsyncMock
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    api = XSenseBase.__new__(XSenseBase)
+    api.set_station_mode = AsyncMock()
+    coordinator = Coordinator(station)
+    coordinator.xsense = api
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    prompts = []
+    panel._async_clear_force_arm_notification = lambda: None
+    panel._async_create_force_arm_notification = lambda station, mode: prompts.append(mode)
+    panel._async_start_arm_request_timeout = lambda: None
+    panel.async_write_ha_state = lambda: None
+
+    for _ in range(3):
+        _parse_mode(station, {"safeMode": "Disarmed"})
+        panel._handle_coordinator_update()
+        del station._xsense_mode_result
+        station.set_alarm_data({"safeMode": target})
+        await panel._set_safe_mode(target, force_arm="0")
+        _parse_confirmation(station, {"safeMode": target, "forceReason": []})
+        panel._handle_coordinator_update()
+        assert panel._pending_force_arm_mode is None
+        assert panel._active_normal_arm_mode == target
+        _parse_confirmation(station, {"forceReason": [{"deviceSN": "door-sn"}]})
+        panel._handle_coordinator_update()
+        assert panel._pending_force_arm_mode == target
+        del station._xsense_mode_result
+        await panel.async_force_arm(target)
+        assert panel._pending_force_arm_mode is None
+        _parse_confirmation(station, {"forceReason": [{"deviceSN": "door-sn"}]})
+        panel._handle_coordinator_update()
+        assert panel._pending_force_arm_mode is None
+        _parse_mode(station, {"safeMode": target})
+        panel._handle_coordinator_update()
+        assert panel._safemode == target
+        with pytest.raises(Exception):
+            await panel.async_force_arm(target)
+
+    assert prompts == [target] * 3
+    assert [call.kwargs["force_arm"] for call in api.set_station_mode.await_args_list] == ["0", "1"] * 3
+
+
+@pytest.mark.parametrize("action", ["Home", "Away", "Disarmed", "already_armed", "force"])
+@pytest.mark.parametrize("publish_fails", [False, True])
+async def test_arm_actions_publish_cleared_pending_attributes(action, publish_fails):
+    from homeassistant.exceptions import HomeAssistantError
+
+    station = _xs01_wx_from_real_shadow()
+    station.type = "SBS50"
+    station.safe_mode = "Home" if action == "already_armed" else "Disarmed"
+    writes = []
+    calls = []
+
+    class API:
+        async def set_station_mode(self, station, safe_mode, force_arm=None):
+            # HA must see prompt removal even while the network call is pending.
+            assert writes and writes[-1] is None
+            calls.append((safe_mode, force_arm))
+            if publish_fails:
+                raise RuntimeError("simulated publish failure")
+
+    coordinator = Coordinator(station)
+    coordinator.xsense = API()
+    panel = XSenseAlarmControlPanel(coordinator, station)
+    panel._safemode = station.safe_mode
+    panel._pending_force_arm_mode = "Away"
+    panel._pending_force_arm_data = {
+        "requestedSafeMode": "Away", "forceReason": [{"deviceSN": "door-sn"}]
+    }
+    station.set_alarm_data(panel._pending_force_arm_data)
+    panel._async_clear_force_arm_notification = lambda: None
+    panel._async_start_arm_request_timeout = lambda: None
+    panel.async_write_ha_state = lambda: writes.append(panel.extra_state_attributes)
+
+    async def invoke():
+        if action == "force":
+            await panel.async_force_arm("Away")
+        else:
+            await panel._set_safe_mode(
+                "Home" if action == "already_armed" else action, force_arm="0"
+            )
+
+    if publish_fails and action != "already_armed":
+        with pytest.raises(HomeAssistantError):
+            await invoke()
+    else:
+        await invoke()
+
+    assert writes and writes[-1] is None
+    assert panel.extra_state_attributes is None
+    assert panel._safemode == station.safe_mode
+    assert len(calls) == (0 if action == "already_armed" else 1)
+
+
 async def test_alarm_panel_unload_cancels_request_timeout(monkeypatch):
     station = _xs01_wx_from_real_shadow()
     station.type = "SBS50"


### PR DESCRIPTION
## Summary

Prepare stable v1.4.21, rolling up the published v1.4.20 pre-releases. This brings the Home Assistant registry deprecation fixes to users on the stable update channel.

Includes two additional Home/Away repairs: use the current reported mode instead of stale alarm snapshot data when deciding whether to send an arm command, and publish cleared pending attributes immediately to Home Assistant. APK confirmation semantics and camera protocol code are unchanged by these additional repairs.

## Validation

- Full server suites passed on Python 3.13 and 3.14: 2,092 tests each before the metadata bump.
- Added regression coverage for stale mode snapshots, repeated arming, prompt preservation, and pending-attribute cleanup on successful and failed actions.
- Release metadata and full suites are rechecked for this branch; fork workflows must pass before merging upstream.

## Release

Stable release, not a pre-release. Release notes consolidate the rollup without user test instructions.
