### PR TITLE
Pre-release v1.4.21.1: isolate live ticket identity

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.21):
-  (e.g., 1.4.21)
+- **X-Sense-Integration Version** (z. B. 1.4.21.1):
+  (e.g., 1.4.21.1)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.1.md
+++ b/.github/release-notes/1.4.21.1.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.21.1
+
+### Cameras
+- Keeps the camera identity from the previous live-view ticket as the first choice when requesting a new ticket, even if recording-history polling selects a different identity.
+- Retains fallback to other known camera identities if X-Sense rejects the previous ticket identity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21.1](.github/release-notes/1.4.21.1.md)
 - [1.4.21](.github/release-notes/1.4.21.md)
 - [1.4.20.23](.github/release-notes/1.4.20.23.md)
 - [1.4.20.22](.github/release-notes/1.4.20.22.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.21"
+PANEL_ASSET_VERSION = "1.4.21.1"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.21",
+  "version": "1.4.21.1",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -1925,7 +1925,14 @@ class AsyncXSense(XSenseBase):
 
         data = None
         last_error: APIFailure | None = None
-        for serial in _camera_addx_serial_candidates(camera):
+        serials = _camera_addx_serial_candidates(camera)
+        # History APIs may prefer another alias; refresh tickets with their own
+        # previously accepted identity before trying the shared fallbacks.
+        ticket_serial = cached.get("serialNumber") if isinstance(cached, dict) else None
+        if ticket_serial not in (None, ""):
+            ticket_serial = str(ticket_serial)
+            serials = [ticket_serial, *(value for value in serials if value != ticket_serial)]
+        for serial in serials:
             try:
                 data = await self._camera_addx_call(
                     camera,

--- a/tests/api/test_webrtc_ticket_identity.py
+++ b/tests/api/test_webrtc_ticket_identity.py
@@ -1,0 +1,55 @@
+"""Keep history discovery from changing a previously accepted ticket identity."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.xsense.python_xsense.async_xsense import AsyncXSense
+from custom_components.xsense.python_xsense.exceptions import APIFailure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reject_previous", [False, True])
+async def test_history_lookup_does_not_replace_ticket_identity(reject_previous):
+    client = AsyncXSense()
+    home = SimpleNamespace(house_id="home-1", mqtt_region="eu-central-1")
+    client.houses = {"home-1": home}
+    data = {"addxSerialNumber": "live-id"}
+    camera = SimpleNamespace(
+        sn="label-id", entity_id="history-id", data=data,
+        house=home, set_data=data.update,
+    )
+    calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        assert endpoint == "/device/getWebrtcTicket"
+        assert kwargs["_house"] is home
+        assert kwargs["verifyDormancyStatus"] is True
+        serial = kwargs["serialNumber"]
+        calls.append(serial)
+        if reject_previous and len(calls) > 1 and serial == "live-id":
+            raise APIFailure("error -2002/DEVICE_NO_ACCESS")
+        return {"signalServer": "https://signal.example"}
+
+    async def history_pages(serials, *args, **kwargs):
+        assert kwargs["house"] is home
+        return {"list": (
+            [{"serialNumber": "history-id", "videoEvent": "motion"}]
+            if serials == ["history-id"] else []
+        )}
+
+    client.addx_call = addx_call
+    client._get_camera_library_pages = history_pages
+    first = await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    assert first["serialNumber"] == "live-id"
+
+    history = await client.get_camera_library_history_for_cameras([camera], 1, 2)
+    assert len(history["list"]) == 1
+    assert data["addxAccessSerialNumber"] == "history-id"
+
+    refreshed = await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    expected = ["live-id", "live-id"]
+    if reject_previous:
+        expected.append("history-id")
+    assert calls == expected
+    assert refreshed["serialNumber"] == expected[-1]


### PR DESCRIPTION
## Summary

Prepare pre-release v1.4.21.1 with a narrow WebRTC ticket identity-isolation change.

Recording-history polling can change the shared preferred camera identity. Ticket refreshes now try the previous ticket's identity first, while preserving DEVICE_NO_ACCESS fallback and the camera's Home context.

The signal handshake, live media path, snapshots, recording playback, and history lookup behavior are unchanged. This addresses a reproduced identity-ordering defect; it does not establish the cause of the reporter's current PEER_IN timeout.

## Validation

- Two regression cases reproduce ticket creation, history lookup through another identity, and ticket refresh, including rejection of the previous identity.
- Both cases failed before the patch and passed afterward.
- Full Python 3.14 server suite passed: 2,094 tests before release metadata changes.
- Fork CI must pass before the upstream merge.
