### PR TITLE
Prepare v1.4.21.4 camera prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.21.3):
-  (e.g., 1.4.21.3)
+- **X-Sense-Integration Version** (z. B. 1.4.21.4):
+  (e.g., 1.4.21.4)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.4.md
+++ b/.github/release-notes/1.4.21.4.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.21.4
+
+### Cameras
+- Aligns live-view ICE ordering with the previously working camera-switching path.
+- Preserves numeric-looking camera identifiers when reading live-view peer messages.
+- Clarifies live-view diagnostics to distinguish queued candidates from socket sends and identify session cleanup paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21.4](.github/release-notes/1.4.21.4.md)
 - [1.4.21.3](.github/release-notes/1.4.21.3.md)
 - [1.4.21.2](.github/release-notes/1.4.21.2.md)
 - [1.4.21.1](.github/release-notes/1.4.21.1.md)

--- a/custom_components/xsense/camera.py
+++ b/custom_components/xsense/camera.py
@@ -395,6 +395,12 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
         except asyncio.CancelledError:
             if self._webrtc_sessions.get(session_id) is session:
                 self._webrtc_sessions.pop(session_id, None)
+            LOGGER.debug(
+                "X-Sense camera WebRTC startup cancelled: %s",
+                _camera_debug_context(
+                    entity, session_id, close_reason="offer_task_cancelled"
+                ),
+            )
             await session.close()
             raise
         except Exception as err:  # noqa: BLE001 - HA frontend needs a clean error
@@ -407,13 +413,21 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
             LOGGER.debug(
                 "X-Sense camera WebRTC signal relay failed: %s",
                 _camera_debug_context(
-                    entity, session_id, error=_error_debug_context(err)
+                    entity, session_id,
+                    error=_error_debug_context(err),
+                    close_reason="startup_failed",
                 ),
             )
             send_message(WebRTCError("xsense_webrtc_start_failed", str(err)))
             return
 
         if self._webrtc_sessions.get(session_id) is not session:
+            LOGGER.debug(
+                "X-Sense camera WebRTC discarded superseded answer: %s",
+                _camera_debug_context(
+                    entity, session_id, close_reason="superseded_answer"
+                ),
+            )
             await session.close()
             return
 
@@ -445,7 +459,11 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
             return
         LOGGER.debug(
             "X-Sense camera closing previous WebRTC signal sessions before new offer: %s",
-            {"count": len(sessions)},
+            {
+                "count": len(sessions),
+                "close_reason": "replacement_offer",
+                "replacement_session": _short_id(preserve_pending_session_id),
+            },
         )
         self._webrtc_sessions.clear()
         for session in sessions:
@@ -459,11 +477,12 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
         if not candidates:
             return
         LOGGER.debug(
-            "X-Sense camera WebRTC forwarding queued HA ICE candidates: %s",
+            "X-Sense camera WebRTC handing queued HA ICE candidates to signal helper: %s",
             _camera_debug_context(
                 entity,
                 session_id,
                 queued_candidate_count=len(candidates),
+                candidate_stage="adapter_to_helper",
             ),
         )
         for candidate in candidates:
@@ -499,12 +518,14 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
                 session_id,
                 had_session=session is not None,
                 remaining_sessions=len(self._webrtc_sessions),
+                close_reason="ha_subscription_cleanup",
             )
             if entity is not None
             else {
                 "session": _short_id(session_id),
                 "had_session": session is not None,
                 "remaining_sessions": len(self._webrtc_sessions),
+                "close_reason": "ha_subscription_cleanup",
             },
         )
         if session is not None:
@@ -527,6 +548,10 @@ class XSenseWebRTCCameraEntity(XSenseCameraEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Stop any WebRTC live view session when Home Assistant removes the entity."""
         sessions = list(self._webrtc_sessions.values())
+        LOGGER.debug(
+            "X-Sense camera WebRTC entity cleanup: %s",
+            {"session_count": len(sessions), "close_reason": "entity_removed"},
+        )
         self._webrtc_sessions.clear()
         self._pending_webrtc_candidates.clear()
         for session in sessions:

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.21.3"
+PANEL_ASSET_VERSION = "1.4.21.4"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.21.3",
+  "version": "1.4.21.4",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -137,6 +137,7 @@ class XSenseWebRTCSignalSession:
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._answer: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._closed = False
+        self._created_at = time.monotonic()
         self._offer_sent = False
         self._camera_peer_ready = False
         self._signal_event_counts: Counter[str] = Counter()
@@ -145,7 +146,6 @@ class XSenseWebRTCSignalSession:
         self._offer_attempt_count = 0
         self._signal_reconnect_count = 0
         self._pending_remote_candidates: list[Any] = []
-        self._ha_candidate_history: list[dict[str, Any]] = []
         self._pending_client_candidates: list[dict[str, Any]] = []
         self._remote_candidate_callback = remote_candidate_callback
         self._forward_client_candidates = False
@@ -158,6 +158,7 @@ class XSenseWebRTCSignalSession:
         context.update(
             {
                 "session": _short_id(self._session_id),
+                "session_age_s": round(time.monotonic() - self._created_at, 3),
                 "recipient": _short_id(self._recipient_client_id),
                 "resolution": self._resolution,
                 "camera_online": self._camera_online,
@@ -241,11 +242,11 @@ class XSenseWebRTCSignalSession:
                 self._debug_context(candidate_type=type(candidate).__name__),
             )
             return
-        self._ha_candidate_history.append(payload)
         if (
             self._ws is None
             or self._ws.closed
             or not self._offer_sent
+            or not _future_has_result(self._answer)
         ):
             self._pending_remote_candidates.append(payload)
             pending = len(self._pending_remote_candidates)
@@ -283,8 +284,9 @@ class XSenseWebRTCSignalSession:
 
     async def _read_loop(self) -> None:
         close_code: int | None = None
+        reader_exit = "socket_iteration_ended"
+        ws = self._ws
         try:
-            ws = self._ws
             assert ws is not None
             async for message in ws:
                 if message.type not in (
@@ -306,7 +308,11 @@ class XSenseWebRTCSignalSession:
                     )
                 await self._handle_signal_event(event, payload)
             close_code = ws.close_code
+        except asyncio.CancelledError:
+            reader_exit = "reader_cancelled"
+            raise
         except Exception as err:
+            reader_exit = "reader_error"
             if not self._answer.done():
                 self._answer.set_exception(err)
             LOGGER.debug(
@@ -316,7 +322,12 @@ class XSenseWebRTCSignalSession:
         finally:
             LOGGER.debug(
                 "X-Sense WebRTC signal relay websocket closed: %s",
-                self._debug_context(signal_close_code=close_code),
+                self._debug_context(
+                    signal_close_code=close_code,
+                    observed_socket_close_code=getattr(ws, "close_code", None),
+                    reader_exit=reader_exit,
+                    local_close_requested=self._closed,
+                ),
             )
             self._schedule_signal_reconnect(close_code)
 
@@ -511,14 +522,14 @@ class XSenseWebRTCSignalSession:
         )
         for candidate in candidates:
             await self._send_candidate(candidate)
-        await self._flush_pending_remote_candidates()
 
     async def _flush_pending_remote_candidates(self) -> None:
-        """Send queued HA candidates once the offer has been sent."""
+        """Send trickled HA candidates after the answer, as in 65984b9."""
         if (
             self._ws is None
             or self._ws.closed
             or not self._offer_sent
+            or not _future_has_result(self._answer)
         ):
             return
         pending = len(self._pending_remote_candidates)
@@ -564,8 +575,6 @@ class XSenseWebRTCSignalSession:
 
     def _reset_offer_attempt(self, reason: str) -> None:
         self._offer_sent = False
-        # A renewed offer still needs the browser's already-gathered candidates.
-        self._pending_remote_candidates = list(self._ha_candidate_history)
         self._local_candidate_count = 0
         self._sent_candidate_count = 0
         LOGGER.debug(
@@ -753,13 +762,16 @@ def _signal_peer_payload(payload: Any) -> Any:
 
 def _decode_signal_peer_payload(payload: str) -> Any:
     with suppress(Exception):
-        return json.loads(payload)
+        value = json.loads(payload)
+        # Peer IDs are text, even when they look like JSON numbers or literals.
+        return value if isinstance(value, (str, dict)) else payload
     if not _looks_like_encoded_peer_payload(payload):
         return payload
     decoded = _base64_decode_text(payload)
     if decoded:
         with suppress(Exception):
-            return json.loads(decoded)
+            value = json.loads(decoded)
+            return value if isinstance(value, (str, dict)) else decoded
         return decoded
     return payload
 
@@ -1215,6 +1227,8 @@ def _candidate_queue_reason(session: XSenseWebRTCSignalSession) -> str:
         return "signal_closed"
     if not session._offer_sent:
         return "waiting_for_peer_offer"
+    if not _future_has_result(session._answer):
+        return "waiting_for_sdp_answer"
     return "unknown"
 
 

--- a/scripts/capture-webrtc-baseline.py
+++ b/scripts/capture-webrtc-baseline.py
@@ -1,0 +1,32 @@
+"""Generate a wire-order fixture from the user-selected historical commit."""
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import types
+
+COMMIT = "65984b9126deb0646f8fd1b4f756f5430e4718e8"
+source = subprocess.check_output([
+    "git", "show", f"{COMMIT}:custom_components/xsense/webrtc_signal.py"
+], text=True)
+assert source.count("from .const import LOGGER") == 1
+source = source.replace("from .const import LOGGER", "import logging\nLOGGER = logging.getLogger(__name__)")
+module = types.ModuleType("xsense_historical_relay")
+sys.modules[module.__name__] = module
+exec(compile(source, COMMIT, "exec"), module.__dict__)
+spec = importlib.util.spec_from_file_location("baseline_test", "tests/test_webrtc_historical_baseline.py")
+test = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(test)
+
+async def main():
+    traces = {}
+    for serial in ("CAMERA_A", "CAMERA_B"):
+        traces[serial] = await test.relay_trace(module, serial)
+    destination = Path("tests/fixtures/webrtc_65984b9.json")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps({"commit": COMMIT, "traces": traces}, indent=2) + "\n")
+    print(f"Captured {COMMIT} -> {destination}")
+
+asyncio.run(main())

--- a/tests/fixtures/webrtc_65984b9.json
+++ b/tests/fixtures/webrtc_65984b9.json
@@ -1,0 +1,189 @@
+{
+  "commit": "65984b9126deb0646f8fd1b4f756f5430e4718e8",
+  "traces": {
+    "CAMERA_A": [
+      {
+        "step": "connect",
+        "url": "wss://signal.example/CAMERA_A/viewer/viewer123?traceId=trace123&time=123456&sign=test-sign&name=test-123",
+        "options": {
+          "url": "wss://192.0.2.10/CAMERA_A/viewer/viewer123?traceId=trace123&time=123456&sign=test-sign&name=test-123",
+          "headers": {
+            "Host": "signal.example"
+          },
+          "server_hostname": "signal.example"
+        }
+      },
+      {
+        "step": "early_trickle",
+        "messages": []
+      },
+      {
+        "step": "unrelated_peer",
+        "messages": []
+      },
+      {
+        "step": "owned_peer_offer_and_embedded_ice",
+        "messages": [
+          {
+            "messageType": "SDP_OFFER",
+            "messagePayload": "eyJ0eXBlIjoib2ZmZXIiLCJzZHAiOiJ2PTBcclxubT1hdWRpbyA5IFVEUC9UTFMvUlRQL1NBVlBGIDBcclxuYT1taWQ6MFxyXG5tPXZpZGVvIDkgVURQL1RMUy9SVFAvU0FWUEYgOTZcclxuYT1taWQ6MVxyXG5hPXJ0cG1hcDo5NiBIMjY0LzkwMDAwXHJcbiJ9",
+            "mode": "vicoo",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session",
+            "viewerType": "a4x_sdk",
+            "resolution": "1920x1080"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjEgMSB1ZHAgMSAxOTIuMC4yLjEgNDAwMCB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "trickle_while_waiting_for_answer",
+        "messages": []
+      },
+      {
+        "step": "rejoined_peer",
+        "messages": [
+          {
+            "messageType": "SDP_OFFER",
+            "messagePayload": "eyJ0eXBlIjoib2ZmZXIiLCJzZHAiOiJ2PTBcclxubT1hdWRpbyA5IFVEUC9UTFMvUlRQL1NBVlBGIDBcclxuYT1taWQ6MFxyXG5tPXZpZGVvIDkgVURQL1RMUy9SVFAvU0FWUEYgOTZcclxuYT1taWQ6MVxyXG5hPXJ0cG1hcDo5NiBIMjY0LzkwMDAwXHJcbiJ9",
+            "mode": "vicoo",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session",
+            "viewerType": "a4x_sdk",
+            "resolution": "1920x1080"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjEgMSB1ZHAgMSAxOTIuMC4yLjEgNDAwMCB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "answer_flushes_trickled_ice",
+        "messages": [
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjIgMSB1ZHAgMSAxOTIuMC4yLjIgNDAwMSB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIxIiwic2RwTUxpbmVJbmRleCI6MSwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjMgMSB1ZHAgMSAxOTIuMC4yLjMgNDAwMiB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_A",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "closed",
+        "socket_closed": true
+      }
+    ],
+    "CAMERA_B": [
+      {
+        "step": "connect",
+        "url": "wss://signal.example/CAMERA_B/viewer/viewer123?traceId=trace123&time=123456&sign=test-sign&name=test-123",
+        "options": {
+          "url": "wss://192.0.2.10/CAMERA_B/viewer/viewer123?traceId=trace123&time=123456&sign=test-sign&name=test-123",
+          "headers": {
+            "Host": "signal.example"
+          },
+          "server_hostname": "signal.example"
+        }
+      },
+      {
+        "step": "early_trickle",
+        "messages": []
+      },
+      {
+        "step": "unrelated_peer",
+        "messages": []
+      },
+      {
+        "step": "owned_peer_offer_and_embedded_ice",
+        "messages": [
+          {
+            "messageType": "SDP_OFFER",
+            "messagePayload": "eyJ0eXBlIjoib2ZmZXIiLCJzZHAiOiJ2PTBcclxubT1hdWRpbyA5IFVEUC9UTFMvUlRQL1NBVlBGIDBcclxuYT1taWQ6MFxyXG5tPXZpZGVvIDkgVURQL1RMUy9SVFAvU0FWUEYgOTZcclxuYT1taWQ6MVxyXG5hPXJ0cG1hcDo5NiBIMjY0LzkwMDAwXHJcbiJ9",
+            "mode": "vicoo",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session",
+            "viewerType": "a4x_sdk",
+            "resolution": "1920x1080"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjEgMSB1ZHAgMSAxOTIuMC4yLjEgNDAwMCB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "trickle_while_waiting_for_answer",
+        "messages": []
+      },
+      {
+        "step": "rejoined_peer",
+        "messages": [
+          {
+            "messageType": "SDP_OFFER",
+            "messagePayload": "eyJ0eXBlIjoib2ZmZXIiLCJzZHAiOiJ2PTBcclxubT1hdWRpbyA5IFVEUC9UTFMvUlRQL1NBVlBGIDBcclxuYT1taWQ6MFxyXG5tPXZpZGVvIDkgVURQL1RMUy9SVFAvU0FWUEYgOTZcclxuYT1taWQ6MVxyXG5hPXJ0cG1hcDo5NiBIMjY0LzkwMDAwXHJcbiJ9",
+            "mode": "vicoo",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session",
+            "viewerType": "a4x_sdk",
+            "resolution": "1920x1080"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjEgMSB1ZHAgMSAxOTIuMC4yLjEgNDAwMCB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "answer_flushes_trickled_ice",
+        "messages": [
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIwIiwic2RwTUxpbmVJbmRleCI6MCwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjIgMSB1ZHAgMSAxOTIuMC4yLjIgNDAwMSB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          },
+          {
+            "messageType": "ICE_CANDIDATE",
+            "messagePayload": "eyJzZHBNaWQiOiIxIiwic2RwTUxpbmVJbmRleCI6MSwiY2FuZGlkYXRlIjoiY2FuZGlkYXRlOjMgMSB1ZHAgMSAxOTIuMC4yLjMgNDAwMiB0eXAgaG9zdCJ9",
+            "recipientClientId": "CAMERA_B",
+            "senderClientId": "viewer123",
+            "sessionId": "baseline-session"
+          }
+        ]
+      },
+      {
+        "step": "closed",
+        "socket_closed": true
+      }
+    ]
+  }
+}

--- a/tests/fixtures/webrtc_65984b9.md
+++ b/tests/fixtures/webrtc_65984b9.md
@@ -1,0 +1,30 @@
+# Live signaling regression baseline
+
+Baseline: `65984b9126deb0646f8fd1b4f756f5430e4718e8` (`v1.3.12.10`).
+Source: `custom_components/xsense/webrtc_signal.py` at that revision.
+
+Issue #182's June 25 ten-switch success follows the announcement of this
+release's answer-gated trickled ICE change:
+- https://github.com/Jarnsen/ha-xsense-component_test/issues/182#issuecomment-4801049469
+- https://github.com/Jarnsen/ha-xsense-component_test/issues/182#issuecomment-4800345651
+
+`webrtc_65984b9.json` records output produced by that historical implementation,
+not output from the current helper. The fixture covers URL/Host/SNI options,
+unrelated-peer rejection, the offer and embedded ICE, trickled ICE held until
+answer, peer exit/rejoin, and closing a session. The regression test runs ten
+alternating simulated camera sessions against those captured outputs.
+
+Regenerate from the repository root with its Python dependencies installed:
+
+```sh
+PYTHONPATH=. python scripts/capture-webrtc-baseline.py
+```
+
+The generator loads the exact commit above and substitutes only the historical
+logger import. Do not regenerate expected output from HEAD or silently change
+the commit to bless a new implementation. Keep future deviations explicit.
+
+These are protocol simulations, not hardware validation. They do not establish
+why a cloud camera might fail to join, reproduce frontend subscription cleanup,
+or prove that a specific user's live feed has returned. Identity/scoping and
+HA adapter lifecycle are covered by separate tests.

--- a/tests/test_camera_entity_guards.py
+++ b/tests/test_camera_entity_guards.py
@@ -6512,8 +6512,9 @@ async def test_webrtc_candidate_is_forwarded_to_matching_signal_session():
 
 
 async def test_early_webrtc_candidate_is_queued_until_signal_session_exists(
-    monkeypatch,
+    monkeypatch, caplog,
 ):
+    caplog.set_level("DEBUG", logger="custom_components.xsense")
     from homeassistant.components.camera.webrtc import WebRTCAnswer
     from custom_components.xsense import camera as camera_module
     from custom_components.xsense.camera import (
@@ -6613,6 +6614,9 @@ async def test_early_webrtc_candidate_is_queued_until_signal_session_exists(
     assert created_sessions[0].candidates == [candidate]
     assert camera._pending_webrtc_candidates == {}
     assert isinstance(messages[0], WebRTCAnswer)
+    assert "handing queued HA ICE candidates to signal helper" in caplog.text
+    assert "adapter_to_helper" in caplog.text
+    assert "forwarding queued HA ICE candidates" not in caplog.text
 
 
 async def test_new_webrtc_offer_closes_previous_signal_session(monkeypatch):
@@ -6714,7 +6718,8 @@ async def test_new_webrtc_offer_closes_previous_signal_session(monkeypatch):
     assert messages[0].answer == "v=0\r\nanswer"
 
 
-async def test_frontend_webrtc_close_closes_signal_session():
+async def test_frontend_webrtc_close_closes_signal_session(caplog):
+    caplog.set_level("DEBUG", logger="custom_components.xsense")
     from custom_components.xsense.camera import (
         CAMERA_DESCRIPTION,
         XSenseWebRTCCameraEntity,
@@ -6763,6 +6768,7 @@ async def test_frontend_webrtc_close_closes_signal_session():
     camera.close_webrtc_session("session-1")
     await tasks[0]
 
+    assert "ha_subscription_cleanup" in caplog.text
     assert session.closed is True
     assert camera_entity.data["cameraWebrtcTicket"] == {"id": "ticket-id"}
     assert camera._webrtc_sessions == {}

--- a/tests/test_webrtc_historical_baseline.py
+++ b/tests/test_webrtc_historical_baseline.py
@@ -1,0 +1,98 @@
+"""Wire sequence captured from #182's repeated-switching baseline, 65984b9."""
+import asyncio
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from custom_components.xsense.python_xsense import webrtc_signal
+
+
+async def relay_trace(module, serial):
+    class Socket:
+        closed = False
+
+        def __init__(self):
+            self.messages = []
+
+        async def send_str(self, message):
+            self.messages.append(json.loads(message))
+
+        async def close(self):
+            self.closed = True
+
+    ws = Socket()
+    ticket = module.XSenseWebRTCTicket.from_api(serial, {
+        "signalServer": "https://signal.example", "groupId": serial,
+        "role": "viewer", "id": "viewer123", "traceId": "trace123",
+        "sign": "test-sign", "time": 123456, "expirationTime": 9999999999999,
+        "signalServerIpAddress": "192.0.2.10",
+    })
+    sdp = (
+        "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 0\r\na=mid:0\r\n"
+        "a=candidate:1 1 udp 1 192.0.2.1 4000 typ host\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96\r\na=mid:1\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+    )
+    session = module.XSenseWebRTCSignalSession(
+        session=object(), ticket=ticket, offer_sdp=sdp,
+        resolution="1920x1080", camera_online=True,
+    )
+    session._session_id = "baseline-session"
+    session._ws = ws
+    trace = [{"step": "connect", "url": ticket.signal_url(),
+              "options": ticket.signal_connect_options()}]
+    offset = 0
+
+    def checkpoint(step):
+        nonlocal offset
+        trace.append({"step": step, "messages": ws.messages[offset:]})
+        offset = len(ws.messages)
+
+    async def event(kind, payload):
+        parsed = module.parse_signal_message(json.dumps({
+            "messageType": kind, "messagePayload": payload,
+        }))
+        await session._handle_signal_event(*parsed)
+
+    try:
+        await session.add_candidate(SimpleNamespace(
+            candidate="candidate:2 1 udp 1 192.0.2.2 4001 typ host",
+            sdp_mid="0", sdp_m_line_index=0,
+        ))
+        checkpoint("early_trickle")
+        await event("PEER_IN", "OTHER_CAMERA")
+        checkpoint("unrelated_peer")
+        await event("PEER_IN", serial)
+        checkpoint("owned_peer_offer_and_embedded_ice")
+        await session.add_candidate(SimpleNamespace(
+            candidate="candidate:3 1 udp 1 192.0.2.3 4002 typ host",
+            sdp_mid="1", sdp_m_line_index=1,
+        ))
+        checkpoint("trickle_while_waiting_for_answer")
+        await event("PEER_OUT", serial)
+        await event("PEER_IN", serial)
+        checkpoint("rejoined_peer")
+        answer_sdp = "v=0\r\n"
+        await session._handle_signal_event("SDP_ANSWER", {
+            "senderClientId": serial, "recipientClientId": "viewer123",
+            "messagePayload": base64.b64encode(json.dumps({
+                "type": "answer", "sdp": answer_sdp,
+            }).encode()).decode(),
+        })
+        checkpoint("answer_flushes_trickled_ice")
+        assert session._answer.result() == answer_sdp
+    finally:
+        await session.close()
+        if not session._answer.done():
+            session._answer.cancel()
+    trace.append({"step": "closed", "socket_closed": ws.closed})
+    return trace
+
+
+async def test_ten_camera_switches_match_65984b9_wire_sequence():
+    fixture = json.loads((Path(__file__).parent / "fixtures" / "webrtc_65984b9.json").read_text())
+    assert fixture["commit"] == "65984b9126deb0646f8fd1b4f756f5430e4718e8"
+    for index in range(10):
+        serial = "CAMERA_A" if index % 2 == 0 else "CAMERA_B"
+        assert await relay_trace(webrtc_signal, serial) == fixture["traces"][serial]

--- a/tests/test_webrtc_signal.py
+++ b/tests/test_webrtc_signal.py
@@ -45,6 +45,51 @@ def test_signal_module_does_not_require_local_aiortc_import():
     assert "aiortc" not in sys.modules
 
 
+@pytest.mark.parametrize("exit_kind", ["normal", "cancelled", "error", "local_close"])
+async def test_signal_reader_logs_exit_without_changing_cleanup(exit_kind, monkeypatch, caplog):
+    caplog.set_level("DEBUG", logger=webrtc_signal.__name__)
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(), ticket=ticket(), offer_sdp="v=0\r\n",
+        resolution="1920x1080", camera_online=True,
+    )
+
+    class Socket(FakeWebSocket):
+        close_code = 1000
+
+        async def __aiter__(self):
+            if exit_kind == "cancelled":
+                raise asyncio.CancelledError
+            if exit_kind == "error":
+                raise OSError("test reader failure")
+            if exit_kind == "local_close":
+                session._closed = True
+            return
+            yield  # Make this an async iterator without incoming messages.
+
+    session._ws = Socket()
+    reconnect_codes = []
+    monkeypatch.setattr(session, "_schedule_signal_reconnect", reconnect_codes.append)
+    if exit_kind == "cancelled":
+        with pytest.raises(asyncio.CancelledError):
+            await session._read_loop()
+    else:
+        await session._read_loop()
+    records = [r for r in caplog.records if "relay websocket closed" in r.message]
+    assert len(records) == 1
+    context = records[0].args
+    assert context["reader_exit"] == {
+        "cancelled": "reader_cancelled", "error": "reader_error",
+    }.get(exit_kind, "socket_iteration_ended")
+    assert context["local_close_requested"] == (exit_kind == "local_close")
+    assert context["observed_socket_close_code"] == 1000
+    assert context["session_age_s"] >= 0
+    assert reconnect_codes == [None if exit_kind in {"error", "cancelled"} else 1000]
+    if session._answer.done():
+        session._answer.exception()
+    else:
+        session._answer.cancel()
+
+
 def test_sdp_offer_payload_strips_candidates_and_keeps_resolution():
     sdp = (
         "v=0\r\n"
@@ -159,6 +204,53 @@ def test_parse_owned_sdp_answer_from_signal_envelope():
 
     assert event == "SDP_ANSWER"
     assert webrtc_signal._owned_answer_sdp(payload, ticket()) == answer_sdp
+
+
+def test_encoded_numeric_peer_remains_text():
+    peer_id = "1234567"
+    payload = base64.b64encode(peer_id.encode()).decode()
+    event, decoded = webrtc_signal.parse_signal_message(json.dumps(
+        {"messageType": "PEER_IN", "messagePayload": payload}
+    ))
+    assert event == "PEER_IN"
+    assert decoded == peer_id
+
+
+@pytest.mark.parametrize("peer_id", ["123456", "1e3", "true", "null", "SSC0ATEST"])
+@pytest.mark.parametrize("shape", ["raw", "json", "object"])
+async def test_signal_reader_preserves_text_peer_identity(peer_id, shape, monkeypatch):
+    """Exercise wire parsing before ownership checks, including JSON-like IDs."""
+    live_ticket = ticket()
+    live_ticket.serial_number = peer_id
+    session = webrtc_signal.XSenseWebRTCSignalSession(
+        session=object(), ticket=live_ticket, offer_sdp="v=0\r\n",
+        resolution="1920x1080", camera_online=True,
+    )
+    payload = {"raw": peer_id, "json": json.dumps(peer_id),
+               "object": {"id": peer_id}}[shape]
+    events = [
+        {"messageType": "PEER_IN", "messagePayload": "another-camera"},
+        {"messageType": "PEER_IN", "messagePayload": payload},
+        {"messageType": "PEER_OUT", "messagePayload": "another-camera"},
+    ]
+
+    class IncomingWebSocket(FakeWebSocket):
+        close_code = 1000
+
+        async def __aiter__(self):
+            for event in events:
+                yield SimpleNamespace(type=webrtc_signal.aiohttp.WSMsgType.TEXT,
+                                      data=json.dumps(event))
+
+    session._ws = IncomingWebSocket()
+    monkeypatch.setattr(session, "_schedule_signal_reconnect", lambda code: None)
+    await session._read_loop()
+
+    assert session._camera_peer_ready
+    assert session._offer_sent
+    assert len(session._ws.messages) == 1
+    assert session._ws.messages[0]["recipientClientId"] == peer_id
+    session._answer.cancel()
 
 
 def test_webrtc_signal_relay_path_is_locked_to_v1_3_12_10_success_shape():
@@ -340,8 +432,8 @@ async def test_webrtc_signal_failed_offer_send_remains_retryable():
     assert session._offer_sent is False
 
 
-async def test_online_camera_sends_ice_after_peer_offer_before_answer(monkeypatch):
-    """Keep peer gating without withholding browser candidates until the answer."""
+async def test_online_camera_holds_trickled_ice_until_answer(monkeypatch):
+    """Preserve 65984b9's distinction between embedded and trickled ICE."""
     websocket = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -373,9 +465,9 @@ async def test_online_camera_sends_ice_after_peer_offer_before_answer(monkeypatc
     )
     await session.add_candidate(candidate)
 
-    assert len(session._pending_remote_candidates) == 0
+    assert len(session._pending_remote_candidates) == 1
     assert [message["messageType"] for message in websocket.messages] == [
-        "SDP_OFFER", "ICE_CANDIDATE",
+        "SDP_OFFER",
     ]
 
     answer_sdp = "v=0\r\n"
@@ -395,7 +487,7 @@ async def test_online_camera_sends_ice_after_peer_offer_before_answer(monkeypatc
     ]
 
 
-async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
+async def test_webrtc_signal_flushes_trickled_ha_candidates_after_answer():
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -427,9 +519,9 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
     await session._send_offer()
 
     assert not session._answer.done()
-    assert len(session._pending_remote_candidates) == 0
+    assert len(session._pending_remote_candidates) == 1
     assert [message["messageType"] for message in fake_ws.messages] == [
-        "SDP_OFFER", "ICE_CANDIDATE",
+        "SDP_OFFER",
     ]
 
     session._answer.set_result("v=0\r\nanswer")
@@ -451,7 +543,7 @@ async def test_webrtc_signal_flushes_trickled_ha_candidates_after_offer():
 
 
 @pytest.mark.parametrize("before_offer", [True, False])
-async def test_webrtc_signal_sends_ha_candidates_after_offer_without_answer(before_offer):
+async def test_webrtc_signal_retains_trickled_candidates_until_answer(before_offer):
     fake_ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(),
@@ -482,8 +574,11 @@ async def test_webrtc_signal_sends_ha_candidates_after_offer_without_answer(befo
     if not before_offer:
         await session.add_candidate(candidate)
 
-    assert len(session._pending_remote_candidates) == 0
+    assert len(session._pending_remote_candidates) == 1
     assert not session._answer.done()
+    assert [message["messageType"] for message in fake_ws.messages] == ["SDP_OFFER"]
+    session._answer.set_result("v=0\r\n")
+    await session._flush_pending_remote_candidates()
     assert [message["messageType"] for message in fake_ws.messages] == [
         "SDP_OFFER",
         "ICE_CANDIDATE",
@@ -498,7 +593,7 @@ async def test_webrtc_signal_sends_ha_candidates_after_offer_without_answer(befo
     }
 
 
-async def test_webrtc_reoffer_resends_trickled_candidates_before_answer():
+async def test_webrtc_reoffer_preserves_queued_candidates_until_answer():
     ws = FakeWebSocket()
     session = webrtc_signal.XSenseWebRTCSignalSession(
         session=object(), ticket=ticket(), offer_sdp="v=0\r\n",
@@ -512,12 +607,17 @@ async def test_webrtc_reoffer_resends_trickled_candidates_before_answer():
         ))
     assert not ws.messages
     await session._handle_signal_event("PEER_IN", "SSC0ATEST")
-    assert session._sent_candidate_count == 12
-    assert not session._pending_remote_candidates
+    assert session._sent_candidate_count == 0
+    assert len(session._pending_remote_candidates) == 12
     await session._handle_signal_event("PEER_OUT", "SSC0ATEST")
     await session._handle_signal_event("PEER_IN", "SSC0ATEST")
-    assert session._sent_candidate_count == 12
+    assert session._sent_candidate_count == 0
+    assert len(session._pending_remote_candidates) == 12
     assert not session._answer.done()
+    assert [item["messageType"] for item in ws.messages] == ["SDP_OFFER"] * 2
+    session._answer.set_result("v=0\r\n")
+    await session._flush_pending_remote_candidates()
     assert [item["messageType"] for item in ws.messages] == (
-        ["SDP_OFFER"] + ["ICE_CANDIDATE"] * 12
-    ) * 2
+        ["SDP_OFFER"] * 2 + ["ICE_CANDIDATE"] * 12
+    )
+    assert session._sent_candidate_count == 12


### PR DESCRIPTION
## Summary

- Restore trickled ICE delivery after the SDP answer, matching the #182 repeated-switching baseline (`65984b9`, v1.3.12.10). Embedded SDP candidates retain their offer-time delivery.
- Preserve text peer IDs that resemble JSON scalars.
- Distinguish adapter handoff, socket sends, and local session cleanup in diagnostics.
- Add a protocol fixture captured from the historical commit and exercise ten alternating simulated camera sessions against it.
- Prepare v1.4.21.4 metadata and release notes.

## Validation

- Full server suite: 2,123 tests passed on Python 3.13 and 3.14 before the metadata bump; release checks will run on this PR revision.
- Historical fixture failed before the ICE-order restoration and passes afterward.
- Snapshot behavior and multi-Home identity handling remain unchanged.

This restores the tested historical sequence; it does not establish that the reporter's missing PEER_IN or live-view failure is resolved. No issue is closed by this PR.
