### PR TITLE
Prepare v1.4.21.3 live-view ICE delivery

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.21.2):
-  (e.g., 1.4.21.2)
+- **X-Sense-Integration Version** (z. B. 1.4.21.3):
+  (e.g., 1.4.21.3)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.3.md
+++ b/.github/release-notes/1.4.21.3.md
@@ -1,0 +1,5 @@
+## X-Sense Home Security v1.4.21.3
+
+### Cameras
+- Sends live-view ICE candidates after the SDP offer instead of holding them until the camera answers.
+- Resends gathered ICE candidates when a camera peer rejoins or signaling reconnects before an answer arrives.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21.3](.github/release-notes/1.4.21.3.md)
 - [1.4.21.2](.github/release-notes/1.4.21.2.md)
 - [1.4.21.1](.github/release-notes/1.4.21.1.md)
 - [1.4.21](.github/release-notes/1.4.21.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.21.2"
+PANEL_ASSET_VERSION = "1.4.21.3"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.21.2",
+  "version": "1.4.21.3",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -145,6 +145,7 @@ class XSenseWebRTCSignalSession:
         self._offer_attempt_count = 0
         self._signal_reconnect_count = 0
         self._pending_remote_candidates: list[Any] = []
+        self._ha_candidate_history: list[dict[str, Any]] = []
         self._pending_client_candidates: list[dict[str, Any]] = []
         self._remote_candidate_callback = remote_candidate_callback
         self._forward_client_candidates = False
@@ -240,11 +241,11 @@ class XSenseWebRTCSignalSession:
                 self._debug_context(candidate_type=type(candidate).__name__),
             )
             return
+        self._ha_candidate_history.append(payload)
         if (
             self._ws is None
             or self._ws.closed
             or not self._offer_sent
-            or not _future_has_result(self._answer)
         ):
             self._pending_remote_candidates.append(payload)
             pending = len(self._pending_remote_candidates)
@@ -510,14 +511,14 @@ class XSenseWebRTCSignalSession:
         )
         for candidate in candidates:
             await self._send_candidate(candidate)
+        await self._flush_pending_remote_candidates()
 
     async def _flush_pending_remote_candidates(self) -> None:
-        """Send any HA candidates that arrived before the X-Sense answer."""
+        """Send queued HA candidates once the offer has been sent."""
         if (
             self._ws is None
             or self._ws.closed
             or not self._offer_sent
-            or not _future_has_result(self._answer)
         ):
             return
         pending = len(self._pending_remote_candidates)
@@ -563,6 +564,8 @@ class XSenseWebRTCSignalSession:
 
     def _reset_offer_attempt(self, reason: str) -> None:
         self._offer_sent = False
+        # A renewed offer still needs the browser's already-gathered candidates.
+        self._pending_remote_candidates = list(self._ha_candidate_history)
         self._local_candidate_count = 0
         self._sent_candidate_count = 0
         LOGGER.debug(
@@ -1212,8 +1215,6 @@ def _candidate_queue_reason(session: XSenseWebRTCSignalSession) -> str:
         return "signal_closed"
     if not session._offer_sent:
         return "waiting_for_peer_offer"
-    if not _future_has_result(session._answer):
-        return "waiting_for_sdp_answer"
     return "unknown"
 
 

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -340,8 +340,8 @@ async def test_webrtc_signal_failed_offer_send_remains_retryable():
     assert session._offer_sent is False
 
 
-async def test_online_camera_preserves_confirmed_offer_answer_ice_order(monkeypatch):
-    """Lock v1.3.12.10 peer, offer, answer, and ICE ordering."""
+async def test_online_camera_sends_ice_after_peer_offer_before_answer(monkeypatch):
+    """Keep peer gating without withholding browser candidates until the answer."""
     websocket = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -373,8 +373,10 @@ async def test_online_camera_preserves_confirmed_offer_answer_ice_order(monkeypa
     )
     await session.add_candidate(candidate)
 
-    assert len(session._pending_remote_candidates) == 1
-    assert [message["messageType"] for message in websocket.messages] == ["SDP_OFFER"]
+    assert len(session._pending_remote_candidates) == 0
+    assert [message["messageType"] for message in websocket.messages] == [
+        "SDP_OFFER", "ICE_CANDIDATE",
+    ]
 
     answer_sdp = "v=0\r\n"
     await session._handle_signal_event(
@@ -393,7 +395,7 @@ async def test_online_camera_preserves_confirmed_offer_answer_ice_order(monkeypa
     ]
 
 
-async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():
+async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -425,8 +427,10 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():
     await session._send_offer()
 
     assert not session._answer.done()
-    assert len(session._pending_remote_candidates) == 1
-    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
+    assert len(session._pending_remote_candidates) == 0
+    assert [message["messageType"] for message in fake_ws.messages] == [
+        "SDP_OFFER", "ICE_CANDIDATE",
+    ]
 
     session._answer.set_result("v=0\r\nanswer")
     await session._flush_pending_remote_candidates()
@@ -446,7 +450,8 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():
     }
 
 
-async def test_webrtc_signal_queues_ha_candidates_until_answer():
+@pytest.mark.parametrize("before_offer", [True, False])
+async def test_webrtc_signal_sends_ha_candidates_after_offer_without_answer(before_offer):
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -469,21 +474,16 @@ async def test_webrtc_signal_queues_ha_candidates_until_answer():
     session._ws = fake_ws
     session._recipient_client_id = "SSC0ATEST"
 
-    await session._send_offer()
-    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
-    assert len(session._pending_remote_candidates) == 0
-    assert not session._answer.done()
-
-    await session.add_candidate(candidate)
-
-    assert len(session._pending_remote_candidates) == 1
-    assert not session._answer.done()
-    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
-
-    session._answer.set_result("v=0\r\nanswer")
-    await session._flush_pending_remote_candidates()
+    if before_offer:
+        await session.add_candidate(candidate)
+        assert len(session._pending_remote_candidates) == 1
+        assert not fake_ws.messages
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
+    if not before_offer:
+        await session.add_candidate(candidate)
 
     assert len(session._pending_remote_candidates) == 0
+    assert not session._answer.done()
     assert [message["messageType"] for message in fake_ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",
@@ -496,3 +496,28 @@ async def test_webrtc_signal_queues_ha_candidates_until_answer():
         "sdpMLineIndex": 1,
         "candidate": "candidate:2 1 udp 1 192.0.2.2 456 typ host",
     }
+
+
+async def test_webrtc_reoffer_resends_trickled_candidates_before_answer():
+    ws = FakeWebSocket()
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(), ticket=ticket(), offer_sdp="v=0\r\n",
+        resolution="1920x1080", camera_online=True,
+    )
+    session._ws = ws
+    for index in range(12):
+        await session.add_candidate(SimpleNamespace(
+            candidate=f"candidate:{index} 1 udp 1 192.0.2.2 {4000 + index} typ host",
+            sdp_mid="0", sdp_m_line_index=0,
+        ))
+    assert not ws.messages
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
+    assert session._sent_candidate_count == 12
+    assert not session._pending_remote_candidates
+    await session._handle_signal_event("PEER_OUT", "SSC0ATEST")
+    await session._handle_signal_event("PEER_IN", "SSC0ATEST")
+    assert session._sent_candidate_count == 12
+    assert not session._answer.done()
+    assert [item["messageType"] for item in ws.messages] == (
+        ["SDP_OFFER"] + ["ICE_CANDIDATE"] * 12
+    ) * 2


### PR DESCRIPTION
## Summary
- Send browser ICE candidates after the SDP offer, including candidates queued before signaling connects.
- Retain gathered candidates for a renewed offer before the camera answers.
- Preserve matching-peer gating and the native HA signal relay.
- Prepare pre-release 1.4.21.3. No snapshot or recording playback changes.

## Validation
- Regression tests reproduce withheld candidates before the fix and cover delivery before an answer.
- A twelve-candidate test covers camera peer departure and rejoin with retransmission.
- Full Python 3.13 and 3.14 test suites and fork CI before upstream merge.

Related to #285. The reported zero-sent/twelve-queued condition is addressed in code; the later missing-peer sessions and hardware recovery remain unconfirmed.
