### PR TITLE
Prepare v1.4.21.2 camera identity isolation

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.21.1):
-  (e.g., 1.4.21.1)
+- **X-Sense-Integration Version** (z. B. 1.4.21.2):
+  (e.g., 1.4.21.2)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.2.md
+++ b/.github/release-notes/1.4.21.2.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.21.2
+
+### Cameras
+- Separates recording and event-history camera identities from live-view access, including history polls that run before the first live-view request after startup.
+- Preserves the discovered camera identity when a live-view ticket requires an alternative identity, so it remains available for recording and event-history requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21.2](.github/release-notes/1.4.21.2.md)
 - [1.4.21.1](.github/release-notes/1.4.21.1.md)
 - [1.4.21](.github/release-notes/1.4.21.md)
 - [1.4.20.23](.github/release-notes/1.4.20.23.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.21.1"
+PANEL_ASSET_VERSION = "1.4.21.2"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.21.1",
+  "version": "1.4.21.2",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -244,6 +244,15 @@ def _camera_addx_serial_candidates(camera: Entity) -> list[str]:
     return list(camera_identifiers(camera)) or [""]
 
 
+def _camera_history_serial_candidates(camera: Entity, key: str) -> list[str]:
+    """Prefer this history endpoint's identity without changing live access."""
+    serials = _camera_addx_serial_candidates(camera)
+    preferred = camera.data.get(key)
+    if preferred in serials:
+        return [preferred, *(serial for serial in serials if serial != preferred)]
+    return serials
+
+
 def camera_addx_serial(camera: Entity) -> str:
     """Return the APK ADDX serial used for account-level camera APIs."""
     return _camera_addx_serial(camera)
@@ -731,7 +740,9 @@ class AsyncXSense(XSenseBase):
         successful_requests = 0
         seen_cameras: list[Entity] = []
         for camera in cameras:
-            serials = _camera_addx_serial_candidates(camera)
+            serials = _camera_history_serial_candidates(
+                camera, "cameraLibrarySerialNumber"
+            )
             if not serials:
                 continue
             if any(cameras_share_identity(camera, seen) for seen in seen_cameras):
@@ -785,8 +796,7 @@ class AsyncXSense(XSenseBase):
             if accepted_serial is not None:
                 camera.set_data(
                     {
-                        "addxAccessSerialNumber": accepted_serial,
-                        "addxSerialNumber": accepted_serial,
+                        "cameraLibrarySerialNumber": accepted_serial,
                     }
                 )
             if camera_request_succeeded:
@@ -855,7 +865,9 @@ class AsyncXSense(XSenseBase):
         successful_requests = 0
         seen_cameras: list[Entity] = []
         for camera in cameras:
-            serials = _camera_addx_serial_candidates(camera)
+            serials = _camera_history_serial_candidates(
+                camera, "cameraEventHistorySerialNumber"
+            )
             if not serials:
                 continue
             if any(cameras_share_identity(camera, seen) for seen in seen_cameras):
@@ -909,8 +921,7 @@ class AsyncXSense(XSenseBase):
             if accepted_serial is not None:
                 camera.set_data(
                     {
-                        "addxAccessSerialNumber": accepted_serial,
-                        "addxSerialNumber": accepted_serial,
+                        "cameraEventHistorySerialNumber": accepted_serial,
                     }
                 )
             if camera_request_succeeded:
@@ -1943,7 +1954,6 @@ class AsyncXSense(XSenseBase):
                 camera.set_data(
                     {
                         "addxAccessSerialNumber": serial,
-                        "addxSerialNumber": serial,
                     }
                 )
                 break

--- a/tests/api/test_async_xsense.py
+++ b/tests/api/test_async_xsense.py
@@ -5398,8 +5398,7 @@ async def test_camera_library_history_tries_apk_identity_alias_after_empty_resul
     ]
     assert updates == [
         {
-            "addxAccessSerialNumber": "camera-access-id",
-            "addxSerialNumber": "camera-access-id",
+            "cameraLibrarySerialNumber": "camera-access-id",
         }
     ]
 
@@ -5617,8 +5616,7 @@ async def test_camera_event_record_history_for_cameras_uses_exact_home_and_ident
     ]
     assert identity_updates == [
         {
-            "addxAccessSerialNumber": "camera-access-id",
-            "addxSerialNumber": "camera-access-id",
+            "cameraEventHistorySerialNumber": "camera-access-id",
         }
     ]
 
@@ -6279,7 +6277,7 @@ async def test_camera_webrtc_ticket_retries_ipc_id_after_rejected_cached_addx_se
         for endpoint, kwargs in calls
         if endpoint == "/device/getWebrtcTicket"
     ] == ["wrong-cached-id", "right-addx-camera-id"]
-    assert camera.data["addxSerialNumber"] == "right-addx-camera-id"
+    assert camera.data["addxSerialNumber"] == "wrong-cached-id"
     assert camera.data["addxAccessSerialNumber"] == "right-addx-camera-id"
     assert camera.data["cameraWebrtcTicket"]["serialNumber"] == "right-addx-camera-id"
 

--- a/tests/api/test_webrtc_ticket_identity.py
+++ b/tests/api/test_webrtc_ticket_identity.py
@@ -1,11 +1,18 @@
 """Keep history discovery from changing a previously accepted ticket identity."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import base64
+import json
 
 import pytest
 
 from custom_components.xsense.python_xsense.async_xsense import AsyncXSense
 from custom_components.xsense.python_xsense.exceptions import APIFailure
+from custom_components.xsense.python_xsense.webrtc_signal import (
+    XSenseWebRTCTicket,
+    XSenseWebRTCSignalSession,
+)
 
 
 @pytest.mark.asyncio
@@ -45,7 +52,8 @@ async def test_history_lookup_does_not_replace_ticket_identity(reject_previous):
 
     history = await client.get_camera_library_history_for_cameras([camera], 1, 2)
     assert len(history["list"]) == 1
-    assert data["addxAccessSerialNumber"] == "history-id"
+    assert data["addxAccessSerialNumber"] == "live-id"
+    assert data["cameraLibrarySerialNumber"] == "history-id"
 
     refreshed = await client.get_camera_webrtc_ticket(camera, force_refresh=True)
     expected = ["live-id", "live-id"]
@@ -53,3 +61,123 @@ async def test_history_lookup_does_not_replace_ticket_identity(reject_previous):
         expected.append("history-id")
     assert calls == expected
     assert refreshed["serialNumber"] == expected[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("history_kind", ["library", "event"])
+@pytest.mark.parametrize("history_first", [True, False])
+async def test_history_identity_is_independent_of_live_startup(history_kind, history_first):
+    client = AsyncXSense()
+    home = SimpleNamespace(house_id="home-1", mqtt_region="eu-central-1")
+    client.houses = {"home-1": home}
+    data = {"addxSerialNumber": "live-id"}
+    camera = SimpleNamespace(
+        sn="label-id", entity_id="history-id", data=data,
+        house=home, set_data=data.update,
+    )
+    ticket_calls = []
+    history_calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        assert endpoint == "/device/getWebrtcTicket"
+        assert kwargs["_house"] is home
+        ticket_calls.append(kwargs["serialNumber"])
+        return {"signalServer": "https://signal.example"}
+
+    async def history_pages(serials, *args, **kwargs):
+        assert kwargs["house"] is home
+        history_calls.append(serials)
+        return {"list": (
+            [{"serialNumber": "history-id", "videoEvent": "motion"}]
+            if serials == ["history-id"] else []
+        )}
+
+    client.addx_call = addx_call
+    client._get_camera_library_pages = history_pages
+    client.get_camera_event_record_history = history_pages
+    history_method = (
+        client.get_camera_library_history_for_cameras
+        if history_kind == "library" else client.get_camera_event_record_history_for_cameras
+    )
+    if not history_first:
+        await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    assert len((await history_method([camera], 1, 2))["list"]) == 1
+    assert data["addxSerialNumber"] == "live-id"
+    ticket = await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    assert ticket["serialNumber"] == "live-id"
+    assert set(ticket_calls) == {"live-id"}
+    signal_ticket = XSenseWebRTCTicket.from_api(ticket["serialNumber"], {
+        **ticket, "groupId": "group", "role": "viewer", "id": "viewer-id",
+        "traceId": "trace", "sign": "signature", "time": 1,
+    })
+    session = XSenseWebRTCSignalSession(
+        session=SimpleNamespace(), ticket=signal_ticket,
+        offer_sdp="v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 99\r\na=mid:0\r\n",
+        resolution="1920x1080", camera_online=True,
+    )
+    ws = SimpleNamespace(closed=False, send_str=AsyncMock(), close=AsyncMock())
+    session._ws = ws
+    try:
+        await session._handle_signal_event("PEER_IN", "other-camera")
+        ws.send_str.assert_not_awaited()
+        await session._handle_signal_event("PEER_IN", "live-id")
+        assert session._camera_peer_ready
+        offer = json.loads(ws.send_str.await_args.args[0])
+        assert offer["messageType"] == "SDP_OFFER"
+        assert offer["recipientClientId"] == "live-id"
+        answer = "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 99\r\na=mid:0\r\n"
+        await session._handle_signal_event("SDP_ANSWER", {
+            "senderClientId": "live-id", "recipientClientId": "viewer-id",
+            "messagePayload": base64.b64encode(json.dumps({
+                "type": "answer", "sdp": answer,
+            }).encode()).decode(),
+        })
+        assert session._answer.done()
+        assert "m=video" in session._answer.result()
+    finally:
+        await session.close()
+    history_calls.clear()
+    assert len((await history_method([camera], 2, 3))["list"]) == 1
+    assert history_calls == [["history-id"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("history_kind", ["library", "event"])
+async def test_ticket_fallback_preserves_discovered_history_identity(history_kind):
+    client = AsyncXSense()
+    home = SimpleNamespace(house_id="home-1", mqtt_region="eu-central-1")
+    client.houses = {"home-1": home}
+    data = {"addxSerialNumber": "recording-id"}
+    camera = SimpleNamespace(
+        sn="label-id", entity_id="live-id", data=data,
+        house=home, set_data=data.update,
+    )
+    history_calls = []
+
+    async def addx_call(endpoint, **kwargs):
+        assert kwargs["_house"] is home
+        if kwargs["serialNumber"] == "recording-id":
+            raise APIFailure("error -2002/DEVICE_NO_ACCESS")
+        return {"signalServer": "https://signal.example"}
+
+    async def history_pages(serials, *args, **kwargs):
+        history_calls.append(serials)
+        return {"list": (
+            [{"serialNumber": "recording-id", "videoEvent": "motion"}]
+            if serials == ["recording-id"] else []
+        )}
+
+    client.addx_call = addx_call
+    client._get_camera_library_pages = history_pages
+    client.get_camera_event_record_history = history_pages
+    history_method = (
+        client.get_camera_library_history_for_cameras
+        if history_kind == "library"
+        else client.get_camera_event_record_history_for_cameras
+    )
+    assert len((await history_method([camera], 1, 2))["list"]) == 1
+    ticket = await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    assert ticket["serialNumber"] == "live-id"
+    history_calls.clear()
+    assert len((await history_method([camera], 2, 3))["list"]) == 1
+    assert history_calls == [["recording-id"]]


### PR DESCRIPTION
## Summary
- Keep library and event-history identity preferences separate from live-view access, including startup before a ticket exists.
- Preserve the discovered camera serial when ticket access falls back to another identity.
- Keep the current WebRTC signaling handshake unchanged.
- Prepare pre-release 1.4.21.2.

## Validation
- Regression coverage for both history endpoints before and after live-view startup.
- Signal-relay coverage for matching camera peers, rejecting unrelated peers, offer routing, and SDP answers.
- Recording-history continuity after a live-ticket identity fallback.
- Full Python 3.13 and 3.14 suites, plus fork CI checks before upstream merge.

Related to #285. These changes address reproduced identity coupling; camera recovery is not yet hardware-confirmed.
