### PR TITLE
Prepare v1.4.21.5 diagnostic prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -23,8 +23,8 @@ Please specify the versions used:
 
 - **Home Assistant Version** (z. B. 2025.3.0):
   (e.g., 2025.3.0)
-- **X-Sense-Integration Version** (z. B. 1.4.21.4):
-  (e.g., 1.4.21.4)
+- **X-Sense-Integration Version** (z. B. 1.4.21.5):
+  (e.g., 1.4.21.5)
 - **HACS Version** (z. B. 2.0.0):  
   (e.g., 2.0.0)
 

--- a/.github/release-notes/1.4.21.5.md
+++ b/.github/release-notes/1.4.21.5.md
@@ -1,0 +1,6 @@
+## X-Sense Home Security v1.4.21.5
+
+### Cameras
+- Adds debug tracing for live-view ticket requests, selected Home/node, and signaling room identities.
+- Adds bounded tracing of the first received signaling frames and a received-frame counter, with sensitive payloads excluded and identifiers redacted.
+- This is a diagnostic update; live-view signaling behavior is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release notes for each published X-Sense Home Security version.
 
+- [1.4.21.5](.github/release-notes/1.4.21.5.md)
 - [1.4.21.4](.github/release-notes/1.4.21.4.md)
 - [1.4.21.3](.github/release-notes/1.4.21.3.md)
 - [1.4.21.2](.github/release-notes/1.4.21.2.md)

--- a/custom_components/xsense/frontend.py
+++ b/custom_components/xsense/frontend.py
@@ -18,7 +18,7 @@ STATIC_URL_PATH = f"/{DOMAIN}_recordings_static"
 PANEL_ELEMENT_NAME = "xsense-recordings-panel"
 FORCE_ARM_PANEL_ELEMENT_NAME = "xsense-force-arm-panel"
 PANEL_TITLE = "X-Sense Recordings"
-PANEL_ASSET_VERSION = "1.4.21.4"
+PANEL_ASSET_VERSION = "1.4.21.5"
 
 
 def _recordings_panel_module_url() -> str:

--- a/custom_components/xsense/manifest.json
+++ b/custom_components/xsense/manifest.json
@@ -21,6 +21,6 @@
     "paho-mqtt==2.1.0"
   ],
   "ssdp": [],
-  "version": "1.4.21.4",
+  "version": "1.4.21.5",
   "zeroconf": []
 }

--- a/custom_components/xsense/python_xsense/async_xsense.py
+++ b/custom_components/xsense/python_xsense/async_xsense.py
@@ -17,6 +17,7 @@ from .exceptions import APIFailure, SessionExpired, XSenseError
 from .house import House
 from .mapping import bool_state
 from .station import Station
+from .webrtc_trace import trace_host, trace_id
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1293,6 +1294,17 @@ class AsyncXSense(XSenseBase):
         data = self._addx_body(addx_session, kwargs)
 
         session = await self._get_session()
+        if endpoint == "/device/getWebrtcTicket":
+            LOGGER.debug(
+                "X-Sense WebRTC ticket HTTP route trace: %s",
+                {
+                    "request_serial": trace_id(data.get("serialNumber")),
+                    "house": trace_id(getattr(_house, "house_id", None)),
+                    "node": node,
+                    "api_host": trace_host(base_url),
+                    "auth_retry": not _retry,
+                },
+            )
         async with session.post(
             f"{base_url}{endpoint}",
             json=data,
@@ -1945,12 +1957,38 @@ class AsyncXSense(XSenseBase):
             serials = [ticket_serial, *(value for value in serials if value != ticket_serial)]
         for serial in serials:
             try:
+                house = self._camera_addx_house(camera)
+                LOGGER.debug(
+                    "X-Sense WebRTC ticket request trace: %s",
+                    {
+                        "camera": trace_id(camera.sn),
+                        "request_serial": trace_id(serial),
+                        "house": trace_id(getattr(house, "house_id", None)),
+                        "node": _ipc_node_type(house.mqtt_region) if house else None,
+                        "attempt": serials.index(serial) + 1,
+                        "force_refresh": force_refresh,
+                    },
+                )
                 data = await self._camera_addx_call(
                     camera,
                     "/device/getWebrtcTicket",
                     serialNumber=serial,
                     verifyDormancyStatus=True,
                 )
+                if isinstance(data, dict):
+                    LOGGER.debug(
+                        "X-Sense WebRTC ticket response trace: %s",
+                        {
+                            "request_serial": trace_id(serial),
+                            "id": trace_id(data.get("id")),
+                            "groupId": trace_id(data.get("groupId")),
+                            "realCxSerialNumber": trace_id(data.get("realCxSerialNumber")),
+                            "response_serial": trace_id(data.get("serialNumber")),
+                            "role": data.get("role") if data.get("role") in ("viewer", "device", "camera") else "other",
+                            "signal_host": trace_host(data.get("signalServer")),
+                            "expirationTime": data.get("expirationTime") if isinstance(data.get("expirationTime"), (int, float)) else None,
+                        },
+                    )
                 camera.set_data(
                     {
                         "addxAccessSerialNumber": serial,

--- a/custom_components/xsense/python_xsense/webrtc_signal.py
+++ b/custom_components/xsense/python_xsense/webrtc_signal.py
@@ -17,6 +17,8 @@ from urllib.parse import urlparse, urlunparse
 
 import aiohttp
 
+from .webrtc_trace import frame_context
+
 LOGGER = logging.getLogger(__name__)
 
 SIGNAL_MODE = "vicoo"
@@ -137,6 +139,7 @@ class XSenseWebRTCSignalSession:
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._answer: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._closed = False
+        self._received_frame_count = 0
         self._created_at = time.monotonic()
         self._offer_sent = False
         self._camera_peer_ready = False
@@ -162,6 +165,7 @@ class XSenseWebRTCSignalSession:
                 "recipient": _short_id(self._recipient_client_id),
                 "resolution": self._resolution,
                 "camera_online": self._camera_online,
+                "received_frame_count": self._received_frame_count,
                 "camera_peer_ready": self._camera_peer_ready,
                 "offer_sent": self._offer_sent,
                 "sdp_answer_received": _future_has_result(self._answer),
@@ -289,6 +293,16 @@ class XSenseWebRTCSignalSession:
         try:
             assert ws is not None
             async for message in ws:
+                self._received_frame_count += 1
+                if self._received_frame_count <= 12 and LOGGER.isEnabledFor(logging.DEBUG):
+                    details = (
+                        frame_context(message.data)
+                        if isinstance(message.data, (str, bytes)) else {}
+                    )
+                    LOGGER.debug(
+                        "X-Sense WebRTC initial frame trace: %s",
+                        self._debug_context(frame_type=message.type.name, frame=details),
+                    )
                 if message.type not in (
                     aiohttp.WSMsgType.TEXT,
                     aiohttp.WSMsgType.BINARY,

--- a/custom_components/xsense/python_xsense/webrtc_trace.py
+++ b/custom_components/xsense/python_xsense/webrtc_trace.py
@@ -1,0 +1,76 @@
+"""Allowlisted live-view diagnostics; never log raw signal payloads."""
+import base64
+import json
+from urllib.parse import urlsplit
+
+
+def trace_id(value):
+    if not isinstance(value, (str, int)) or isinstance(value, bool):
+        return None
+    text = str(value)
+    if not text:
+        return None
+    return "..." + text[-min(6, max(0, len(text) - 1)):] if len(text) > 1 else "..."
+
+
+def trace_host(value):
+    if not isinstance(value, str):
+        return None
+    try:
+        return urlsplit(value if "://" in value else "//" + value).hostname
+    except ValueError:
+        return None
+
+
+def frame_context(raw):
+    result = {"length": len(raw), "messageType": "unrecognized"}
+    if len(raw) > 65536:
+        result["inspection"] = "size_limit"
+        return result
+    try:
+        envelope = json.loads(raw)
+    except (ValueError, UnicodeError, TypeError):
+        result["inspection"] = "non_json"
+        return result
+    if not isinstance(envelope, dict):
+        result["inspection"] = "non_object"
+        return result
+    event = next((envelope.get(key) for key in (
+        "messageType", "event", "type", "method"
+    ) if envelope.get(key)), None)
+    if event in ("PEER_IN", "PEER_OUT", "SDP_ANSWER", "SDP_OFFER", "ICE_CANDIDATE"):
+        result["messageType"] = event
+    result["envelope"] = _identities(envelope)
+    if event not in ("PEER_IN", "PEER_OUT"):
+        return result
+    payload = next((envelope[key] for key in (
+        "messagePayload", "payload", "data", "message", "body", "value"
+    ) if key in envelope), None)
+    if isinstance(payload, str):
+        try:
+            decoded = json.loads(payload)
+            if isinstance(decoded, (dict, str)):
+                payload = decoded
+        except ValueError:
+            if any(char in payload for char in "=+/") or payload.startswith("eyJ"):
+                try:
+                    decoded = base64.b64decode(payload + "=" * (-len(payload) % 4)).decode()
+                    try:
+                        payload = json.loads(decoded)
+                    except ValueError:
+                        payload = decoded
+                except (ValueError, UnicodeError):
+                    pass
+    result["peer"] = _identities(payload) if isinstance(payload, dict) else {"id": trace_id(payload)}
+    return result
+
+
+def _identities(data):
+    result = {key: trace_id(data[key]) for key in (
+        "id", "name", "group", "clientId", "serialNumber",
+        "senderClientId", "recipientClientId"
+    ) if key in data}
+    if "role" in data:
+        role = data["role"]
+        result["role"] = role if role in ("viewer", "device", "camera") else "other"
+    return result

--- a/tests/test_webrtc_pending_lifecycle.py
+++ b/tests/test_webrtc_pending_lifecycle.py
@@ -1,0 +1,93 @@
+"""Exercise pending live-view cleanup with the real signal helper."""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.components.camera import Camera
+
+from custom_components.xsense.camera import XSenseWebRTCCameraEntity
+from custom_components.xsense.python_xsense.webrtc_signal import (
+    XSenseWebRTCSignalSession,
+    XSenseWebRTCTicket,
+)
+
+
+async def test_replacement_and_late_cleanup_do_not_close_current_pending_session():
+    sockets = []
+
+    class Socket:
+        closed = False
+        close_code = None
+
+        def __init__(self):
+            self.stopped = asyncio.Event()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await self.stopped.wait()
+            raise StopAsyncIteration
+
+        async def close(self):
+            self.closed = True
+            self.stopped.set()
+
+    async def connect(*args, **kwargs):
+        socket = Socket()
+        sockets.append(socket)
+        return socket
+
+    ticket = XSenseWebRTCTicket.from_api("CAMERA_A", {
+        "signalServer": "https://signal.example", "groupId": "group",
+        "role": "viewer", "id": "viewer", "traceId": "trace",
+        "sign": "test", "time": 1, "expirationTime": 9999999999999,
+    })
+
+    def new_session():
+        return XSenseWebRTCSignalSession(
+            session=SimpleNamespace(ws_connect=connect), ticket=ticket,
+            offer_sdp="v=0\r\n", resolution="1280x720", camera_online=True,
+        )
+
+    camera = object.__new__(XSenseWebRTCCameraEntity)
+    Camera.__init__(camera)
+    camera._current_entity = lambda: None
+    camera.coordinator = SimpleNamespace()
+    close_tasks = []
+
+    def create_task(coro):
+        task = asyncio.create_task(coro)
+        close_tasks.append(task)
+        return task
+
+    camera.hass = SimpleNamespace(async_create_task=create_task)
+    camera._pending_webrtc_candidates = {"new": []}
+    old = new_session()
+    camera._webrtc_sessions = {"old": old}
+    old_start = asyncio.create_task(old.start())
+    await asyncio.sleep(0)
+    await camera._close_existing_webrtc_sessions(preserve_pending_session_id="new")
+    with pytest.raises(asyncio.CancelledError):
+        await old_start
+    assert sockets[0].closed
+
+    current = new_session()
+    camera._webrtc_sessions["new"] = current
+    current_start = asyncio.create_task(current.start())
+    try:
+        await asyncio.sleep(0)
+        camera.close_webrtc_session("old")
+        await asyncio.sleep(0)
+        assert not current_start.done()
+        assert not sockets[1].closed
+        assert camera._webrtc_sessions == {"new": current}
+        camera.close_webrtc_session("new")
+        await asyncio.gather(*close_tasks)
+        with pytest.raises(asyncio.CancelledError):
+            await current_start
+        assert sockets[1].closed
+        assert camera._webrtc_sessions == {}
+    finally:
+        await current.close()
+        await asyncio.gather(current_start, return_exceptions=True)

--- a/tests/test_webrtc_trace.py
+++ b/tests/test_webrtc_trace.py
@@ -1,0 +1,69 @@
+"""Privacy and shape checks for ticket-to-peer traces."""
+import base64
+import json
+
+import pytest
+
+from custom_components.xsense.python_xsense.webrtc_trace import frame_context, trace_host, trace_id
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+def test_peer_trace_preserves_identity_suffixes_without_payload_secrets(encoded):
+    peer = {"id": "camera-123456", "name": "camera-123456", "group": "camera-123456",
+            "role": "device", "sign": "PRIVATE_SIGNATURE", "token": "PRIVATE_TOKEN"}
+    payload = json.dumps(peer)
+    if encoded:
+        payload = base64.b64encode(payload.encode()).decode()
+    result = frame_context(json.dumps({"messageType": "PEER_IN", "messagePayload": payload,
+                                      "Authorization": "PRIVATE_AUTH"}))
+    assert result["peer"] == {"id": "...123456", "name": "...123456", "group": "...123456", "role": "device"}
+    assert result["messageType"] == "PEER_IN"
+    assert "PRIVATE" not in str(result)
+    assert "camera-" not in str(result)
+
+
+def test_answer_trace_does_not_decode_sdp_or_ice():
+    result = frame_context(json.dumps({"messageType": "SDP_ANSWER",
+        "senderClientId": "camera-123456", "recipientClientId": "viewer-654321",
+        "messagePayload": "PRIVATE_SDP", "candidate": "PRIVATE_ICE"}))
+    assert result["envelope"]["senderClientId"] == "...123456"
+    assert "PRIVATE" not in str(result)
+
+
+@pytest.mark.parametrize("raw", [b"\xff", "[]", "123", "null", "PRIVATE" * 20000,
+                                   '{"messageType":{"secret":"PRIVATE"}}'])
+def test_unrecognized_frames_remain_safe(raw):
+    assert "PRIVATE" not in str(frame_context(raw))
+
+
+def test_trace_host_excludes_credentials_and_query():
+    assert trace_host("wss://user:PRIVATE@signal.example/path?sign=PRIVATE") == "signal.example"
+    assert trace_host("wss://[") is None
+    assert trace_id("123456") == "...23456"
+    assert trace_id("x") == "..."
+
+
+async def test_ticket_trace_uses_actual_request_identity(caplog):
+    from custom_components.xsense.python_xsense.async_xsense import AsyncXSense
+    from custom_components.xsense.python_xsense.entity import Entity
+    caplog.set_level("DEBUG")
+    client = AsyncXSense()
+    camera = Entity()
+    camera.sn = "camera-123456"
+    camera.type = "SSC0A"
+    calls = []
+
+    async def call(endpoint, **kwargs):
+        calls.append(kwargs["serialNumber"])
+        return {"id": "viewer-654321", "groupId": camera.sn, "role": "viewer",
+                "realCxSerialNumber": camera.sn, "sign": "PRIVATE_SIGNATURE",
+                "accessToken": "PRIVATE_TOKEN", "signalServer": "wss://signal.example/path?token=PRIVATE",
+                "expirationTime": 9999999999999}
+
+    client.addx_call = call
+    await client.get_camera_webrtc_ticket(camera, force_refresh=True)
+    assert calls == [camera.sn]
+    assert "request_serial': '...123456'" in caplog.text
+    assert "groupId': '...123456'" in caplog.text
+    assert "PRIVATE" not in caplog.text
+    assert camera.sn not in caplog.text


### PR DESCRIPTION
## Summary

- Add allowlisted, redacted ticket-to-peer diagnostics for issue #285.
- Record each attempted ticket serial and the actual ADDX HTTP node and Home route.
- Trace the first 12 received frames and retain a frame counter without logging raw credentials, SDP, or ICE payloads.
- Add privacy tests and pending-session lifecycle coverage.
- Prepare v1.4.21.5 prerelease metadata.

## Validation

- Full Python 3.14 server suite: 2,135 passed before the metadata bump.
- Fork CI validates the committed release revision before upstream merge.
- Offer, ICE, and PEER_IN gates are unchanged; no live-view recovery is claimed.

No issue is closed by this diagnostic prerelease.
